### PR TITLE
Various updates for Scenarios 51 to 63

### DIFF
--- a/data/fh/label.json
+++ b/data/fh/label.json
@@ -111,9 +111,6 @@
           "21-1": {
             "1": "on any empty starting hex"
           },
-          "70-1": {
-            "1": "at any empty starting hex"
-          },
           "65-3": {
             "1": "Open all doors %game.mapMarker.1%. Place all characters and character summons, in initiative order, in the closest empty hex on tile 16-A, then remove all doors and tile 13-A from the map."
           }

--- a/data/fh/scenarios/051.json
+++ b/data/fh/scenarios/051.json
@@ -22,6 +22,23 @@
     "flamefruit": 1,
     "arrowvine": 1
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "amAdd",
+          "value": "minus1:2",
+          "scenarioEffect": true
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,

--- a/data/fh/scenarios/054.json
+++ b/data/fh/scenarios/054.json
@@ -6,7 +6,25 @@
   "unlocks": [
     "60"
   ],
-  "monsters": [],
+  "monsters": [
+    "lightning-eel",
+    "lurker-clawcrusher",
+    "lurker-mindsnipper",
+    "lurker-soldier",
+    "lurker-wavethrower"
+  ],
+  "objectives": [
+    {
+      "name": "Ice Pillar",
+      "health": "[(L+1)xC/2{$math.floor}]",
+      "count": 4
+    },
+    {
+      "name": "Large Cave Rock",
+      "health": "[(L+1)xC/2{$math.floor}]",
+      "count": 3
+    }
+  ],
   "lootDeckConfig": {
     "money": 8,
     "lumber": 2,
@@ -16,11 +34,51 @@
     "arrowvine": 2,
     "random_item": 1
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "amAdd",
+          "value": "minus1:3",
+          "scenarioEffect": true
+        }
+      ]
+    },
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": "(?!.*coral|kelp).*"
+          },
+          "type": "amAdd",
+          "value": "curse:2"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
       "initial": true,
-      "monster": []
+      "monster": [],
+      "objectives": [
+        1,
+        1,
+        1,
+        1,
+        2,
+        2,
+        2
+      ]
     }
   ]
 }

--- a/data/fh/scenarios/056.json
+++ b/data/fh/scenarios/056.json
@@ -10,7 +10,7 @@
   ],
   "objectives": [
     {
-      "name": "Altar",
+      "name": "Altar 1",
       "health": "(L+1)xC"
     }
   ],
@@ -22,6 +22,26 @@
     "rockroot": 2,
     "flamefruit": 2
   },
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "3.2"
+      ],
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Altar 1"
+          },
+          "type": "dead"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -50,6 +70,9 @@
           "player3": "normal",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/scenarios/057.json
+++ b/data/fh/scenarios/057.json
@@ -4,7 +4,96 @@
   "name": "Sanctuary of Snow",
   "edition": "fh",
   "monsters": [
-    "render"
+    "render",
+    "wind-demon"
+  ],
+  "objectives": [
+    {
+      "name": "Denpang",
+      "escort": true,
+      "initiative": 40,
+      "marker": "a",
+      "actions": [
+        {
+          "type": "move",
+          "value": 4
+        }
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "round": "R == 2",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "wind-demon",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "wind-demon",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        }
+      ]
+    },
+    {
+      "round": "R == 4",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "wind-demon",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "wind-demon",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        }
+      ]
+    },
+    {
+      "round": "R == 10",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "wind-demon",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "wind-demon",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        }
+      ]
+    }
   ],
   "rooms": [
     {
@@ -18,6 +107,9 @@
           "name": "render",
           "type": "boss"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/scenarios/058.json
+++ b/data/fh/scenarios/058.json
@@ -25,6 +25,26 @@
     "flamefruit": 1,
     "random_item": 1
   },
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "61.1"
+      ],
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Glowing Orb"
+          },
+          "type": "dead"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -54,6 +74,9 @@
           "name": "steel-automaton",
           "player4": "normal"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/scenarios/059.json
