### PR TITLE
FH: 037, Add Section 144.1, Scenario Effects

### DIFF
--- a/data/fh/scenarios/037.json
+++ b/data/fh/scenarios/037.json
@@ -24,6 +24,23 @@
     "arrowvine": 2,
     "random_item": 1
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "amAdd",
+          "value": "minus1:2",
+          "scenarioEffect": true
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,

--- a/data/fh/sections/144-1.json
+++ b/data/fh/sections/144-1.json
@@ -1,0 +1,44 @@
+{
+  "index": "144.1",
+  "name": "The Dead Mile",
+  "edition": "fh",
+  "parent": "37",
+  "monsters": [
+    "living-bones"
+  ],
+  "rooms": [
+    {
+      "roomNumber": 4,
+      "initial": true,
+      "monster": [
+        {
+          "name": "living-bones",
+          "player2": "normal",
+          "player3": "elite",
+          "player4": "elite"
+        },
+        {
+          "name": "living-bones",
+          "player2": "normal",
+          "player3": "elite",
+          "player4": "elite"
+        },
+        {
+          "name": "living-bones",
+          "player2": "elite",
+          "player3": "elite",
+          "player4": "elite"
+        },
+        {
+          "name": "living-bones",
+          "player3": "normal",
+          "player4": "normal"
+        },
+        {
+          "name": "living-bones",
+          "player4": "normal"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hello!

I've been using your wonderful app to streamline my play through of Frosthaven. It's truly fantastic!

While I was playing scenario 37 I noticed a missing section. This PR adds that section (144.1) as well as the scenario effects for 37.

What I couldn't figure out was how to properly implement the special rules introduced by sections 70.1, 81.5, and 144.1 b/c the monster level switches to elite every other spawn for three players. I fiddled with a few experiments but nothing seemed quite right. If I missed something, please let me know, I'd be happy to implement it!