### PR TITLE
Scenario 114 fix-ups

### DIFF
--- a/data/fh/scenarios.json
+++ b/data/fh/scenarios.json
@@ -3125,20 +3125,130 @@
       "polar-bear",
       "snow-imp"
     ],
-    "objectives": [
-      {
-        "name": "Ice Pillar",
-        "health": "(2xL)+2",
-        "count": 2
-      }
-    ],
     "lootDeckConfig": {
       "money": 10,
       "metal": 3,
       "hide": 4,
       "axenut": 1,
       "snowthistle": 2
-    }
+    },
+    "objectives": [
+      {
+        "name": "Ice Pillar",
+        "health": "(2xL)+2",
+        "marker": "b",
+        "actions": [
+          {
+            "type": "shield",
+            "value": "[L/2{$math.ceil}]"
+          }
+        ]
+      },
+      {
+        "name": "Ice Pillar",
+        "health": "(2xL)+2",
+        "actions": [
+          {
+            "type": "shield",
+            "value": "[L/2{$math.ceil}]"
+          }
+        ]
+      }
+    ],
+    "rules": [
+      {
+        "round": "R % 2 == 0",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "snow-imp",
+              "player2": "normal",
+              "player3": "elite",
+              "player4": "normal"
+            },
+            "marker": "d"
+          },
+          {
+            "monster": {
+              "name": "snow-imp",
+              "player4": "elite"
+            },
+            "marker": "d"
+          }
+        ]
+      },
+      {
+        "round": "R % 2 == 1",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "hound",
+              "player2": "normal",
+              "player3": "elite"
+            },
+            "marker": "c"
+          },
+          {
+            "monster": {
+              "name": "polar-bear",
+              "player4": "normal"
+            },
+            "marker": "c"
+          }
+        ]
+      }
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "13-A",
+        "initial": true,
+        "monster": [
+          {
+            "name": "hound",
+            "player4": "normal"
+          },
+          {
+            "name": "hound",
+            "player4": "normal"
+          },
+          {
+            "name": "hound",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "hound",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "type": "elite"
+          },
+          {
+            "name": "polar-bear",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          }
+        ],
+        "objectives": [
+          1,
+          1,
+          2,
+          2
+        ]
+      }
+    ]
   },
   {
     "index": "115",

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -155,7 +155,7 @@
               "name": "black-imp",
               "player2": "normal"
             },
-            "marker": "a"
+            "marker": "b"
           }
         ]
       },
@@ -169,7 +169,7 @@
               "player3": "normal",
               "player4": "elite"
             },
-            "marker": "a"
+            "marker": "b"
           }
         ]
       }

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -1108,7 +1108,7 @@
     "rules": [
       {
         "round": "R % 2 == 0",
-        "start": false,
+        "start": true,
         "spawns": [
           {
             "monster": {
@@ -1126,11 +1126,19 @@
             },
             "marker": "f"
           }
+        ],
+        "disableRules": [
+          {
+            "edition": "fh",
+            "scenario": "114",
+            "index": 0,
+            "section": true
+          }
         ]
       },
       {
         "round": "R % 2 == 1",
-        "start": false,
+        "start": true,
         "spawns": [
           {
             "monster": {
@@ -1146,6 +1154,14 @@
               "player4": "normal"
             },
             "marker": "e"
+          }
+        ],
+        "disableRules": [
+          {
+            "edition": "fh",
+            "scenario": "114",
+            "index": 1,
+            "section": true
           }
         ]
       }

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -1088,6 +1088,118 @@
     ]
   },
   {
+    "index": "159.1",
+    "name": "Work Freeze",
+    "parent": "114",
+    "edition": "fh",
+    "marker": "b",
+    "objectives": [
+      {
+        "name": "Ice Pillar",
+        "health": "(2xL)+2",
+        "actions": [
+          {
+            "type": "shield",
+            "value": "[L/2{$math.ceil}]"
+          }
+        ]
+      }
+    ],
+    "rules": [
+      {
+        "round": "R % 2 == 0",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "snow-imp",
+              "player2": "normal",
+              "player3": "elite",
+              "player4": "normal"
+            },
+            "marker": "f"
+          },
+          {
+            "monster": {
+              "name": "snow-imp",
+              "player4": "elite"
+            },
+            "marker": "f"
+          }
+        ]
+      },
+      {
+        "round": "R % 2 == 1",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "hound",
+              "player2": "normal",
+              "player3": "elite"
+            },
+            "marker": "e"
+          },
+          {
+            "monster": {
+              "name": "polar-bear",
+              "player4": "normal"
+            },
+            "marker": "e"
+          }
+        ]
+      }
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "13-C",
+        "initial": true,
+        "monster": [
+          {
+            "name": "hound",
+            "player4": "normal"
+          },
+          {
+            "name": "hound",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "type": "normal"
+          },
+          {
+            "name": "snow-imp",
+            "player4": "elite"
+          },
+          {
+            "name": "snow-imp",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "polar-bear",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "polar-bear",
+            "type": "normal"
+          }
+        ],
+        "objectives": [
+          1,
+          1,
+          1,
+          1
+        ]
+      }
+    ]
+  },
+  {
     "index": "172.1",
     "name": "The Eternal Crave",
     "parent": "122",


### PR DESCRIPTION
I'm curious if it is possible to replace an old ruleset for a new one?

In scenario 114, when section 159.1 is revealed, the special spawning rules of base 114 are replaced with the 159.1 ones, but with how I've done it for now, the app suggests spawning in both ruleset.