### PR TITLE
Updated Treasure Data (2 minor issues remain)

### DIFF
--- a/data/fh/scenarios/026.json
+++ b/data/fh/scenarios/026.json
@@ -26,6 +26,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        73
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/fh/scenarios/029.json
+++ b/data/fh/scenarios/029.json
@@ -27,7 +27,7 @@
       "roomNumber": 1,
       "initial": true,
       "treasures": [
-        49
+        45
       ],
       "monster": [
         {

--- a/data/fh/scenarios/029.json
+++ b/data/fh/scenarios/029.json
@@ -26,6 +26,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        49
+      ],
       "monster": [
         {
           "name": "algox-icespeaker",

--- a/data/fh/scenarios/057.json
+++ b/data/fh/scenarios/057.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        53
+      ],
       "monster": [
         {
           "name": "render",

--- a/data/fh/scenarios/062.json
+++ b/data/fh/scenarios/062.json
@@ -32,6 +32,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        21
+      ],
       "monster": [
         {
           "name": "chaos-demon",

--- a/data/fh/scenarios/063.json
+++ b/data/fh/scenarios/063.json
@@ -37,6 +37,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        72
+      ],
       "monster": []
     }
   ]

--- a/data/fh/scenarios/068.json
+++ b/data/fh/scenarios/068.json
@@ -17,6 +17,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        59
+      ],
       "monster": [
         {
           "name": "chaos-demon",

--- a/data/fh/scenarios/076.json
+++ b/data/fh/scenarios/076.json
@@ -28,6 +28,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        2
+      ],
       "monster": [
         {
           "name": "algox-archer",

--- a/data/fh/scenarios/080.json
+++ b/data/fh/scenarios/080.json
@@ -43,6 +43,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        62, 69
+      ],
       "monster": [
         {
           "name": "robotic-boltshooter",

--- a/data/fh/scenarios/102.json
+++ b/data/fh/scenarios/102.json
@@ -17,6 +17,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        57, 85
+      ],
       "monster": []
     }
   ]

--- a/data/fh/scenarios/130.json
+++ b/data/fh/scenarios/130.json
@@ -21,6 +21,9 @@
     {
       "roomNumber": 1,
       "initial": true,
+      "treasures": [
+        11
+      ],
       "monster": [
         {
           "name": "frozen-corpse",

--- a/data/fh/sections/104-4.json
+++ b/data/fh/sections/104-4.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        61
+      ],
       "monster": [
         {
           "name": "living-bones",

--- a/data/fh/sections/105-4.json
+++ b/data/fh/sections/105-4.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        55
+      ],
       "monster": [
         {
           "name": "flaming-bladespinner",

--- a/data/fh/sections/106-2.json
+++ b/data/fh/sections/106-2.json
@@ -13,6 +13,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        82
+      ],
       "monster": [
         {
           "name": "city-guard",

--- a/data/fh/sections/108-1.json
+++ b/data/fh/sections/108-1.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        14
+      ],
       "monster": [
         {
           "name": "robotic-boltshooter",

--- a/data/fh/sections/109-2.json
+++ b/data/fh/sections/109-2.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        30
+      ],
       "monster": [
         {
           "name": "frozen-corpse",

--- a/data/fh/sections/116-2.json
+++ b/data/fh/sections/116-2.json
@@ -12,6 +12,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        10
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/fh/sections/121-1.json
+++ b/data/fh/sections/121-1.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        7
+      ],
       "monster": [
         {
           "name": "steel-automaton",

--- a/data/fh/sections/123-3.json
+++ b/data/fh/sections/123-3.json
@@ -13,6 +13,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        41
+      ],
       "monster": [
         {
           "name": "algox-archer",

--- a/data/fh/sections/124-2.json
+++ b/data/fh/sections/124-2.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        34
+      ],
       "monster": [
         {
           "name": "polar-bear",

--- a/data/fh/sections/128-4.json
+++ b/data/fh/sections/128-4.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        52
+      ],
       "monster": [
         {
           "name": "power-core",

--- a/data/fh/sections/130-5.json
+++ b/data/fh/sections/130-5.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        15
+      ],
       "monster": [
         {
           "name": "frost-demon",

--- a/data/fh/sections/132-2.json
+++ b/data/fh/sections/132-2.json
@@ -13,6 +13,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        37
+      ],
       "monster": [
         {
           "name": "frozen-corpse",

--- a/data/fh/sections/133-3.json
+++ b/data/fh/sections/133-3.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 5,
       "initial": true,
+      "treasures": [
+        1
+      ],
       "monster": [
         {
           "name": "snow-imp",

--- a/data/fh/sections/139-1.json
+++ b/data/fh/sections/139-1.json
@@ -12,6 +12,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        54
+      ],
       "monster": [
         {
           "name": "abael-scout",

--- a/data/fh/sections/143-1.json
+++ b/data/fh/sections/143-1.json
@@ -12,6 +12,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        33
+      ],
       "monster": [
         {
           "name": "abael-herder",

--- a/data/fh/sections/145-3.json
+++ b/data/fh/sections/145-3.json
@@ -12,6 +12,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        35
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/fh/sections/146-3.json
+++ b/data/fh/sections/146-3.json
@@ -14,6 +14,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        42
+      ],
       "monster": [
         {
           "name": "algox-archer",

--- a/data/fh/sections/148-4.json
+++ b/data/fh/sections/148-4.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 6,
       "initial": true,
+      "treasures": [
+        24
+      ],
       "monster": [
         {
           "name": "deep-terror",

--- a/data/fh/sections/154-2.json
+++ b/data/fh/sections/154-2.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        78
+      ],
       "monster": [
         {
           "name": "algox-guard",

--- a/data/fh/sections/156-2.json
+++ b/data/fh/sections/156-2.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        25
+      ],
       "monster": [
         {
           "name": "burrowing-blade",

--- a/data/fh/sections/160-1.json
+++ b/data/fh/sections/160-1.json
@@ -12,6 +12,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        65
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/fh/sections/165-5.json
+++ b/data/fh/sections/165-5.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        3
+      ],
       "monster": [
         {
           "name": "ice-wraith",

--- a/data/fh/sections/166-3.json
+++ b/data/fh/sections/166-3.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        80
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/fh/sections/167-1.json
+++ b/data/fh/sections/167-1.json
@@ -7,6 +7,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        5
+      ],
       "monster": []
     }
   ]

--- a/data/fh/sections/174-3.json
+++ b/data/fh/sections/174-3.json
@@ -20,6 +20,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        19
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/fh/sections/177-2.json
+++ b/data/fh/sections/177-2.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 5,
       "initial": true,
+      "treasures": [
+        20, 51, 55
+      ],
       "monster": [
         {
           "name": "frost-demon",

--- a/data/fh/sections/180-4.json
+++ b/data/fh/sections/180-4.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        83
+      ],
       "monster": [
         {
           "name": "living-bones",

--- a/data/fh/sections/184-6.json
+++ b/data/fh/sections/184-6.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 5,
       "initial": true,
+      "treasures": [
+        38
+      ],
       "monster": [
         {
           "name": "polar-bear",

--- a/data/fh/sections/186-3.json
+++ b/data/fh/sections/186-3.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        75
+      ],
       "monster": [
         {
           "name": "living-spirit",

--- a/data/fh/sections/20-3.json
+++ b/data/fh/sections/20-3.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        12
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/fh/sections/25-1.json
+++ b/data/fh/sections/25-1.json
@@ -13,6 +13,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        6
+      ],
       "monster": [
         {
           "name": "savvas-icestorm",

--- a/data/fh/sections/29-2.json
+++ b/data/fh/sections/29-2.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        68
+      ],
       "monster": [
         {
           "name": "blacksmith",

--- a/data/fh/sections/29-4.json
+++ b/data/fh/sections/29-4.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        28
+      ],
       "monster": [
         {
           "name": "frost-demon",

--- a/data/fh/sections/32-1.json
+++ b/data/fh/sections/32-1.json
@@ -12,6 +12,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        56
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/fh/sections/36-5.json
+++ b/data/fh/sections/36-5.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        43
+      ],
       "monster": [
         {
           "name": "frost-demon",

--- a/data/fh/sections/37-2.json
+++ b/data/fh/sections/37-2.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        26
+      ],
       "monster": [
         {
           "name": "robotic-boltshooter",

--- a/data/fh/sections/45-1.json
+++ b/data/fh/sections/45-1.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        15
+      ],
       "monster": [
         {
           "name": "algox-icespeaker",

--- a/data/fh/sections/51-2.json
+++ b/data/fh/sections/51-2.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        61
+      ],
       "monster": [
         {
           "name": "abael-scout",

--- a/data/fh/sections/59-2.json
+++ b/data/fh/sections/59-2.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        58
+      ],
       "monster": [
         {
           "name": "abael-herder",

--- a/data/fh/sections/61-1.json
+++ b/data/fh/sections/61-1.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        81
+      ],
       "monster": [
         {
           "name": "ruined-machine",

--- a/data/fh/sections/61-2.json
+++ b/data/fh/sections/61-2.json
@@ -18,6 +18,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        74
+      ],
       "monster": [
         {
           "name": "robotic-boltshooter",

--- a/data/fh/sections/70-1.json
+++ b/data/fh/sections/70-1.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        56
+      ],
       "monster": [
         {
           "name": "ruined-machine",

--- a/data/fh/sections/71-5.json
+++ b/data/fh/sections/71-5.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        36
+      ],
       "monster": [
         {
           "name": "deep-terror",

--- a/data/fh/sections/75-3.json
+++ b/data/fh/sections/75-3.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        16
+      ],
       "monster": [
         {
           "name": "sun-demon",

--- a/data/fh/sections/76-1.json
+++ b/data/fh/sections/76-1.json
@@ -12,6 +12,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        8
+      ],
       "monster": [
         {
           "name": "frozen-corpse",

--- a/data/fh/sections/77-2.json
+++ b/data/fh/sections/77-2.json
@@ -10,6 +10,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        27
+      ],
       "monster": [
         {
           "name": "lurker-clawcrusher",

--- a/data/fh/sections/80-1.json
+++ b/data/fh/sections/80-1.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        66
+      ],
       "monster": [
         {
           "name": "frost-demon",

--- a/data/fh/sections/80-2.json
+++ b/data/fh/sections/80-2.json
@@ -14,6 +14,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        41
+      ],
       "monster": []
     }
   ]

--- a/data/fh/sections/82-2.json
+++ b/data/fh/sections/82-2.json
@@ -12,6 +12,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        76
+      ],
       "monster": [
         {
           "name": "deep-terror",

--- a/data/fh/sections/85-2.json
+++ b/data/fh/sections/85-2.json
@@ -20,6 +20,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        15
+      ],
       "monster": [
         {
           "name": "abael-herder",

--- a/data/fh/sections/87-3.json
+++ b/data/fh/sections/87-3.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        29
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/fh/sections/89-1.json
+++ b/data/fh/sections/89-1.json
@@ -21,6 +21,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        39
+      ],
       "monster": [
         {
           "name": "frozen-corpse-scenario-65",

--- a/data/fh/sections/91-1.json
+++ b/data/fh/sections/91-1.json
@@ -7,6 +7,9 @@
     {
       "roomNumber": 6,
       "initial": true,
+      "treasures": [
+        13
+      ],
       "monster": []
     }
   ]

--- a/data/fh/sections/91-3.json
+++ b/data/fh/sections/91-3.json
@@ -11,6 +11,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        41
+      ],
       "monster": [
         {
           "name": "algox-scout",


### PR DESCRIPTION
I've double checked the treasure data file and corrected a few typos. I've also inputted the treasures into all sections; however, there are 2 issues:

- Sections 2.1, 3.2, and 6.3 are currently missing - I'll see if I have some free time later in the week to help input those three missing sections and the treasure data
- ~~Section 177.2 contains 3 treasures (20, 51, 55) and I wasn't sure how this data should be entered.~~

Outside of the above issues, all treasure data should now present and double checked. 

Edit: I looked back at my spreadsheet of chest values and some of them appear to be missing from my list. I need to double check what happened there. 

Edit 2: Ah, the ~20 missing chest values are located in the initial scenario files. I'll start entering those in. 