### PR TITLE
Scenario 22 fix-ups

### DIFF
--- a/data/fh/deck/lurker-wavethrower.json
+++ b/data/fh/deck/lurker-wavethrower.json
@@ -84,7 +84,7 @@
         },
         {
           "type": "custom",
-          "value": "Summone one Lightning Eel in an adjacenty<br>unoccupied hex with a water tile.<br>Normal Wavethrowers summon<br>normal Eels, elites summon elites.",
+          "value": "Summon one Lightning Eel in an adjacent<br>unoccupied hex with a water tile.<br>Normal Wavethrowers summon<br>normal Eels, elites summon elites.",
           "small": true
         }
       ]
@@ -102,7 +102,7 @@
         },
         {
           "type": "custom",
-          "value": "Summone one Lightning Eel in an adjacenty<br>unoccupied hex with a water tile.<br>Normal Wavethrowers summon<br>normal Eels, elites summon elites.",
+          "value": "Summon one Lightning Eel in an adjacent<br>unoccupied hex with a water tile.<br>Normal Wavethrowers summon<br>normal Eels, elites summon elites.",
           "small": true
         }
       ]

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -126,6 +126,72 @@
     ]
   },
   {
+    "index": "41.2",
+    "name": "Ice Floes",
+    "parent": "22",
+    "edition": "fh",
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "07-G",
+        "initial": true,
+        "monster": [
+          {
+            "name": "lurker-clawcrusher",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "lurker-clawcrusher",
+            "type": "elite"
+          },
+          {
+            "name": "lurker-clawcrusher",
+            "player4": "normal"
+          },
+          {
+            "name": "lurker-wavethrower",
+            "player4": "normal"
+          },
+          {
+            "name": "lurker-wavethrower",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "lurker-wavethrower",
+            "type": "normal"
+          },
+          {
+            "name": "lightning-eel",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          {
+            "name": "lightning-eel",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "lightning-eel",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "lightning-eel",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "index": "48.1",
     "name": "Realm of Endless Frost",
     "parent": "21",


### PR DESCRIPTION
One thing of note, the wavethrowers can summon lightning eels, yet they are not as available monsters in the first half of the scenario (for some reason), so you need to manually add them as monsters to do so.