+++ b/data/fh/scenarios/059.json
@@ -7,7 +7,9 @@
     "58"
   ],
   "monsters": [
-    "robotic-boltshooter"
+    "flaming-bladespinner",
+    "robotic-boltshooter",
+    "ruined-machine"
   ],
   "objectives": [
     {
@@ -15,7 +17,13 @@
       "escort": true,
       "health": "(L+C)x2",
       "initiative": 1,
-      "marker": "a"
+      "marker": "a",
+      "actions": [
+        {
+          "type": "move",
+          "value": 3
+        }
+      ]
     }
   ],
   "lootDeckConfig": {
@@ -26,6 +34,243 @@
     "axenut": 1,
     "random_item": 1
   },
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Orphan"
+          },
+          "type": "dead"
+        }
+      ],
+      "finish": "lost"
+    },
+    {
+      "round": "R == 3",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "flaming-bladespinner",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "flaming-bladespinner",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "d"
+        }
+      ]
+    },
+    {
+      "round": "R == 4",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "robotic-boltshooter",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "robotic-boltshooter",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    },
+    {
+      "round": "R == 5",
+      "start": true,
+      "note": "at any starting hex",
+      "spawns": [
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player4": "elite"
+          },
+          "count": "2"
+        },
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player3": "normal"
+          }
+        },
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player3": "elite"
+          }
+        }
+      ]
+    },
+    {
+      "round": "R == 7",
+      "start": true,
+      "note": "at any starting hex",
+      "spawns": [
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player4": "elite"
+          },
+          "count": "2"
+        },
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player3": "normal"
+          }
+        },
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player3": "elite"
+          }
+        }
+      ]
+    },
+    {
+      "round": "R == 9",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "flaming-bladespinner",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "flaming-bladespinner",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "d"
+        }
+      ]
+    },
+    {
+      "round": "R == 10",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "robotic-boltshooter",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "robotic-boltshooter",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    },
+    {
+      "round": "R == 11",
+      "start": true,
+      "note": "at any starting hex",
+      "spawns": [
+        {
+          "monster": {
+            "name": "flaming-bladespinner",
+            "player2": "normal",
+            "player4": "elite"
+          },
+          "count": "2"
+        },
+        {
+          "monster": {
+            "name": "flaming-bladespinner",
+            "player3": "normal"
+          }
+        },
+        {
+          "monster": {
+            "name": "flaming-bladespinner",
+            "player3": "elite"
+          }
+        }
+      ]
+    },
+    {
+      "round": "R > 11",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -43,6 +288,9 @@
           "player3": "elite",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/scenarios/060.json
+++ b/data/fh/scenarios/060.json
@@ -20,6 +20,37 @@
     "snowthistle": 1,
     "random_item": 1
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "amAdd",
+          "value": "minus1:3",
+          "scenarioEffect": true
+        }
+      ]
+    },
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": "(?!.*coral|kelp).*"
+          },
+          "type": "amAdd",
+          "value": "curse:2"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -37,6 +68,8 @@
         },
         {
           "name": "lightning-eel",
+          "player2": "normal",
+          "player3": "elite",
           "player4": "elite"
         },
         {

--- a/data/fh/scenarios/061.json
+++ b/data/fh/scenarios/061.json
@@ -14,9 +14,19 @@
     {
       "name": "Moonshard",
       "escort": true,
-      "health": "(L+Cx2)x2",
+      "health": "(L+(2xC))x2",
       "initiative": 50,
-      "marker": "a"
+      "marker": "a",
+      "actions": [
+        {
+          "type": "move",
+          "value": 3
+        },
+        {
+          "type": "attack",
+          "value": "L+1"
+        }
+      ]
     }
   ],
   "lootDeckConfig": {
@@ -28,6 +38,48 @@
     "corpsecap": 2,
     "random_item": 1
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "amAdd",
+          "value": "minus1:2",
+          "scenarioEffect": true
+        },
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "muddle",
+          "scenarioEffect": true
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Moonshard"
+          },
+          "type": "dead"
+        }
+      ],
+      "finish": "lost"
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -58,6 +110,9 @@
           "name": "harrower-infester",
           "player4": "normal"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/scenarios/062.json
+++ b/data/fh/scenarios/062.json
@@ -16,7 +16,16 @@
       "escort": true,
       "health": "(L+C)x2+2",
       "initiative": 99,
