### PR TITLE
Various updates for Scenarios 95 to 116

### DIFF
--- a/data/fh/scenarios/095.json
+++ b/data/fh/scenarios/095.json
@@ -13,6 +13,15 @@
     "corpsecap": 2,
     "snowthistle": 2
   },
+  "rules": [
+    {
+      "round": "R == 8",
+      "start": true,
+      "sections": [
+        "43.1"
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,

--- a/data/fh/scenarios/096.json
+++ b/data/fh/scenarios/096.json
@@ -13,6 +13,12 @@
     "ancient-artillery",
     "rending-drake"
   ],
+  "objectives": [
+    {
+      "name": "Debris",
+      "health": "L+10"
+    }
+  ],
   "lootDeckConfig": {
     "money": 14,
     "lumber": 1,
@@ -37,6 +43,10 @@
           "player3": "normal",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1,
+        1
       ]
     }
   ]

--- a/data/fh/scenarios/098.json
+++ b/data/fh/scenarios/098.json
@@ -15,6 +15,23 @@
     "hide": 3,
     "rockroot": 2
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "damage",
+          "value": "3",
+          "scenarioEffect": true
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -37,11 +54,11 @@
         {
           "name": "black-imp",
           "player3": "normal",
-          "player4": "normal"
+          "player4": "elite"
         },
         {
           "name": "black-imp",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "spitting-drake",

--- a/data/fh/scenarios/099.json
+++ b/data/fh/scenarios/099.json
@@ -43,6 +43,10 @@
           "player4": "elite"
         },
         {
+          "name": "frozen-corpse",
+          "player4": "normal"
+        },
+        {
           "name": "robotic-boltshooter",
           "type": "normal"
         },
@@ -58,6 +62,7 @@
         },
         {
           "name": "robotic-boltshooter",
+          "player3": "elite",
           "player4": "elite"
         },
         {

--- a/data/fh/scenarios/100.json
+++ b/data/fh/scenarios/100.json
@@ -13,6 +13,23 @@
   "lootDeckConfig": {
     "money": 15
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "amAdd",
+          "value": "minus1:2",
+          "scenarioEffect": true
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -32,6 +49,10 @@
           "player2": "normal",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "shrike-fiend",
+          "player4": "normal"
         }
       ]
     }

--- a/data/fh/scenarios/101.json
+++ b/data/fh/scenarios/101.json
@@ -37,11 +37,12 @@
           "name": "algox-guard",
           "player2": "elite",
           "player3": "normal",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "algox-guard",
-          "player3": "normal"
+          "player3": "normal",
+          "player4": "elite"
         }
       ]
     }

