### PR TITLE
Scenario 21 fix-ups

### DIFF
--- a/data/fh/scenarios.json
+++ b/data/fh/scenarios.json
@@ -690,6 +690,15 @@
             "type": "gainCondition",
             "value": "muddle",
             "scenarioEffect": true
+          },
+          {
+            "identifier": {
+              "type": "character",
+              "name": ".*"
+            },
+            "type": "discard",
+            "value": "two",
+            "scenarioEffect": true
           }
         ]
       }

--- a/data/fh/scenarios.json
+++ b/data/fh/scenarios.json
@@ -707,6 +707,10 @@
             "player2": "normal",
             "player3": "elite",
             "player4": "elite"
+          },
+          {
+            "name": "living-spirit",
+            "player4": "normal"
           }
         ]
       }

--- a/data/fh/scenarios.json
+++ b/data/fh/scenarios.json
@@ -697,7 +697,7 @@
               "name": ".*"
             },
             "type": "discard",
-            "value": "two",
+            "value": "2",
             "scenarioEffect": true
           }
         ]

--- a/data/fh/scenarios.json
+++ b/data/fh/scenarios.json
@@ -677,6 +677,23 @@
       "snowthistle": 2,
       "random_item": 1
     },
+	"rules": [
+      {
+        "round": "R == 1",
+        "start": true,
+        "figures": [
+          {
+            "identifier": {
+              "type": "character",
+              "name": ".*"
+            },
+            "type": "gainCondition",
+            "value": "muddle",
+            "scenarioEffect": true
+          }
+        ]
+      }
+    ],
     "rooms": [
       {
         "roomNumber": 1,

--- a/data/fh/scenarios.json
+++ b/data/fh/scenarios.json
@@ -677,7 +677,7 @@
       "snowthistle": 2,
       "random_item": 1
     },
-	"rules": [
+    "rules": [
       {
         "round": "R == 1",
         "start": true,

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -452,7 +452,7 @@
         "actions": [
           {
             "type": "custom",
-            "value": "Whenever it suffers damage, all characters and monsters suffer %game.action.damage% 2"
+            "value": "Whenever it suffers damage, all characters and monsters suffer %game.damage:2%"
           }
         ]
       }

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -472,7 +472,7 @@
         "actions": [
           {
             "type": "custom",
-            "value": "Whenever it suffers damage, all characters and monsters suffer 2 %game.action.damage%"
+            "value": "Whenever it suffers damage, all characters and monsters suffer %game.action.damage% 2"
           }
         ]
       }

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -386,7 +386,7 @@
     "parent": "21",
     "edition": "fh",
     "marker": "2",
-    "parentSection": [
+    "parentSections": [
       "51.1"
     ],
     "objectives": [
@@ -461,6 +461,16 @@
       {
         "round": "true",
         "start": false,
+        "figures": [
+          {
+            "type": "present",
+            "identifier": {
+              "type": "objective",
+              "edition": "objective",
+              "name": "Glowing Orb"
+            }
+          }
+        ],
         "spawns": [
           {
             "monster": {
@@ -470,13 +480,7 @@
               "player4": "elite"
             },
             "marker": "a"
-          }
-        ]
-      },
-      {
-        "round": "true",
-        "start": false,
-        "spawns": [
+          },
           {
             "monster": {
               "name": "living-bones",
@@ -485,34 +489,6 @@
               "player4": "elite"
             },
             "marker": "b"
-          }
-        ]
-      },
-      {
-        "round": "true",
-        "start": false,
-        "figures": [
-          {
-            "type": "dead",
-            "identifier": {
-              "type": "objective",
-              "edition": "objective",
-              "name": "Glowing Orb"
-            }
-          }
-        ],
-        "disableRules": [
-          {
-            "edition": "fh",
-            "scenario": "51.1",
-            "index": 0,
-            "section": true
-          },
-          {
-            "edition": "fh",
-            "scenario": "51.1",
-            "index": 1,
-            "section": true
           }
         ]
       }

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -399,26 +399,6 @@
         "health": "L+2"
       }
     ],
-    "rules": [
-      {
-        "round": "always",
-        "always": true,
-        "disableRules": [
-          {
-            "edition": "fh",
-            "scenario": "51.1",
-            "index": 0,
-            "section": true
-          },
-          {
-            "edition": "fh",
-            "scenario": "51.1",
-            "index": 1,
-            "section": true
-          }
-        ]
-      }
-    ],
     "rooms": [
       {
         "roomNumber": 1,
@@ -505,6 +485,34 @@
               "player4": "elite"
             },
             "marker": "b"
+          }
+        ]
+      },
+      {
+        "round": "true",
+        "start": false,
+        "figures": [
+          {
+            "type": "dead",
+            "identifier": {
+              "type": "objective",
+              "edition": "objective",
+              "name": "Glowing Orb"
+            }
+          }
+        ],
+        "disableRules": [
+          {
+            "edition": "fh",
+            "scenario": "51.1",
+            "index": 0,
+            "section": true
+          },
+          {
+            "edition": "fh",
+            "scenario": "51.1",
+            "index": 1,
+            "section": true
           }
         ]
       }