-      "marker": "a"
+      "marker": "a",
+      "actions": [
+        {
+          "type": "move",
+          "value": 3
+        },
+        {
+          "type": "jump"
+        }
+      ]
     }
   ],
   "lootDeckConfig": {
@@ -48,6 +57,9 @@
           "player3": "elite",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/scenarios/063.json
+++ b/data/fh/scenarios/063.json
@@ -13,6 +13,8 @@
     "earth-demon",
     "flame-demon",
     "frost-demon",
+    "savvas-icestorm",
+    "savvas-lavaflow",
     "wind-demon"
   ],
   "objectives": [
@@ -33,6 +35,188 @@
     "corpsecap": 2,
     "random_item": 1
   },
+  "rules": [
+    {
+      "round": "R == 1 || R == 3",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "savvas-icestorm",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "b"
+        }
+      ]
+    },
+    {
+      "round": "R == 2 || R == 4",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "savvas-lavaflow",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        }
+      ]
+    },
+    {
+      "round": "R == 4",
+      "sections": [
+        "7.1"
+      ]
+    },
+    {
+      "round": "R == 5 || R == 7",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "savvas-icestorm",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    },
+    {
+      "round": "R == 6 || R == 8",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "savvas-lavaflow",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "d"
+        }
+      ]
+    },
+    {
+      "round": "R == 9",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "earth-demon",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "flame-demon",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    },
+    {
+      "round": "R == 10",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "wind-demon",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "frost-demon",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    },
+    {
+      "round": "R == 11",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "savvas-lavaflow",
+            "player2": "elite",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "earth-demon",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    },
+    {
+      "round": "R == 12",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "savvas-icestorm",
+            "player2": "elite",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "frost-demon",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    },
+    {
+      "round": "R == 12",
+      "finish": "won"
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Crain"
+          },
+          "type": "dead"
+        }
+      ],
+      "finish": "lost"
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -40,7 +224,10 @@
       "treasures": [
         72
       ],
-      "monster": []
+      "monster": [],
+      "objectives": [
+        1
+      ]
     }
   ]
 }

--- a/data/fh/sections/105-1.json
+++ b/data/fh/sections/105-1.json
@@ -3,9 +3,54 @@
   "name": "Life and Death",
   "edition": "fh",
   "parent": "61",
+  "marker": "1",
   "monsters": [
     "deep-terror",
     "earth-demon"
+  ],
+  "objectives": [
+    {
+      "name": "Moonshard",
+      "escort": true,
+      "health": "(L+(2xC))x2",
+      "initiative": 50,
+      "marker": "a",
+      "actions": [
+        {
+          "type": "move",
+          "value": 3
+        },
+        {
+          "type": "attack",
+          "value": "L+2"
+        }
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "marker": "a",
+            "edition": "escort",
+            "name": "Moonshard"
+          },
+          "type": "transfer",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All characters and character summons gain disadvantage on all their attacks"
+    }
   ],
   "rooms": [
     {

--- a/data/fh/sections/122-5.json
+++ b/data/fh/sections/122-5.json
@@ -1,0 +1,39 @@
+{
+  "index": "122.5",
+  "name": "The Savvas Seal",
+  "edition": "fh",
+  "parent": "63",
+  "parentSections": [
+    "148.1"
+  ],
+  "monsters": [
+    "savvas-icestorm",
+    "savvas-lavaflow"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All monsters gain %game.condition.wound%. Monsters cannot remove %game.condition.wound% with healing"
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All monsters gain disadvantage on all their attacks"
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All monsters add -1 %game.action.attack% to all their attacks"
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All characters and character summons add +1 %game.action.attack% to all their attacks"
+    }
+  ]
+}

--- a/data/fh/sections/13-3.json
+++ b/data/fh/sections/13-3.json
@@ -3,11 +3,45 @@
   "name": "Among the Wreckage",
   "edition": "fh",
   "parent": "54",
+  "parentSections": [
+    "167.1"
+  ],
+  "marker": "2",
+  "objectives": [
+    {
+      "name": "Large Cave Rock 4-A",
+      "health": "[(L+1)xC/2{$math.floor}]",
+      "count": 1
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "50.1"
+      ],
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Large Cave Rock 4-A"
+          },
+          "type": "dead"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 2,
       "initial": true,
-      "monster": []
+      "monster": [],
+      "objectives": [
+        1
+      ]
     }
   ]
 }

--- a/data/fh/sections/133-3.json
+++ b/data/fh/sections/133-3.json
@@ -3,6 +3,7 @@
   "name": "Fleeting Permanence",
   "edition": "fh",
   "parent": "52",
+  "marker": "2",
   "monsters": [
     "snow-imp"
   ],