--- a/data/fh/scenarios/102.json
+++ b/data/fh/scenarios/102.json
@@ -7,12 +7,33 @@
     "103"
   ],
   "monsters": [
+    "chaos-demon",
     "frost-demon",
+    "living-spirit",
+    "night-demon",
+    "savvas-icestorm",
     "wind-demon"
   ],
   "lootDeckConfig": {
     "money": 15
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "amAdd",
+          "value": "minus1:1",
+          "scenarioEffect": true
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,

--- a/data/fh/scenarios/103.json
+++ b/data/fh/scenarios/103.json
@@ -4,7 +4,10 @@
   "name": "The Lead Door",
   "edition": "fh",
   "monsters": [
-    "living-spirit"
+    "living-doom",
+    "living-spirit",
+    "lurker-clawcrusher",
+    "shrike-fiend"
   ],
   "objectives": [
     {
@@ -17,6 +20,58 @@
     "money": 15,
     "random_item": 1
   },
+  "rules": [
+    {
+      "round": "true",
+      "spawns": [
+        {
+          "monster": {
+            "name": "living-spirit",
+            "type": "normal"
+          },
+          "count": "0",
+          "manual": true,
+          "manualMax": 4
+        },
+        {
+          "monster": {
+            "name": "shrike-fiend",
+            "type": "normal"
+          },
+          "count": "0",
+          "manual": true,
+          "manualMax": 4
+        },
+        {
+          "monster": {
+            "name": "living-doom",
+            "type": "normal"
+          },
+          "count": "0",
+          "manual": true,
+          "manualMax": 4
+        },
+        {
+          "monster": {
+            "name": "living-spirit",
+            "type": "elite"
+          },
+          "count": "0",
+          "manual": true,
+          "manualMax": 4
+        },
+        {
+          "monster": {
+            "name": "lurker-clawcrusher",
+            "type": "normal"
+          },
+          "count": "0",
+          "manual": true,
+          "manualMax": 4
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -34,8 +89,15 @@
         },
         {
           "name": "living-spirit",
+          "player3": "elite",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1,
+        1,
+        1,
+        1
       ]
     }
   ]

--- a/data/fh/scenarios/104.json
+++ b/data/fh/scenarios/104.json
@@ -20,6 +20,23 @@
     "axenut": 1,
     "snowthistle": 1
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "brittle",
+          "scenarioEffect": true
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,

--- a/data/fh/scenarios/105.json
+++ b/data/fh/scenarios/105.json
@@ -20,6 +20,59 @@
     "corpsecap": 1,
     "flamefruit": 1
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "wound",
+          "scenarioEffect": true
+        }
+      ],
+      "elements": [
+        {
+          "type": "air",
+          "state": "strong"
+        }
+      ]
+    },
+    {
+      "round": "R % 3 == 1",
+      "note": "All characters and character summons in row %game.element.air%, in right-to-left order, move one hex to the right. Move the %game.element.air% token to %game.mapMarker.b%",
+      "elements": [
+        {
+          "type": "air",
+          "state": "strong"
+        }
+      ]
+    },
+    {
+      "round": "R % 3 == 2",
+      "note": "All characters and character summons in row %game.element.air%, in right-to-left order, move one hex to the right. Move the %game.element.air% token to %game.mapMarker.c%",
+      "elements": [
+        {
+          "type": "air",
+          "state": "strong"
+        }
+      ]
+    },
+    {
+      "round": "R % 3 == 0",
+      "note": "All characters and character summons in row %game.element.air%, in right-to-left order, move one hex to the right. Move the %game.element.air% token to %game.mapMarker.a%",
+      "elements": [
+        {
+          "type": "air",
+          "state": "strong"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,

--- a/data/fh/scenarios/110.json
+++ b/data/fh/scenarios/110.json
@@ -9,6 +9,18 @@
     "ruined-machine",
     "shrike-fiend"
   ],
+  "objectives": [
+    {
+      "name": "Ice Pillar",
+      "count": 6,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "Can only be destoyed when a Ruined Machine dies in an adjacent hex"
+        }
+      ]
+    }
+  ],
   "lootDeckConfig": {
     "money": 6,
     "lumber": 2,
@@ -17,6 +29,87 @@
     "rockroot": 1,
     "corpsecap": 1
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "amAdd",
+          "value": "curse:2",
+          "scenarioEffect": true
+        }
+      ]
+    },
+    {
+      "round": "R % 3 == 1",
+      "start": true,
+      "note": "Ice Pillars %game.mapMarker.a% active"
+    },
+    {
+      "round": "R % 3 == 2",
+      "start": true,
+      "note": "Ice Pillars %game.mapMarker.b% active"
+    },
+    {
+      "round": "R % 3 == 0",
+      "start": true,
+      "note": "Ice Pillars %game.mapMarker.c% active"
+    },
+    {
+      "round": "R % 2 == 0",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "d"
+        }
+      ]
+    },
+    {
+      "round": "R > 1 && R % 2 == 1",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "d"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "186.3"
+      ],
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Ice Pillar"
+          },
+          "type": "dead",
+          "value": "2"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -49,6 +142,14 @@
           "name": "shrike-fiend",
           "player4": "normal"
         }
+      ],
+      "objectives": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
       ]
     }
   ]

--- a/data/fh/scenarios/111.json
+++ b/data/fh/scenarios/111.json
@@ -16,6 +16,23 @@
     "corpse": 1,
     "arrowvine": 2
   },
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "muddle",
+          "scenarioEffect": true
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,

--- a/data/fh/scenarios/112.json
+++ b/data/fh/scenarios/112.json
@@ -9,6 +9,9 @@
     "earth-demon",
     "hound-scenario-112"
   ],
+  "allies": [
+    "hound-scenario-112"
+  ],
   "lootDeckConfig": {
     "money": 8,
     "lumber": 1,

--- a/data/fh/scenarios/113.json
+++ b/data/fh/scenarios/113.json
@@ -36,10 +36,6 @@
         },
         {
           "name": "forest-imp",
-          "type": "normal"
-        },
-        {
-          "name": "forest-imp",
           "player2": "normal",
           "player3": "normal",
           "player4": "elite"
@@ -52,7 +48,14 @@
         },
         {
           "name": "forest-imp",
+          "player2": "normal",
+          "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "forest-imp",
+          "player3": "normal",
+          "player4": "normal"
         }
       ]
     }

--- a/data/fh/scenarios/114.json
+++ b/data/fh/scenarios/114.json
@@ -15,6 +15,9 @@
       "name": "Ice Pillar",
       "health": "(2xL)+2",
       "marker": "b",
