### PR TITLE
Scenario 32 fix-ups

### DIFF
--- a/data/fh/scenarios.json
+++ b/data/fh/scenarios.json
@@ -1101,7 +1101,7 @@
   },
   {
     "index": "32",
-    "name": "Raven's Roost",
+    "name": "Ravens' Roost",
     "edition": "fh",
     "monsters": [
       "frozen-corpse",
@@ -1115,7 +1115,58 @@
       "axenut": 2,
       "flamefruit": 2,
       "random_item": 1
-    }
+    },
+    "rules": [
+      {
+        "round": "R == 1",
+        "start": true,
+        "figures": [
+          {
+            "identifier": {
+              "type": "character",
+              "name": ".*"
+            },
+            "type": "gainCondition",
+            "value": "wound",
+            "scenarioEffect": true
+          }
+        ]
+      }
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "05-B",
+        "initial": true,
+        "monster": [
+          {
+            "name": "frozen-corpse",
+            "type": "normal"
+          },
+          {
+            "name": "frozen-corpse",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "frozen-corpse",
+            "type": "normal"
+          },
+          {
+            "name": "frozen-corpse",
+            "type": "normal"
+          },
+          {
+            "name": "frozen-corpse",
+            "player4": "normal"
+          },
+          {
+            "name": "frozen-corpse",
+            "player4": "normal"
+          }
+        ]
+      }
+    ]
   },
   {
     "index": "33",

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -424,10 +424,83 @@
     "name": "Ravens' Roost",
     "parent": "32",
     "edition": "fh",
+    "marker": "1",
     "objectives": [
       {
         "name": "Raven Nest a",
         "health": "(L+2)xCx3"
+      }
+    ],
+    "rules": [
+      {
+        "round": "R % 4 == 1",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "shrike-fiend",
+              "player2": "normal",
+              "player3": "normal",
+              "player4": "elite"
+            },
+            "marker": "a"
+          }
+        ]
+      },
+      {
+        "round": "R % 4 == 3",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "shrike-fiend",
+              "player2": "normal",
+              "player3": "elite",
+              "player4": "elite"
+            },
+            "marker": "a"
+          }
+        ]
+      }
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "13-A",
+        "initial": true,
+        "monster": [
+          {
+            "name": "harrower-infester",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "harrower-infester",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          }
+        ]
+      },
+      {
+        "roomNumber": 2,
+        "ref": "15-A",
+        "initial": "true",
+        "treasures": [
+          67
+        ],
+        "monster": [
+          {
+            "name": "harrower-infester",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          }
+        ],
+        "objectives": [
+          1
+        ]
       }
     ]
   },


### PR DESCRIPTION
One thing, I wasn't sure if was possible to add:
The objective Raven Nest (a) has retaliate X, Range 10, where X = (L+1)/3 round up. This would be good to calculate on the fly, but I wasn't sure if it was possible currently with objectives.

There is also a special rule with frozen corpses in the first room, but I don't think that's quite as important.