### PR TITLE
Add scenario 122

### DIFF
--- a/data/fh/scenarios.json
+++ b/data/fh/scenarios.json
@@ -3197,11 +3197,6 @@
     "index": "122",
     "name": "The Eternal Crave",
     "edition": "fh",
-    "monsters": [
-      "ice-wraith",
-      "polar-bear",
-      "snow-imp"
-    ],
     "lootDeckConfig": {
       "money": 6,
       "lumber": 3,

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -18,6 +18,47 @@
     ]
   },
   {
+    "index": "8.4",
+    "name": "The Eternal Crave",
+    "parent": "122",
+    "edition": "fh",
+    "marker": "6",
+    "parentSections": [
+      "172.1"
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "11-B",
+        "initial": true,
+        "treasures": [
+          31
+        ],
+        "monster": [
+          {
+            "name": "ice-wraith",
+            "type": "elite"
+          },
+          {
+            "name": "ice-wraith",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "elite",
+            "player3": "normal",
+            "player4": "elite"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "index": "11.7",
     "name": "The Lead Door",
     "parent": "103",
@@ -336,8 +377,49 @@
     "name": "The Eternal Crave",
     "parent": "122",
     "edition": "fh",
+    "marker": "1",
     "monsters": [
-      "hungry-maw"
+      "hungry-maw",
+      "snow-imp"
+    ],
+    "blocksSections": [
+      "152.1"
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "15-C",
+        "initial": true,
+        "monster": [
+          {
+            "name": "hungry-maw",
+            "type": "boss"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "type": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "type": "normal"
+          }
+        ]
+      }
     ]
   },
   {
@@ -359,6 +441,55 @@
     "edition": "fh",
     "monsters": [
       "flaming-sword-of-justice"
+    ]
+  },
+  {
+    "index": "109.3",
+    "name": "The Eternal Crave",
+    "parent": "122",
+    "edition": "fh",
+    "parentSections": [
+      "8.4",
+      "145.1"
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "15-B",
+        "initial": true,
+        "monster": [
+          {
+            "name": "ice-wraith",
+            "player2": "elite",
+            "player3": "elite",
+            "player4": "normal"
+          },
+          {
+            "name": "ice-wraith",
+            "player4": "normal"
+          },
+          {
+            "name": "ice-wraith",
+            "player4": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite"
+          }
+        ]
+      }
     ]
   },
   {
@@ -430,12 +561,177 @@
     ]
   },
   {
+    "index": "145.1",
+    "name": "The Eternal Crave",
+    "parent": "122",
+    "edition": "fh",
+    "marker": "5",
+    "parentSections": [
+      "179.2"
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "11-B",
+        "initial": true,
+        "treasures": [
+          31
+        ],
+        "monster": [
+          {
+            "name": "ice-wraith",
+            "type": "elite"
+          },
+          {
+            "name": "ice-wraith",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "polar-bear",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "polar-bear",
+            "player4": "normal"
+          },
+          {
+            "name": "polar-bear",
+            "player4": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "index": "146.3",
     "name": "A Contained Fire",
     "parent": "89",
     "edition": "fh",
     "monsters": [
       "vanjal"
+    ]
+  },
+  {
+    "index": "151.1",
+    "name": "The Eternal Crave",
+    "parent": "122",
+    "edition": "fh",
+    "marker": "2",
+    "monsters": [
+      "polar-bear"
+    ],
+    "parentSections": [
+      "98.1"
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "12-B",
+        "initial": true,
+        "treasures": [
+          31
+        ],
+        "monster": [
+          {
+            "name": "polar-bear",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "polar-bear",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "type": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "player4": "elite"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "index": "152.1",
+    "name": "The Eternal Crave",
+    "parent": "122",
+    "edition": "fh",
+    "marker": "2",
+    "monsters": [
+      "polar-bear",
+      "snow-imp"
+    ],
+    "blocksSections": [
+      "98.1"
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "12-B",
+        "initial": true,
+        "monster": [
+          {
+            "name": "polar-bear",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "type": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "player4": "normal"
+          }
+        ]
+      }
     ]
   },
   {
@@ -451,6 +747,48 @@
     ]
   },
   {
+    "index": "172.1",
+    "name": "The Eternal Crave",
+    "parent": "122",
+    "edition": "fh",
+    "marker": "4",
+    "monsters": [
+      "ice-wraith"
+    ],
+    "parentSections": [
+      "152.1"
+    ],
+    "blocksSections": [
+      "179.2"
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "07-A",
+        "initial": true,
+        "monster": [
+          {
+            "name": "polar-bear",
+            "player4": "normal"
+          },
+          {
+            "name": "polar-bear",
+            "type": "normal"
+          },
+          {
+            "name": "ice-wraith",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "ice-wraith",
+            "type": "elite"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "index": "174.3",
     "name": "Ruinous Research Lab",
     "parent": "81",
@@ -459,6 +797,53 @@
       {
         "name": "Barricade",
         "health": "L+5"
+      }
+    ]
+  },
+  {
+    "index": "179.2",
+    "name": "The Eternal Crave",
+    "parent": "122",
+    "edition": "fh",
+    "marker": "3",
+    "monsters": [
+      "ice-wraith"
+    ],
+    "parentSections": [
+      "152.1"
+    ],
+    "blocksSections": [
+      "172.1"
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "01-F",
+        "initial": true,
+        "monster": [
+          {
+            "name": "polar-bear",
+            "type": "elite"
+          },
+          {
+            "name": "polar-bear",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          {
+            "name": "ice-wraith",
+            "type": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player4": "elite"
+          }
+        ]
       }
     ]
   },

--- a/data/fh/sections/26-1.json
+++ b/data/fh/sections/26-1.json
@@ -27,7 +27,7 @@
           "monster": {
             "name": "ooze",
             "player2": "normal",
-            "player3": "ekite",
+            "player3": "elite",
             "player4": "elite"
           },
           "count": "F"

--- a/src/app/game/businesslogic/ScenarioManager.ts
+++ b/src/app/game/businesslogic/ScenarioManager.ts
@@ -451,7 +451,7 @@ export class ScenarioManager {
       return [];
     }
 
-    return gameManager.sectionData(this.game.scenario.edition).filter((sectionData) => (this.game.scenario && sectionData.edition == this.game.scenario.edition && sectionData.parent == this.game.scenario.index && (!sectionData.parentSections || sectionData.parentSections.length == 0) || this.game.sections.find((active) => active.edition == sectionData.edition && sectionData.parentSections && sectionData.parentSections.indexOf(active.index) != -1)) && !this.game.sections.find((active) => active.edition == sectionData.edition && active.index == sectionData.index));
+    return gameManager.sectionData(this.game.scenario.edition).filter((sectionData) => (this.game.scenario && sectionData.edition == this.game.scenario.edition && sectionData.parent == this.game.scenario.index && (!sectionData.parentSections || sectionData.parentSections.length == 0) || this.game.sections.find((active) => active.edition == sectionData.edition && sectionData.parentSections && sectionData.parentSections.indexOf(active.index) != -1)) && !this.game.sections.find((active) => active.edition == sectionData.edition && active.index == sectionData.index) && !this.game.sections.find((active) => active.edition == sectionData.edition && sectionData.blocksSections && sectionData.blocksSections.indexOf(active.index) != -1));
   }
 
   openRooms(initial: boolean = false): RoomData[] {

--- a/src/app/game/model/data/ScenarioData.ts
+++ b/src/app/game/model/data/ScenarioData.ts
@@ -27,6 +27,7 @@ export class ScenarioData implements Editional, Spoilable {
   lootDeckConfig: LootDeckConfig = {};
   parent: string | undefined;
   parentSections: string[] = [];
+  blocksSections: string[] = [];
   resetRound: boolean = false;
 
   // from Editional


### PR DESCRIPTION
I waited with this one until after the update push because it adds a new functionality:
In Scenario 122, by taking one path, you block other paths, for example, path 1 (to Hungry Maw) closes path 2 (to Puzzle), the same also is true if you do path 2.

First room also features no enemies, so I removed the starting monsters.

Also finally something I was unsure about, section 145.1 and section 109.3 both feature a "Special Rules" box that simply just summon enemies on a marker, I wasn't sure how you best intended to do this so I left it to simply just make the enemies like normal.

Also P.S:
My apologies for the json formatting and misused markers, still getting used to the formatting 😄 