### PR TITLE
fix: #51 trapper perks

### DIFF
--- a/data/fh/character/trap.json
+++ b/data/fh/character/trap.json
@@ -91,6 +91,155 @@
       }
     }
   ],
-  "perks": [],
+  "perks": [
+    {
+      "type": "remove",
+      "count": 1,
+      "cards": [
+        {
+          "count": 1,
+          "attackModifier": {
+            "type": "minus2"
+          }
+        }
+      ]
+    },
+    {
+      "type": "replace",
+      "count": 2,
+      "cards": [
+        {
+          "count": 1,
+          "attackModifier": {
+            "type": "minus1"
+          }
+        },
+        {
+          "count": 1,
+          "attackModifier": {
+            "type": "plus0",
+            "effects": [
+              {
+                "type": "custom",
+                "value": "Create one %game.action.heal% 2 trap in an empty hex adjacent to the target"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "replace",
+      "count": 3,
+      "cards": [
+        {
+          "count": 1,
+          "attackModifier": {
+            "type": "minus1"
+          }
+        },
+        {
+          "count": 1,
+          "attackModifier": {
+            "type": "plus0",
+            "effects": [
+              {
+                "type": "custom",
+                "value": "Create one %game.damage:1% trap in an empty hex adjacent to the target"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "replace",
+      "count": 3,
+      "cards": [
+        {
+          "count": 2,
+          "attackModifier": {
+            "type": "plus0"
+          }
+        },
+        {
+          "count": 2,
+          "attackModifier": {
+            "type": "plus0",
+            "effects": [
+              {
+                "type": "custom",
+                "value": "Add %game.damage:2% or %game.action.heal% 2 to a trap within %game.action.range% 2 of you"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "replace",
+      "count": 2,
+      "cards": [
+        {
+          "count": 2,
+          "attackModifier": {
+            "type": "plus1"
+          }
+        },
+        {
+          "count": 2,
+          "attackModifier": {
+            "type": "plus2",
+            "effects": [
+              {
+                "type": "condition",
+                "value": "immobilize"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "add",
+      "count": 3,
+      "cards": [
+        {
+          "count": 2,
+          "attackModifier": {
+            "type": "plus0",
+            "rolling": true,
+            "effects": [
+              {
+                "type": "custom",
+                "value": "Add %game.action.push% 2 or %game.action.pull% 2"
+              }
+            ]
+
+          }
+        }
+      ]
+    },
+    {
+      "type": "custom",
+      "count": 1,
+      "custom": "Ignore scenario effects"
+    },
+    {
+      "type": "custom",
+      "count": 1,
+      "custom": "Whenever you long rest, you may create one %game.damage:1% trap in an adjacent empty hex"
+    },
+    {
+      "type": "custom",
+      "count": 1,
+      "custom": "Whenever you enter a hex with a trap, you may choose to not spring the trap"
+    },
+    {
+      "type": "custom",
+      "count": 1,
+      "custom": "At the start of each scenario, you may create one %game.damage:2% trap in an adjacent empty hex"
+    }
+  ],
   "replace": false
 }


### PR DESCRIPTION
I'm not sure about some of the text for the traps; e.g. should I be using:

-  %game.action.attack% 1
-  +1 %game.action.attack% 
-  %game.damage:1% 

I ended up using %game.action.attack% 1
I'm also not sure what the value of value property should be for custom attackModifier.effects.

Lastly, I noticed the perks for this one are so long that you can't read the last one. So heads up, that might need a style fix.