### PR TITLE
Do not remove Algox's pernament regenenaration

### DIFF
--- a/src/app/game/businesslogic/EntityManager.ts
+++ b/src/app/game/businesslogic/EntityManager.ts
@@ -9,6 +9,7 @@ import { Objective } from "../model/Objective";
 import { Summon, SummonState } from "../model/Summon";
 import { gameManager } from "./GameManager";
 import { settingsManager } from "./SettingsManager";
+import { CharacterClass } from "../model/data/CharacterData";
 
 export class EntityManager {
 
@@ -98,7 +99,10 @@ export class EntityManager {
 
       const regenerate = entity.entityConditions.find((entityCondition) => !entityCondition.expired && entityCondition.state != EntityConditionState.new && entityCondition.name == ConditionName.regenerate);
 
-      if (regenerate && value < 0) {
+
+      const isAlgox = entity instanceof Character && entity.characterClass === CharacterClass.algox;
+
+      if (regenerate && value < 0 && !isAlgox) {
         regenerate.expired = true;
       }
 


### PR DESCRIPTION
Algox has permanent regeneration with his 'One with the Mountain' card. However, whenever he gets damaged the regeneration is removed. 

The card is crucial to the class' mechanics so I suppose that everyone will use it and it makes sense to never automatically remove regeneration from this class.
