### PR TITLE
Fixed some perk typos

### DIFF
--- a/data/fh/character/astral.json
+++ b/data/fh/character/astral.json
@@ -96,7 +96,13 @@
                 "value": "dark"
               }
             ]
-          }
+          },
+          {
+          "count": 1, 
+          "attackModifier": {
+            "type": "minus1"
+              }
+           }
         }
       ]
     },

--- a/data/fh/character/drill.json
+++ b/data/fh/character/drill.json
@@ -194,7 +194,7 @@
     {
       "type": "add",
       "count": 1,
-      "custom": "%game.custom.perks.ignoreNegativeScenario%",
+      "custom": "%game.custom.perks.ignoreNegativeItemFh%",
       "cards": [
         {
           "count": 2,

--- a/data/fh/character/geminate.json
+++ b/data/fh/character/geminate.json
@@ -173,7 +173,7 @@
             "type": "plus1",
             "effects": [
               {
-                "type": "pierce",
+                "type": "push",
                 "value": 3
               }
             ]

--- a/data/fh/character/meteor.json
+++ b/data/fh/character/meteor.json
@@ -109,7 +109,7 @@
             "effects": [
               {
                 "type": "custom",
-                "value": "Create one 1-hex hazardouus terrain tile in a featureless hex adjacent to the target"
+                "value": "Create one 1-hex hazardous terrain tile in a featureless hex adjacent to the target"
               }
             ]
           }
@@ -219,7 +219,7 @@
     }
   ],
   "masteries": [
-    "Create or destroy at least one obstalce or hazardous terrain tile each round",
-    "Move enemeis through six different hexes of hazardous terrain you created in one turn"
+    "Create or destroy at least one obstacle or hazardous terrain tile each round",
+    "Move enemies through six different hexes of hazardous terrain you created in one turn"
   ]
 }

--- a/data/fh/character/shackles.json
+++ b/data/fh/character/shackles.json
@@ -280,7 +280,7 @@
     {
       "type": "custom",
       "count": 1,
-      "custom": "Each round in which you long rest, you may ignore all negative conditions you haven.<br>If you do, they cannot be removed that round"
+      "custom": "Each round in which you long rest, you may ignore all negative conditions you have.<br>If you do, they cannot be removed that round"
     },
     {
       "type": "custom",

--- a/data/fh/character/shards.json
+++ b/data/fh/character/shards.json
@@ -139,7 +139,7 @@
           }
         },
         {
-          "count": 1,
+          "count": 2,
           "attackModifier": {
             "type": "plus2",
             "effects": [


### PR DESCRIPTION
I've checked through all perks, updating values and fixing typos. Hopefully, I got all the brackets correct on the astral icon perk change. 

The shackles icon has a mastery that's not loading correctly on my devices (checked iPad Safari and computer Firefox browsers). I didn't see anything wrong in the code, so I'm not sure why the icons aren't loading (the last one is though). 