### PR TITLE
Fix Jotl Scenario 4 Rule 2

### DIFF
--- a/data/jotl/scenarios/4.json
+++ b/data/jotl/scenarios/4.json
@@ -101,7 +101,7 @@
         {
           "monster": {
             "name": "zealot",
-            "type": "normal"
+            "type": "elite"
           },
           "marker": "A",
           "count": 2


### PR DESCRIPTION
I noticed that in scenario 4 the zealots of the second rule at the A marker should be elite and not normal, or at least in the German translation, I did not find an English version to verify.