--- a/data/fh/sections/137-1.json
+++ b/data/fh/sections/137-1.json
@@ -4,6 +4,10 @@
   "name": "Orphan's Halls",
   "edition": "fh",
   "parent": "51",
+  "parentSections": [
+    "32.1"
+  ],
+  "marker": "2",
   "monsters": [
     "ancient-artillery",
     "flaming-bladespinner"
@@ -44,6 +48,9 @@
           "player3": "normal",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/148-1.json
+++ b/data/fh/sections/148-1.json
@@ -1,0 +1,33 @@
+{
+  "index": "148.1",
+  "name": "The Savvas Seal",
+  "edition": "fh",
+  "parent": "63",
+  "parentSections": [
+    "7.1"
+  ],
+  "monsters": [
+    "savvas-icestorm",
+    "savvas-lavaflow"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All monsters gain %game.condition.wound%. Monsters cannot remove %game.condition.wound% with healing"
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All monsters gain disadvantage on all their attacks"
+    },
+    {
+      "round": "R == 10",
+      "sections": [
+        "122.5"
+      ]
+    }
+  ]
+}

--- a/data/fh/sections/167-1.json
+++ b/data/fh/sections/167-1.json
@@ -3,6 +3,20 @@
   "name": "Among the Wreckage",
   "edition": "fh",
   "parent": "54",
+  "marker": "1",
+  "monsters": [],
+  "objectives": [
+    {
+      "name": "Ice Pillar",
+      "health": "[(L+1)xC/2{$math.floor}]",
+      "count": 6
+    },
+    {
+      "name": "Large Cave Rock",
+      "health": "[(L+1)xC/2{$math.floor}]",
+      "count": 3
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 4,
@@ -10,7 +24,18 @@
       "treasures": [
         5
       ],
-      "monster": []
+      "monster": [],
+      "objectives": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2,
+        2,
+        2
+      ]
     }
   ]
 }

--- a/data/fh/sections/29-4.json
+++ b/data/fh/sections/29-4.json
@@ -3,6 +3,7 @@
   "name": "Fleeting Permanence",
   "edition": "fh",
   "parent": "52",
+  "marker": "4",
   "monsters": [
     "frost-demon"
   ],

--- a/data/fh/sections/3-2.json
+++ b/data/fh/sections/3-2.json
@@ -1,0 +1,26 @@
+{
+  "index": "3.2",
+  "name": "Call of the Harbinger",
+  "edition": "fh",
+  "parent": "56",
+  "monsters": [
+    "harbinger-of-shadow"
+  ],
+  "rooms": [
+    {
+      "roomNumber": 4,
+      "ref": "15-B",
+      "initial": true,
+      "treasures": [
+        4
+      ],
+      "monster": [
+        {
+          "name": "harbinger-of-shadow",
+          "type": "boss",
+          "marker": "1"
+        }
+      ]
+    }
+  ]
+}

--- a/data/fh/sections/32-1.json
+++ b/data/fh/sections/32-1.json
@@ -3,10 +3,46 @@
   "name": "Orphan's Halls",
   "edition": "fh",
   "parent": "51",
