### PR TITLE
Fix missing jotl treasures

### DIFF
--- a/data/jotl/scenarios/10.json
+++ b/data/jotl/scenarios/10.json
@@ -103,6 +103,9 @@
       "roomNumber": 3,
       "ref": "jotl10-3",
       "marker": 2,
+      "treasures": [
+        8
+      ],
       "monster": [
         {
           "name": "black-sludge",

--- a/data/jotl/scenarios/5.json
+++ b/data/jotl/scenarios/5.json
@@ -69,6 +69,9 @@
       "rooms": [
         3
       ],
+      "treasures": [
+        9
+      ],
       "monster": [
         {
           "name": "chaos-demon",


### PR DESCRIPTION
I'm currently playing jotl with 4 players and noticed that some treasures are missing.
I added the two that were obvious, but I'm struggling with Scenario 18 there, it is not obvious which room is which.
Also, it looks like the special rules are missing there aswell.