--- a/data/fh/sections.json
+++ b/data/fh/sections.json
@@ -385,30 +385,77 @@
     "name": "Realm of Endless Frost",
     "parent": "21",
     "edition": "fh",
+    "marker": "2",
+    "parentSection": [
+      "51.1"
+    ],
     "objectives": [
       {
-        "name": "Crate 1",
+        "name": "Crate",
         "health": "L+2"
       },
       {
-        "name": "Crate 2",
+        "name": "Bookshelf",
         "health": "L+2"
-      },
+      }
+    ],
+    "rules": [
       {
-        "name": "Crate 3",
-        "health": "L+2"
-      },
+        "round": "always",
+        "always": true,
+        "disableRules": [
+          {
+            "edition": "fh",
+            "scenario": "51.1",
+            "index": 0,
+            "section": true
+          },
+          {
+            "edition": "fh",
+            "scenario": "51.1",
+            "index": 1,
+            "section": true
+          }
+        ]
+      }
+    ],
+    "rooms": [
       {
-        "name": "Bookshelf 1",
-        "health": "L+2"
-      },
-      {
-        "name": "Bookshelf 2",
-        "health": "L+2"
-      },
-      {
-        "name": "Bookshelf 3",
-        "health": "L+2"
+        "roomNumber": 1,
+        "ref": "07-E",
+        "initial": true,
+        "treasures": [
+          84
+        ],
+        "monster": [
+          {
+            "name": "living-bones",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          {
+            "name": "living-spirit",
+            "type": "normal"
+          },
+          {
+            "name": "living-spirit",
+            "player4": "normal"
+          },
+          {
+            "name": "living-spirit",
+            "player3": "normal",
+            "player4": "elite"
+          }
+        ],
+        "objectives": [
+          1,
+          1,
+          1,
+          2,
+          2,
+          2
+        ]
       }
     ]
   },
@@ -417,10 +464,74 @@
     "name": "Realm of Endless Frost",
     "parent": "21",
     "edition": "fh",