+  "marker": "1",
   "monsters": [
     "ancient-artillery",
     "ruined-machine",
     "steel-automaton"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "a"
+        },
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "a"
+        },
+        {
+          "monster": {
+            "name": "steel-automaton",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "b"
+        }
+      ]
+    }
   ],
   "rooms": [
     {

--- a/data/fh/sections/36-5.json
+++ b/data/fh/sections/36-5.json
@@ -3,6 +3,7 @@
   "name": "Fleeting Permanence",
   "edition": "fh",
   "parent": "52",
+  "marker": "3",
   "monsters": [
     "frost-demon",
     "snow-imp"

--- a/data/fh/sections/50-1.json
+++ b/data/fh/sections/50-1.json
@@ -3,6 +3,9 @@
   "name": "Among the Wreckage",
   "edition": "fh",
   "parent": "54",
+  "parentSections": [
+    "13.3"
+  ],
   "monsters": [
     "seeker-of-the-abyss"
   ],

--- a/data/fh/sections/61-1.json
+++ b/data/fh/sections/61-1.json
@@ -6,6 +6,23 @@
   "monsters": [
     "ruined-machine"
   ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "orphan"
+          },
+          "type": "damage",
+          "value": "(L+3)xC"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 2,

--- a/data/fh/sections/7-1.json
+++ b/data/fh/sections/7-1.json
@@ -1,0 +1,24 @@
+{
+  "index": "7.1",
+  "name": "The Savvas Seal",
+  "edition": "fh",
+  "parent": "63",
+  "monsters": [
+    "savvas-icestorm",
+    "savvas-lavaflow"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All monsters gain %game.condition.wound%. Monsters cannot remove %game.condition.wound% with healing"
+    },
+    {
+      "round": "R == 8",
+      "sections": [
+        "148.1"
+      ]
+    }
+  ]
+}

--- a/data/fh/sections/70-1.json
+++ b/data/fh/sections/70-1.json
@@ -13,7 +13,7 @@
     {
       "round": "R % 2 == 0",
       "start": true,
-      "note": "%data.section.rules.fh.70-1.1%",
+      "note": "at any empty starting hex",
       "spawns": [
         {
           "monster": {
@@ -21,15 +21,14 @@
             "player2": "normal",
             "player3": "normal",
             "player4": "elite"
-          },
-          "count": 1
+          }
         }
       ]
     },
     {
       "round": "R % 2 == 1",
       "start": true,
-      "note": "%data.section.rules.fh.70-1.1%",
+      "note": "at any empty starting hex",
       "spawns": [
         {
           "monster": {
@@ -37,8 +36,7 @@
             "player2": "normal",
             "player3": "elite",
             "player4": "elite"
-          },
-          "count": 1
+          }
         }
       ]
     }

--- a/data/fh/sections/80-1.json
+++ b/data/fh/sections/80-1.json
@@ -3,6 +3,7 @@
   "name": "Fleeting Permanence",
   "edition": "fh",
   "parent": "52",
+  "marker": "1",
   "monsters": [
     "frost-demon",
     "snow-imp"

--- a/data/fh/sections/80-2.json
+++ b/data/fh/sections/80-2.json
@@ -4,10 +4,53 @@
   "name": "Change of Heart",
   "edition": "fh",
   "parent": "55",
+  "marker": "1",
+  "monsters": [
+    "frozen-fist",
+    "snowdancer"
+  ],
   "objectives": [
     {
       "name": "Large Ice Crystal",
       "health": "(L+2)xCx4"
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "Setup the Frozen Fist if Snowdancer is unlocked or the Snowdancer if Frozen Fist is unlocked"
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "frozen-fist",
+            "type": "boss"
+          },
+          "count": "0",
+          "manual": true
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "snowdancer",
+            "type": "boss"
+          },
+          "count": "0",
+          "manual": true
+        }
+      ]
     }
   ],
   "rooms": [
@@ -17,7 +60,10 @@
       "treasures": [
         41
       ],
-      "monster": []
+      "monster": [],
+      "objectives": [
+        1
+      ]
     }
   ]
 }

--- a/data/fh/sections/82-2.json
+++ b/data/fh/sections/82-2.json
@@ -3,10 +3,64 @@
   "name": "Life and Death",
   "edition": "fh",
   "parent": "61",
