### PR TITLE
[Spawnbroker] Town guard perk updates

### DIFF
--- a/data/fh/campaign.json
+++ b/data/fh/campaign.json
@@ -193,7 +193,7 @@
                             "effects": [
                                 {
                                     "type": "custom",
-                                    "value": "Gain Adavantage on this target"
+                                    "value": "Gain Advantage on this target"
                                 }
                             ]
                         }

--- a/data/fh/campaign.json
+++ b/data/fh/campaign.json
@@ -98,7 +98,7 @@
                         }
                     },
                     {
-                        "count": 1,
+                        "count": 2,
                         "attackModifier": {
                             "type": "plus",
                             "value": 30

--- a/data/fh/campaign.json
+++ b/data/fh/campaign.json
@@ -156,7 +156,8 @@
                     {
                         "count": 2,
                         "attackModifier": {
-                            "type": "plus0"
+                            "type": "plus",
+                            "value": 0
                         }
                     },
                     {


### PR DESCRIPTION
Hi there! Brand new to this repo and wanted to help out, so started reading the data files for typos / errors.

Found some things in the Town Guard Perks that seemed incorrect. Changes in this PR:
- The second perk should add **two** +30 cards, not one.
- The fourth perk had the type and value in the same field; I changed this to separate them like the others. Let me know if this is incorrect, this was just a guess on my part
- In the fifth perk, Advantage was misspelled