### PR TITLE
Updates to boss specials for Scenario 68

### DIFF
--- a/data/fh/monster/tormentor.json
+++ b/data/fh/monster/tormentor.json
@@ -18,14 +18,135 @@
     "special": [
       [
         {
+          "type": "move",
+          "value": 0,
+          "valueType": "plus"
+        },
+        {
+          "type": "attack",
+          "value": "C-4",
+          "valueType": "plus",
+          "subActions": [
+            {
+              "type": "range",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "earth",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "condition",
+                  "value": "immobilize",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        },
+        {
           "type": "custom",
-          "value": "See scenario Special Rules"
+          "value": "Create 1-hex hazardous terrain in all featureless hexes adjacent to target, enemies in these hexes suffer",
+          "small": true,
+          "subActions": [
+            {
+              "type": "damage",
+              "value": "C-1",
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "fire",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "damage",
+                  "value": 1,
+                  "valueType": "add"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "value": "light"
         }
       ],
       [
         {
+          "type": "move",
+          "value": 1,
+          "valueType": "minus"
+        },
+        {
+          "type": "attack",
+          "value": "C-5",
+          "valueType": "plus",
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "curse",
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "air",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "target",
+                  "value": 1,
+                  "valueType": "add",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        },
+        {
           "type": "custom",
-          "value": "See scenario Special Rules"
+          "value": "Create 1-hex icy terrain in all featureless hexes adjacent to targets of the attack",
+          "small": true
+        },
+        {
+          "type": "push",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "target",
+              "value": "%game.target.all%",
+              "small": true
+            },
+            {
+              "type": "range",
+              "value": 1,
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "push",
+                  "value": 2,
+                  "valueType": "add",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "value": "dark"
         }
       ]
     ]

--- a/data/fh/scenarios/067.json
+++ b/data/fh/scenarios/067.json
@@ -10,7 +10,13 @@
     "68"
   ],
   "monsters": [
-    "chaos-demon"
+    "chaos-demon",
+    "earth-demon",
+    "flame-demon",
+    "frost-demon",
+    "night-demon",
+    "sun-demon",
+    "wind-demon"
   ],
   "objectives": [
     {
@@ -56,6 +62,9 @@
           "name": "chaos-demon",
           "player4": "elite"
         }
+      ],
+      "objectives": [
+        "1:4"
       ]
     }
   ]

--- a/data/fh/scenarios/068.json
+++ b/data/fh/scenarios/068.json
@@ -5,7 +5,13 @@
   "edition": "fh",
   "monsters": [
     "chaos-demon",
-    "tormentor"
+    "earth-demon",
+    "flame-demon",
+    "frost-demon",
+    "night-demon",
+    "sun-demon",
+    "tormentor",
+    "wind-demon"
   ],
   "lootDeckConfig": {
     "lumber": 5,


### PR DESCRIPTION
I had a go at adding the missing boss specials for Scenario 68.

This probably needs to be reviewed - I _think_ the formatting and code is right, but there are some issues. Feel free to decline this if it's simply wrong.

- The calculated attack is incorrect when using +C-4 or +C-5 (showing -2 for 2 players at Lv 1 when it should be 4 + C - 4 = 2)
- The 'damage' type colouring is black
- Not sure how to get the "suffer" text and damage value on the same line in Special 1
- The `"small": "true"` style seems inconsistent (see elements consumed and adding targets/push for special 2) - actually this might be ok

Images below showing rule book vs app
Special 1
![image](https://user-images.githubusercontent.com/124784924/232307209-13201b1d-1404-47c1-92ff-2d4f46777e18.png)
![image](https://user-images.githubusercontent.com/124784924/232307204-c28f5f25-d3a3-40a5-a7a8-aa143b74cf45.png)
![image](https://user-images.githubusercontent.com/124784924/232307207-7a08ec1a-f3f5-4a36-a57b-2d07d7bce45c.png)

Special 2
![image](https://user-images.githubusercontent.com/124784924/232307314-51dbc4da-4cd4-415b-b4cb-b79eba66b3fe.png)
![image](https://user-images.githubusercontent.com/124784924/232307316-9ded570e-de07-4e01-bacf-ec7a985a4f35.png)
![image](https://user-images.githubusercontent.com/124784924/232307319-c10f631a-6c60-4569-a616-87919b93686f.png)