+    "marker": "1",
     "objectives": [
       {
         "name": "Glowing Orb",
-        "health": "(L+2)xC"
+        "health": "(L+2)xC",
+        "actions": [
+          {
+            "type": "custom",
+            "value": "Whenever it suffers damage, all characters and monsters suffer 2 %game.action.damage%"
+          }
+        ]
+      }
+    ],
+    "rules": [
+      {
+        "round": "true",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "living-bones",
+              "player2": "normal",
+              "player3": "normal",
+              "player4": "elite"
+            },
+            "marker": "a"
+          }
+        ]
+      },
+      {
+        "round": "true",
+        "start": false,
+        "spawns": [
+          {
+            "monster": {
+              "name": "living-bones",
+              "player2": "normal",
+              "player3": "elite",
+              "player4": "elite"
+            },
+            "marker": "b"
+          }
+        ]
+      }
+    ],
+    "rooms": [
+      {
+        "roomNumber": 1,
+        "ref": "15-C",
+        "initial": true,
+        "monster": [
+          {
+            "name": "living-bones",
+            "type": "elite"
+          },
+          {
+            "name": "living-bones",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          {
+            "name": "living-bones",
+            "player4": "normal"
+          }
+        ],
+        "objectives": [
+          1
+        ]
       }
     ]
   },

--- a/src/app/game/model/data/ScenarioRule.ts
+++ b/src/app/game/model/data/ScenarioRule.ts
@@ -41,7 +41,7 @@ export class MonsterSpawnData {
 export class ScenarioFigureRule {
 
   identifier: FigureIdentifier = undefined;
-  type: "present" | "dead" | "gainCondition" | "looseCondition" | "damage" | "hp" | "toggleOff" | "toggleOn" | "transfer" | "remove" | "amAdd" | "amRemove" = "present";
+  type: "present" | "dead" | "gainCondition" | "looseCondition" | "damage" | "hp" | "discard" | "toggleOff" | "toggleOn" | "transfer" | "remove" | "amAdd" | "amRemove" = "present";
   value: string = "";
   scenarioEffect: boolean = false;
 

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -149,11 +149,11 @@
           "download": "Download Character Data as JSON file"
         },
         "hp": {
-          "0": "Low Profile",
-          "1": "Middle Profile",
-          "2": "High Profile",
           ".": "Hit Points",
           "-1": "Custom Profile"
+          "0": "Low Profile",
+          "1": "Middle Profile",
+          "2": "High Profile"
         }
       },
       "edition": "Edition",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -149,11 +149,11 @@
           "download": "Download Character Data as JSON file"
         },
         "hp": {
-          ".": "Hit Points",
-          "-1": "Custom Profile",
           "0": "Low Profile",
           "1": "Middle Profile",
-          "2": "High Profile"
+          "2": "High Profile",
+          ".": "Hit Points",
+          "-1": "Custom Profile"
         }
       },
       "edition": "Edition",
@@ -734,6 +734,7 @@
         "damage": "{0} suffer %game.damage:{2}%",
         "gainCondition": "{0} gain %game.condition.{1}%",
         "hp": "{0} HP to {2}",
+        "discard": "{0} discards {2} cards",
         "looseCondition": "{0} loose %game.condition.{1}%",
         "scenarioEffect": "as scenario effect",
         "toggleOff": "{0} to inactive",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -734,7 +734,7 @@
         "damage": "{0} suffer %game.damage:{2}%",
         "gainCondition": "{0} gain %game.condition.{1}%",
         "hp": "{0} HP to {2}",
-        "discard": "{0} discards {2} cards",
+        "discard": "{0} discards %number.{2}% cards",
         "looseCondition": "{0} loose %game.condition.{1}%",
         "scenarioEffect": "as scenario effect",
         "toggleOff": "{0} to inactive",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -150,7 +150,7 @@
         },
         "hp": {
           ".": "Hit Points",
-          "-1": "Custom Profile"
+          "-1": "Custom Profile",
           "0": "Low Profile",
           "1": "Middle Profile",
           "2": "High Profile"


### PR DESCRIPTION
Only first half of scenario 21, because we didn't get to the final room (yet), I'll update it again tonight/tomorrow/sometime later when we do get to it.

A couple of things:
* Index 51.1's custom ruleset should be disabled when the objective in 51.1 is destroyed, not when section 48.1 is opened, I wasn't sure if it was possible to base a rule disabling off the killing of an objective yet?
* The %game.action.damage% symbol is a bit hard to see, white text and then the black symbol, would it be possible to make it white or alike?