### PR TITLE
Fixing ward and brittle calculations

### DIFF
--- a/src/app/game/businesslogic/EntityManager.ts
+++ b/src/app/game/businesslogic/EntityManager.ts
@@ -173,7 +173,7 @@ export class EntityManager {
       }
 
       if (condition.name == ConditionName.ward) {
-        entity.health += Math.floor((condition.value - 1) / 2);
+        entity.health += Math.ceil(condition.value / 2);
         const maxHealth = EntityValueFunction(entity.maxHealth);
         if (entity.health > maxHealth) {
           entity.health = maxHealth;
@@ -189,7 +189,7 @@ export class EntityManager {
       }
 
       if (condition.name == ConditionName.brittle) {
-        entity.health -= Math.floor((condition.value - 1) / 2);
+        entity.health -= condition.value;
         if (entity.health < 0) {
           entity.health = 0;
         }


### PR DESCRIPTION
Ward should result in taking half damage rounded down. Since the code is written for healing the damage, I believe it should be  entity.health += ceil(damage taken / 2), assuming entity.health already has incorporated the full damage. 

For brittle, the damage should be double what was done. It looks like the code was using the same function as the ward and subtracting, so the value was less than double. If I understand the code correctly, I think changing it to just condition.value should fix that?