### PR TITLE
Scenario 33 fix-ups

### DIFF
--- a/data/fh/scenarios.json
+++ b/data/fh/scenarios.json
@@ -1185,10 +1185,46 @@
       "money": 8,
       "lumber": 5,
       "hide": 3,
+      "axenut": 2,
       "rockroot": 1,
-      "flamefruit": 1,
-      "axenut": 2
-    }
+      "flamefruit": 1
+    },
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "11-C",
+        "initial": true,
+        "monster": [
+          {
+            "name": "shrike-fiend",
+            "type": "normal"
+          },
+          {
+            "name": "shrike-fiend",
+            "player4": "normal"
+          },
+          {
+            "name": "shrike-fiend",
+            "type": "elite"
+          },
+          {
+            "name": "black-imp",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "black-imp",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "black-imp",
+            "type": "normal"
+          }
+        ]
+      }
+    ]
   },
   {
     "index": "34",

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -139,6 +139,37 @@
     "edition": "fh"
   },
   {
+    "index": "20.1",
+    "name": "Thawed Wood",
+    "parent": "33",
+    "edition": "fh",
+    "marker": "1",
+    "rules": [
+      {
+        "round": "R % 2 == 1",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "black-imp",
+              "player2": "normal",
+              "player3": "normal",
+              "player4": "elite"
+            },
+            "marker": "a"
+          }
+        ]
+      }
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "16-B",
+        "initial": true
+      }
+    ]
+  },
+  {
     "index": "29.2",
     "name": "Crystal Trench",
     "parent": "106",

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -153,13 +153,25 @@
             "monster": {
               "name": "black-imp",
               "player2": "normal",
-              "player3": "normal",
               "player4": "elite"
             },
             "marker": "a"
           }
         ]
-      }
+      },
+	  {
+	    "round": "R > 0",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "black-imp",
+              "player3": "normal"
+            },
+            "marker": "a"
+          }
+        ]
+	  }
     ],
     "rooms": [
       {

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -159,8 +159,8 @@
           }
         ]
       },
-	  {
-	    "round": "R > 0",
+      {
+        "round": "R > 0",
         "start": false,
         "spawns": [
           {
@@ -171,7 +171,7 @@
             "marker": "a"
           }
         ]
-	  }
+      }
     ],
     "rooms": [
       {


### PR DESCRIPTION
One thing:
I don't have the section book with me at the moment, but I believe the summoning in section 20.1 is rather unique in ruleset:
2 players - 1 normal black imp spawns every other round
3 players - 1 normal black imp spawns every round
4 players - 1 elite black imp spawns every other round

I wasn't sure if this was possible to code in at the moment, so I opted to not do so.