+      "tags": [
+        "ice-pillar-b"
+      ],
       "actions": [
         {
           "type": "shield",
@@ -81,6 +84,27 @@
           "marker": "c"
         }
       ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "159.1"
+      ],
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Ice Pillar",
+            "tags": [
+              "ice-pillar-b"
+            ]
+          },
+          "type": "dead"
+        }
+      ]
     }
   ],
   "rooms": [
@@ -98,10 +122,6 @@
         {
           "name": "hound",
           "player3": "normal",
-          "player4": "normal"
-        },
-        {
-          "name": "hound",
           "player4": "normal"
         },
         {

--- a/data/fh/scenarios/115.json
+++ b/data/fh/scenarios/115.json
@@ -112,6 +112,10 @@
           "count": "2"
         }
       ]
+    },
+    {
+      "round": "R == 10",
+      "finish": "won"
     }
   ],
   "rooms": [

--- a/data/fh/scenarios/116.json
+++ b/data/fh/scenarios/116.json
@@ -6,16 +6,28 @@
   "monsters": [
     "algox-archer",
     "algox-guard",
+    "algox-icespeaker",
     "algox-scout"
   ],
   "objectives": [
     {
       "name": "Caravan Wagon",
-      "escort": true,
       "health": "Cx2+L",
+      "escort": true,
       "initiative": 50,
-      "marker": "a",
-      "count": 5
+      "tags": [
+        "caravan-wagon"
+      ],
+      "actions": [
+        {
+          "type": "move",
+          "value": "3"
+        },
+        {
+          "type": "custom",
+          "value": "Focus on moving towards %game.mapMarker.b%"
+        }
+      ]
     }
   ],
   "lootDeckConfig": {
@@ -27,6 +39,119 @@
     "arrowvine": 1,
     "axenut": 1
   },
+  "rules": [
+    {
+      "round": "R > 1 && R < 6",
+      "start": true,
+      "objectiveSpawns": [
+        {
+          "objective": {
+            "index": 1,
+            "name": "Caravan Wagon",
+            "tags": [
+              "caravan-wagon"
+            ],
+            "escort": true
+          },
+          "marker": "a"
+        }
+      ]
+    },
+    {
+      "round": "R == 3",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "algox-icespeaker",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "algox-icespeaker",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "algox-archer",
+            "player3": "elite",
+            "player4": "normal"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "algox-archer",
+            "player3": "elite",
+            "player4": "normal"
+          },
+          "marker": "d"
+        }
+      ]
+    },
+    {
+      "round": "R == 6",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "algox-archer",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "algox-archer",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "algox-icespeaker",
+            "type": "normal"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "algox-icespeaker",
+            "type": "normal"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "algox-guard",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "algox-guard",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          "marker": "d"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -53,6 +178,9 @@
           "player3": "elite",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/102-1.json
+++ b/data/fh/sections/102-1.json
@@ -3,6 +3,10 @@
   "name": "Inside the Swarm",
   "edition": "fh",
   "parent": "100",
+  "parentSections": [
+    "141.3"
+  ],
+  "marker": "2",
   "monsters": [
     "burrowing-blade",
     "earth-demon",
@@ -53,6 +57,10 @@
           "player2": "normal",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "lurker-mindsnipper",
+          "player4": "normal"
         },
         {
           "name": "shrike-fiend",

--- a/data/fh/sections/103-1.json
+++ b/data/fh/sections/103-1.json
@@ -3,6 +3,10 @@
   "name": "My Private Empire",
   "edition": "fh",
   "parent": "107",
+  "parentSections": [
+    "188.1"
+  ],
+  "marker": "c",
   "monsters": [
     "steel-automaton"
   ],

--- a/data/fh/sections/11-7.json
+++ b/data/fh/sections/11-7.json
@@ -4,6 +4,7 @@
   "name": "The Lead Door",
   "edition": "fh",
   "parent": "103",
+  "marker": "2",
   "monsters": [
     "living-spirit"
   ],
@@ -23,6 +24,9 @@
           "player3": "normal",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/116-1.json
+++ b/data/fh/sections/116-1.json
@@ -3,6 +3,10 @@
   "name": "My Private Empire",
   "edition": "fh",
   "parent": "107",
+  "parentSections": [
+    "149.4"
+  ],
+  "marker": "d",
   "monsters": [
     "living-bones",
     "living-doom"

--- a/data/fh/sections/116-2.json
+++ b/data/fh/sections/116-2.json
@@ -3,6 +3,10 @@
   "name": "Underground Station",
   "edition": "fh",
   "parent": "96",
+  "parentSections": [
+    "18.1"
+  ],
+  "marker": "2",
   "monsters": [
     "ancient-artillery",
     "black-imp",
@@ -20,21 +24,23 @@
           "name": "ancient-artillery",
           "player2": "normal",
           "player3": "elite",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "ancient-artillery",
           "player2": "normal",
-          "player3": "elite"
-        },
-        {
-          "name": "black-imp",
-          "player2": "normal",
-          "player3": "normal",
+          "player3": "elite",
           "player4": "elite"
         },
         {
           "name": "black-imp",
+          "player2": "normal",
+          "player3": "elite",
+          "player4": "elite"
+        },
+        {
+          "name": "black-imp",
+          "player3": "normal",
           "player4": "elite"
         },
         {
@@ -48,6 +54,12 @@
           "player3": "normal",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1,
+        1,
+        1,
+        1
       ]
     }
   ]

--- a/data/fh/sections/126-2.json
+++ b/data/fh/sections/126-2.json
@@ -3,6 +3,7 @@
   "name": "Harrower Library",
   "edition": "fh",
   "parent": "101",
+  "marker": "1",
   "monsters": [
     "algox-archer",
     "algox-guard",
@@ -38,6 +39,10 @@
           "player2": "normal",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "algox-guard",
+          "player4": "normal"
         },
         {
           "name": "algox-priest",

--- a/data/fh/sections/127-3.json
+++ b/data/fh/sections/127-3.json
@@ -3,6 +3,7 @@
   "name": "Prison Break",
   "edition": "fh",
   "parent": "99",
+  "marker": "1",
   "monsters": [
     "frozen-corpse",
     "robotic-boltshooter",

--- a/data/fh/sections/131-3.json
+++ b/data/fh/sections/131-3.json
@@ -3,6 +3,10 @@
   "name": "Collapsing Vent",
   "edition": "fh",
   "parent": "98",
+  "parentSections": [
+    "145.3"
+  ],
+  "marker": "3",
   "rooms": [
     {
       "roomNumber": 2,

--- a/data/fh/sections/138-2.json
+++ b/data/fh/sections/138-2.json
@@ -3,6 +3,10 @@
   "name": "Ice Cave",
   "edition": "fh",
   "parent": "111",
+  "parentSections": [
+    "182.2"
+  ],
+  "marker": "2",
   "monsters": [
     "frost-demon",
     "hound"
@@ -41,6 +45,10 @@
           "name": "hound",
           "player3": "normal",
           "player4": "elite"
+        },
+        {
+          "name": "hound",
+          "player4": "normal"
         }
       ]
     }

--- a/data/fh/sections/14-2.json
+++ b/data/fh/sections/14-2.json
@@ -3,6 +3,10 @@
   "name": "Ruins of the Solstice",
   "edition": "fh",
   "parent": "104",
+  "parentSections": [
+    "164.3"
+  ],
+  "marker": "2",
   "monsters": [
     "earth-demon",
     "forest-imp",

--- a/data/fh/sections/140-1.json
+++ b/data/fh/sections/140-1.json
@@ -3,6 +3,7 @@
   "name": "Lustrous Pit",
   "edition": "fh",
   "parent": "108",
+  "marker": "1",
   "monsters": [
     "ice-wraith",
     "snow-imp"

--- a/data/fh/sections/141-3.json
+++ b/data/fh/sections/141-3.json
@@ -3,6 +3,7 @@
   "name": "Inside the Swarm",
   "edition": "fh",
   "parent": "100",
+  "marker": "1",
   "monsters": [
     "burrowing-blade",
     "lurker-mindsnipper"

--- a/data/fh/sections/145-3.json
+++ b/data/fh/sections/145-3.json
@@ -3,6 +3,10 @@
   "name": "Collapsing Vent",
   "edition": "fh",
   "parent": "98",
+  "parentSections": [
+    "160.1"
+  ],
+  "marker": "2",
   "monsters": [
     "ancient-artillery",
     "burrowing-blade",

--- a/data/fh/sections/146-5.json
+++ b/data/fh/sections/146-5.json
@@ -3,6 +3,10 @@
   "name": "Lush Grotto",
   "edition": "fh",
   "parent": "113",
+  "parentSections": [
+    "112.1",
+    "183.2"
+  ],
   "monsters": [
     "forest-imp",
     "polar-bear"

--- a/data/fh/sections/149-3.json
+++ b/data/fh/sections/149-3.json
@@ -3,6 +3,10 @@
   "name": "To Bury the Dead",
   "edition": "fh",
   "parent": "95",
+  "parentSections": [
+    "84.1"
+  ],
+  "marker": "2",
   "monsters": [
     "ice-wraith",
     "living-bones",

--- a/data/fh/sections/149-4.json
+++ b/data/fh/sections/149-4.json
@@ -3,6 +3,10 @@
   "name": "My Private Empire",
   "edition": "fh",
   "parent": "107",
+  "parentSections": [
+    "155.1"
+  ],
+  "marker": "3",
   "rooms": [
     {
       "roomNumber": 5,

--- a/data/fh/sections/150-3.json
+++ b/data/fh/sections/150-3.json
@@ -3,6 +3,10 @@
   "name": "My Private Empire",
   "edition": "fh",
   "parent": "107",
+  "parentSections": [
+    "168.4"
+  ],
+  "marker": "1",
   "rooms": [
     {
       "roomNumber": 6,

--- a/data/fh/sections/155-1.json
+++ b/data/fh/sections/155-1.json
@@ -3,6 +3,10 @@
   "name": "My Private Empire",
   "edition": "fh",
   "parent": "107",
+  "parentSections": [
+    "103.1"
+  ],
+  "marker": "c",
   "monsters": [
     "flaming-bladespinner",
     "robotic-boltshooter"

--- a/data/fh/sections/156-2.json
+++ b/data/fh/sections/156-2.json
@@ -3,6 +3,10 @@
   "name": "Raised by Wolves",
   "edition": "fh",
   "parent": "112",
+  "parentSections": [
+    "97.1"
+  ],
+  "marker": "2",
   "monsters": [
     "burrowing-blade",
     "chaos-demon"

--- a/data/fh/sections/159-1.json
+++ b/data/fh/sections/159-1.json
@@ -4,6 +4,7 @@
   "edition": "fh",
   "parent": "114",
   "marker": "b",
+  "resetRound": "hidden",
   "monsters": [
     "hound",
     "polar-bear",
@@ -42,14 +43,6 @@
           },
           "marker": "f"
         }
-      ],
-      "disableRules": [
-        {
-          "edition": "fh",
-          "scenario": "114",
-          "index": 0,
-          "section": true
-        }
       ]
     },
     {
@@ -71,13 +64,23 @@
           },
           "marker": "e"
         }
-      ],
+      ]
+    },
+    {
+      "round": "true",
+      "always": true,
       "disableRules": [
         {
           "edition": "fh",
           "scenario": "114",
+          "index": 0,
+          "section": false
+        },
+        {
+          "edition": "fh",
+          "scenario": "114",
           "index": 1,
-          "section": true
+          "section": false
         }
       ]
     }

--- a/data/fh/sections/160-1.json
+++ b/data/fh/sections/160-1.json
@@ -3,6 +3,7 @@
   "name": "Collapsing Vent",
   "edition": "fh",
   "parent": "98",
+  "marker": "1",
   "monsters": [
     "ancient-artillery",
     "black-imp",

--- a/data/fh/sections/162-1.json
+++ b/data/fh/sections/162-1.json
@@ -3,10 +3,18 @@
   "name": "Furious Factory",
   "edition": "fh",
   "parent": "109",
+  "marker": "3",
   "monsters": [
     "ancient-artillery",
     "flaming-bladespinner",
     "ruined-machine"
+  ],
+  "objectives": [
+    {
+      "name": "Metal Cabinet",
+      "health": "(2+L)xC/2",
+      "marker": "b"
+    }
   ],
   "rooms": [
     {
@@ -32,6 +40,9 @@
           "name": "ruined-machine",
           "player2": "normal"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/164-3.json
+++ b/data/fh/sections/164-3.json
@@ -3,6 +3,7 @@
   "name": "Ruins of the Solstice",
   "edition": "fh",
   "parent": "104",
+  "marker": "1",
   "monsters": [
     "earth-demon",
     "forest-imp",

--- a/data/fh/sections/165-5.json
+++ b/data/fh/sections/165-5.json
@@ -3,6 +3,10 @@
   "name": "Lustrous Pit",
   "edition": "fh",
   "parent": "108",
+  "parentSections": [
+    "140.1"
+  ],
+  "marker": "2",
   "monsters": [
     "ice-wraith"
   ],

--- a/data/fh/sections/166-3.json
+++ b/data/fh/sections/166-3.json
@@ -3,9 +3,17 @@
   "name": "Furious Factory",
   "edition": "fh",
   "parent": "109",
+  "marker": "1",
   "monsters": [
     "ancient-artillery",
     "ruined-machine"
+  ],
+  "objectives": [
+    {
+      "name": "Metal Cabinet",
+      "health": "(2+L)xC/2",
+      "marker": "b"
+    }
   ],
   "rooms": [
     {
@@ -35,6 +43,9 @@
           "player3": "elite",
           "player4": "normal"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/167-4.json
+++ b/data/fh/sections/167-4.json
@@ -3,6 +3,10 @@
   "name": "Underground Station",
   "edition": "fh",
   "parent": "96",
+  "parentSections": [
+    "116.2"
+  ],
+  "marker": "3",
   "monsters": [
     "ancient-artillery",
     "black-imp",

--- a/data/fh/sections/168-4.json
+++ b/data/fh/sections/168-4.json
@@ -3,6 +3,7 @@
   "name": "My Private Empire",
   "edition": "fh",
   "parent": "107",
+  "marker": "a",
   "monsters": [
     "living-bones"
   ],

--- a/data/fh/sections/171-3.json
+++ b/data/fh/sections/171-3.json
@@ -3,6 +3,10 @@
   "name": "Harrower Library",
   "edition": "fh",
   "parent": "101",
+  "parentSections": [
+    "126.2"
+  ],
+  "marker": "3",
   "monsters": [
     "algox-archer",
     "algox-priest"

--- a/data/fh/sections/172-5.json
+++ b/data/fh/sections/172-5.json
@@ -3,9 +3,17 @@
   "name": "Furious Factory",
   "edition": "fh",
   "parent": "109",
+  "marker": "4",
   "monsters": [
     "ancient-artillery",
     "flaming-bladespinner"
+  ],
+  "objectives": [
+    {
+      "name": "Metal Cabinet",
+      "health": "(2+L)xC/2",
+      "marker": "b"
+    }
   ],
   "rooms": [
     {
@@ -24,6 +32,9 @@
           "name": "flaming-bladespinner",
           "player4": "normal"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/18-1.json
+++ b/data/fh/sections/18-1.json
@@ -3,6 +3,7 @@
   "name": "Underground Station",
   "edition": "fh",
   "parent": "96",
+  "marker": "1",
   "monsters": [
     "ancient-artillery",
     "black-imp",
@@ -71,7 +72,16 @@
           "name": "rending-drake",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "rending-drake",
+          "player4": "normal"
         }
+      ],
+      "objectives": [
+        1,
+        1,
+        1
       ]
     }
   ]

--- a/data/fh/sections/182-2.json
+++ b/data/fh/sections/182-2.json
@@ -4,6 +4,7 @@
   "name": "Ice Cave",
   "edition": "fh",
   "parent": "111",
+  "marker": "1",
   "monsters": [
     "frost-demon",
     "night-demon",

--- a/data/fh/sections/183-1.json
+++ b/data/fh/sections/183-1.json
@@ -3,8 +3,31 @@
   "name": "The Tempus Forge",
   "edition": "fh",
   "parent": "106",
+  "marker": "4",
   "monsters": [
     "wind-demon"
+  ],
+  "objectives": [
+    {
+      "name": "Altar 4",
+      "health": "[(L+2)xC/2{$math.floor}]"
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "note": "The Altar performs %game.action.push% 1, %game.action.target% all characters, %game.action.range% 5",
+      "figures": [
+        {
+          "type": "present",
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Altar 4"
+          }
+        }
+      ]
+    }
   ],
   "rooms": [
     {
@@ -23,6 +46,9 @@
           "player3": "elite",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/183-2.json
+++ b/data/fh/sections/183-2.json
@@ -3,6 +3,10 @@
   "name": "Lush Grotto",
   "edition": "fh",
   "parent": "113",
+  "parentSections": [
+    "146.5",
+    "154.1"
+  ],
   "monsters": [
     "chaos-demon",
     "polar-bear"

--- a/data/fh/sections/184-4.json
+++ b/data/fh/sections/184-4.json
@@ -3,8 +3,31 @@
   "name": "The Tempus Forge",
   "edition": "fh",
   "parent": "106",
+  "marker": "2",
   "monsters": [
     "earth-demon"
+  ],
+  "objectives": [
+    {
+      "name": "Altar 2",
+      "health": "[(L+2)xC/2{$math.floor}]"
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "note": "All monsters perform %game.action.heal% 2 self",
+      "figures": [
+        {
+          "type": "present",
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Altar 2"
+          }
+        }
+      ]
+    }
   ],
   "rooms": [
     {
@@ -23,6 +46,9 @@
           "player3": "elite",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/186-2.json
+++ b/data/fh/sections/186-2.json
@@ -3,9 +3,17 @@
   "name": "Furious Factory",
   "edition": "fh",
   "parent": "109",
+  "marker": "2",
   "monsters": [
     "ancient-artillery",
     "ruined-machine"
+  ],
+  "objectives": [
+    {
+      "name": "Metal Cabinet",
+      "health": "(2+L)xC/2",
+      "marker": "b"
+    }
   ],
   "rooms": [
     {
@@ -38,6 +46,9 @@
           "player3": "elite",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/186-3.json
+++ b/data/fh/sections/186-3.json
@@ -4,7 +4,39 @@
   "edition": "fh",
   "parent": "110",
   "monsters": [
+    "living-doom",
     "living-spirit"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "disableRules": [
+        {
+          "edition": "fh",
+          "scenario": "110",
+          "index": 1,
+          "section": false
+        },
+        {
+          "edition": "fh",
+          "scenario": "110",
+          "index": 2,
+          "section": false
+        },
+        {
+          "edition": "fh",
+          "scenario": "110",
+          "index": 3,
+          "section": false
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "note": "Remaining Ice Pillars active"
+    }
   ],
   "rooms": [
     {
@@ -15,7 +47,7 @@
       ],
       "monster": [
         {
-          "name": "living-spirit",
+          "name": "living-doom",
           "player2": "normal",
           "player3": "normal",
           "player4": "elite"

--- a/data/fh/sections/188-1.json
+++ b/data/fh/sections/188-1.json
@@ -3,6 +3,10 @@
   "name": "My Private Empire",
   "edition": "fh",
   "parent": "107",
+  "parentSections": [
+    "95.2"
+  ],
+  "marker": "2",
   "rooms": [
     {
       "roomNumber": 9,

--- a/data/fh/sections/189-2.json
+++ b/data/fh/sections/189-2.json
@@ -3,8 +3,38 @@
   "name": "The Tempus Forge",
   "edition": "fh",
   "parent": "106",
+  "marker": "3",
   "monsters": [
     "frost-demon"
+  ],
+  "objectives": [
+    {
+      "name": "Altar 3",
+      "health": "[(L+2)xC/2{$math.floor}]"
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "figures": [
+        {
+          "type": "present",
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Altar 3"
+          }
+        },
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "muddle"
+        }
+      ]
+    }
   ],
   "rooms": [
     {
@@ -23,6 +53,9 @@
           "player3": "elite",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/191-3.json
+++ b/data/fh/sections/191-3.json
@@ -3,9 +3,56 @@
   "name": "Ruins of the Equinox",
   "edition": "fh",
   "parent": "105",
+  "marker": "1",
   "monsters": [
     "flame-demon",
     "rending-drake"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "disableRules": [
+        {
+          "edition": "fh",
+          "scenario": "105",
+          "index": 1,
+          "section": false
+        },
+        {
+          "edition": "fh",
+          "scenario": "105",
+          "index": 2,
+          "section": false
+        },
+        {
+          "edition": "fh",
+          "scenario": "105",
+          "index": 3,
+          "section": false
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "damage",
+          "value": "1"
+        }
+      ],
+      "elements": [
+        {
+          "type": "fire",
+          "state": "strong"
+        }
+      ]
+    }
   ],
   "rooms": [
     {

--- a/data/fh/sections/192-4.json
+++ b/data/fh/sections/192-4.json
@@ -3,6 +3,10 @@
   "name": "Lustrous Pit",
   "edition": "fh",
   "parent": "108",
+  "parentSections": [
+    "140.1"
+  ],
+  "marker": "3",
   "monsters": [
     "ice-wraith"
   ],

--- a/data/fh/sections/194-4.json
+++ b/data/fh/sections/194-4.json
@@ -3,6 +3,10 @@
   "name": "Harrower Library",
   "edition": "fh",
   "parent": "101",
+  "parentSections": [
+    "126.2"
+  ],
+  "marker": "2",
   "monsters": [
     "algox-archer",
     "algox-guard",
@@ -17,6 +21,10 @@
           "name": "algox-archer",
           "player2": "normal",
           "player3": "elite",
+          "player4": "normal"
+        },
+        {
+          "name": "algox-archer",
           "player4": "elite"
         },
         {

--- a/data/fh/sections/29-2.json
+++ b/data/fh/sections/29-2.json
@@ -4,8 +4,33 @@
   "name": "Crystal Trench",
   "edition": "fh",
   "parent": "106",
+  "marker": "5",
   "monsters": [
     "blacksmith"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "note": "The Blacksmith performs %game.action.heal% 2 self; %game.action.push% 1, %game.action.target% all characters, %game.action.range% 5, %game.condition.muddle%",
+      "figures": [
+        {
+          "type": "present",
+          "identifier": {
+            "type": "monster",
+            "edition": "fh",
+            "name": "blacksmith"
+          }
+        },
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "damage",
+          "value": "1"
+        }
+      ]
+    }
   ],
   "rooms": [
     {

--- a/data/fh/sections/30-4.json
+++ b/data/fh/sections/30-4.json
@@ -4,6 +4,7 @@
   "name": "The Lead Door",
   "edition": "fh",
   "parent": "103",
+  "marker": "1",
   "monsters": [
     "living-spirit"
   ],
@@ -23,6 +24,9 @@
           "player3": "normal",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/8-1.json
+++ b/data/fh/sections/8-1.json
@@ -4,13 +4,37 @@
   "name": "The Tempus Forge",
   "edition": "fh",
   "parent": "106",
+  "marker": "1",
   "monsters": [
     "flame-demon"
   ],
   "objectives": [
     {
-      "name": "Altar",
-      "health": "(L+2)xC/2"
+      "name": "Altar 1",
+      "health": "[(L+2)xC/2{$math.floor}]"
+    }
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "figures": [
+        {
+          "type": "present",
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Altar 1"
+          }
+        },
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "damage",
+          "value": "1"
+        }
+      ]
     }
   ],
   "rooms": [
@@ -30,6 +54,9 @@
           "player3": "elite",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        1
       ]
     }
   ]

--- a/data/fh/sections/84-1.json
+++ b/data/fh/sections/84-1.json
@@ -4,6 +4,7 @@
   "name": "To Bury the Dead",
   "edition": "fh",
   "parent": "95",
+  "marker": "1",
   "monsters": [
     "ice-wraith",
     "living-bones",

--- a/data/fh/sections/95-2.json
+++ b/data/fh/sections/95-2.json
@@ -3,6 +3,10 @@
   "name": "My Private Empire",
   "edition": "fh",
   "parent": "107",
+  "parentSections": [
+    "150.3"
+  ],
+  "marker": "b",
   "monsters": [
     "ruined-machine"
   ],

--- a/data/fh/sections/97-1.json
+++ b/data/fh/sections/97-1.json
@@ -3,6 +3,7 @@
   "name": "Raised by Wolves",
   "edition": "fh",
   "parent": "112",
+  "marker": "1",
   "monsters": [
     "chaos-demon",
     "earth-demon"


### PR DESCRIPTION
Almost there. Made the following updates:

**Scenario 95**
Sections 84.1, 149.3
- Updated section links and markers

**Scenario 96**
Sections 18.1 116.2, 167.4
- Updated section markers
- Added objectives
- Added missing imp for 3 players
- Added missing drake and artillery for 4 players

**Scenario 98**
Sections 131.5, 145.3, 160.1
- Added missing scenario effects
- Added section markers

**Scenario 99**
Sections 127.3
- Added missing frozen corpse for 4 players
- Added missing boltshooter for 3 players
- Added section markers

**Scenario 100**
Sections 102.1, 141.3
- Added missing scenario effects
- Added missing shrike fiend for 4 players
- Added missing mindsnipper for 4 players
- Added section markers

**Scenario 101**
Sections 126.2, 171.3, 194.4
- Added missing guards for 4 players
- Updated section links and markers

**Scenario 102**
- Added missing scenario effects

**Scenario 103**
- Added section markers and objectives
- Added special spawn rules

**Scenario 104**
- Added missing scenario effects
- Added section links and markers

**Scenario 105**
Section 191.3
- Added missing scenario effects
- Added elements and special rules
- Added section markers

**Scenario 106**
Sections 8.1, 29.2, 183.1, 184.4, 189.2
- Added objectives and special conditional rules
- Added section markers

**Scenario 107**
Sections 95.2, 103.1, 116.1, 149.4, 150.3, 155.1, 168.4, 188.1
- Added section links and markers

**Scenario 108**
Sections 140.1, 165.5, 192.4
- Added section links and markers

**Scenario 109**
Sections 162.1, 166.3, 172.5, 186.2
- Added section markers and objectives

**Scenario 110**
Section 186.3
- Added spawn rules and objectives
- Added missing living doom
- Added scenario effect

**Scenario 111**
Sections 138.2, 182.2
- Added scenario effect
- Added missing hound
- Added section links and markers

**Scenario 112**
Sections 97.1, 156.2
- Added allies
- Added section links and markers

**Scenario 113**
Sections 146.5, 183.2
- Added missing imp for 3 players
- Added section links

**Scenario 114**
Section 159.1
- Removed extra hound for 4 players
- Added section link on objective
- Fixed disable rule function

**Scenario 115**
- Added win condition 

**Scenario 116**
- Added monster spawning rules
- Added objective spawning and actions