+  "parentSections": [
+    "105.1"
+  ],
+  "marker": "2",
   "monsters": [
     "deep-terror",
     "earth-demon",
     "harrower-infester"
+  ],
+  "objectives": [
+    {
+      "name": "Moonshard",
+      "escort": true,
+      "health": "(L+(2xC))x2",
+      "initiative": 50,
+      "marker": "a",
+      "actions": [
+        {
+          "type": "move",
+          "value": 3
+        },
+        {
+          "type": "attack",
+          "value": "L+3"
+        }
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "marker": "a",
+            "edition": "escort",
+            "name": "Moonshard"
+          },
+          "type": "transfer",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All characters and character summons gain disadvantage on all their attacks"
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All monsters add +1 %game.action.attack% to all their attacks targeting characters or character summons"
+    }
   ],
   "rooms": [
     {

--- a/data/fh/sections/90-4.json
+++ b/data/fh/sections/90-4.json
@@ -3,9 +3,39 @@
   "name": "Call of the Harbinger",
   "edition": "fh",
   "parent": "56",
+  "parentSections": [
+    "99.4"
+  ],
+  "marker": "2",
   "monsters": [
     "harrower-infester",
     "shrike-fiend"
+  ],
+  "objectives": [
+    {
+      "name": "Altar 3",
+      "health": "(L+1)xC"
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "69.3"
+      ],
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Altar 3"
+          },
+          "type": "dead"
+        }
+      ]
+    }
   ],
   "rooms": [
     {
@@ -26,7 +56,14 @@
           "player2": "normal",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "shrike-fiend",
+          "player4": "normal"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/97-3.json
+++ b/data/fh/sections/97-3.json
@@ -3,10 +3,70 @@
   "name": "Life and Death",
   "edition": "fh",
   "parent": "61",
+  "parentSections": [
+    "82.2"
+  ],
+  "marker": "3",
   "monsters": [
     "deep-terror",
     "earth-demon",
     "harrower-infester"
+  ],
+  "objectives": [
+    {
+      "name": "Moonshard",
+      "escort": true,
+      "health": "(L+(2xC))x2",
+      "initiative": 50,
+      "marker": "a",
+      "actions": [
+        {
+          "type": "move",
+          "value": 3
+        },
+        {
+          "type": "attack",
+          "value": "L+4"
+        }
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "marker": "a",
+            "edition": "escort",
+            "name": "Moonshard"
+          },
+          "type": "transfer",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All characters and character summons gain disadvantage on all their attacks"
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All characters and character summons add -1 %game.action.attack% to all their attacks and -1 %game.action.move% to all their move abilities"
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All monsters add +1 %game.action.attack% to all their attacks targeting characters or character summons"
+    }
   ],
   "rooms": [
     {
@@ -17,7 +77,7 @@
           "name": "deep-terror",
           "player2": "normal",
           "player3": "elite",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "deep-terror",
@@ -28,7 +88,8 @@
         {
           "name": "deep-terror",
           "player2": "normal",
-          "player3": "elite"
+          "player3": "elite",
+          "player4": "elite"
         },
         {
           "name": "earth-demon",

--- a/data/fh/sections/99-4.json
+++ b/data/fh/sections/99-4.json
@@ -3,9 +3,39 @@
   "name": "Call of the Harbinger",
   "edition": "fh",
   "parent": "56",
+  "parentSections": [
+    "3.2"
+  ],
+  "marker": "1",
   "monsters": [
     "black-imp",
     "shrike-fiend"
+  ],
+  "objectives": [
+    {
+      "name": "Altar 2",
+      "health": "(L+1)xC"
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "66.3"
+      ],
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Altar 2"
+          },
+          "type": "dead"
+        }
+      ]
+    }
   ],
   "rooms": [
     {
@@ -15,11 +45,12 @@
         {
           "name": "black-imp",
           "player2": "normal",
-          "player3": "normal",
+          "player3": "elite",
           "player4": "elite"
         },
         {
           "name": "black-imp",
+          "player3": "normal",
           "player4": "elite"
         },
         {
@@ -31,6 +62,9 @@
           "player3": "normal",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]


### PR DESCRIPTION
Made the following changes:

**Scenario 51**
- Added scenario effects

Section 32.1
- Added section marker
- Added monster spawning rules

Section 137.1
- Added section marker and objective

**Scenario 52**
Section 29.4, 36.5, 80.1, 133.3
- Updated section markers

**Scenario 54**
- Added scenario effects and objectives

Section 13.3
Section 50.1
Section 167.1
- Added section markers and updated section links

**Scenario 55**

Section 80.2
- Added manual boss spawn rules and objective

**Scenario 56**
- Added objective and section links

Section 3.2
- Created file and added boss and treasure 4

Section 90.4
- Added missing shrike fiend for 4 players
- Added objective, section links and marker

Section 99.4
- Added objective, section links and marker
- Updated monster counts

**Scenario 57**
- Added escort objective
- Added monster spawning rules

**Scenario 58**
- Added objective and section link

Section 61.1
- Added special rule for boss

**Scenario 59**
- Updated objective actions and loss condition
- Added per round spawn rules

**Scenario 60**
- Added scenario effects
- Added missing monster counts

**Scenario 61**
- Added objective actions
- Added scenario effects

Section 82.2
Section 97.3
Section 105.1
- Added objective stat transfer
- Added section links and marker
- Added custom special rules notes

**Scenario 62**
- Added objective and actions

**Scenario 63**
- Added objective and per round spawns
- Added section links and win/loss conditions

Section 7.1
Section 122.5
Section 148.1
- Created files and added custom special rules notes and section links
