### PR TITLE
Update boneshaper.json

### DIFF
--- a/data/fh/character/boneshaper.json
+++ b/data/fh/character/boneshaper.json
@@ -184,7 +184,7 @@
       "count": 2,
       "cards": [
         {
-          "count": 2,
+          "count": 3,
           "attackModifier": {
             "type": "plus0",
             "rolling": true,


### PR DESCRIPTION
Corrected perk: Each perk check should add 3 heal 1, target Boneshaper, rolling modifier cards