### PR TITLE
Various special rule fixes or improvements and boss updates

### DIFF
--- a/data/fh/deck/vermling-scout-scenario-94.json
+++ b/data/fh/deck/vermling-scout-scenario-94.json
@@ -1,0 +1,19 @@
+{
+  "name": "vermling-scout-scenario-94",
+  "edition": "fh",
+  "abilities": [
+    {
+      "name": "Flee",
+      "cardId": 752,
+      "initiative": 99,
+      "shuffle": true,
+      "actions": [
+        {
+          "type": "move",
+          "value": 0,
+          "valueType": "plus"
+        }
+      ]
+    }
+  ]
+}

--- a/data/fh/monster/hungry-maw.json
+++ b/data/fh/monster/hungry-maw.json
@@ -20,14 +20,106 @@
     "special": [
       [
         {
-          "type": "custom",
-          "value": "See Scenario Special Rules."
+          "type": "move",
+          "value": 1,
+          "valueType": "plus"
+        },
+        {
+          "type": "attack",
+          "value": 1,
+          "valueType": "plus",
+          "subActions": [
+            {
+              "type": "target",
+              "value": 2,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "push",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "target",
+              "value": "%game.target.all%",
+              "small": true
+            },
+            {
+              "type": "range",
+              "value": 1,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "value": "ice"
         }
       ],
       [
         {
-          "type": "custom",
-          "value": "See Scenario Special Rules."
+          "type": "shield",
+          "value": 1
+        },
+        {
+          "type": "move",
+          "value": 0,
+          "valueType": "plus",
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "move",
+                  "value": 2,
+                  "valueType": "add",
+                  "small": true
+                },
+                {
+                  "type": "sufferDamage",
+                  "value": 1,
+                  "small": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 0,
+          "valueType": "plus"
+        },
+        {
+          "type": "element",
+          "value": "ice",
+          "valueType": "minus",
+          "subActions": [
+            {
+              "type": "push",
+              "value": 2,
+              "valueType": "add",
+              "small": true
+            },
+            {
+              "type": "target",
+              "value": "%game.target.all%",
+              "small": true
+            },
+            {
+              "type": "range",
+              "value": 1,
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "brittle",
+              "small": true
+            }
+          ]
         }
       ]
     ]

--- a/data/fh/monster/reluctant-ghost-section-149.3.json
+++ b/data/fh/monster/reluctant-ghost-section-149.3.json
@@ -1,0 +1,201 @@
+{
+  "name": "reluctant-ghost-section-149.3",
+  "thumbnail": "fh-living-spirit",
+  "edition": "fh",
+  "deck": "living-spirit",
+  "boss": true,
+  "hidden": true,
+  "count": 1,
+  "standeeShare": "living-spirit",
+  "baseStat": {
+    "type": "boss",
+    "movement": 3,
+    "note": "Focus on moving torward the closest starting hex"
+  },
+  "stats": [
+    {
+      "level": 0,
+      "health": "(2xC)/2",
+      "attack": 2,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "level": 1,
+      "health": "(2xC)/2",
+      "attack": 2,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 2,
+      "health": "(2xC)/2",
+      "attack": 2,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 3,
+      "health": "(3xC)/2",
+      "attack": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 4,
+      "health": "(3xC)/2",
+      "attack": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "level": 5,
+      "health": "(4xC)/2",
+      "attack": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "level": 6,
+      "health": "(6xC)/2",
+      "attack": 4,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "level": 7,
+      "health": "(7xC)/2",
+      "attack": 5,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 0,
+      "health": "(3xC)/2",
+      "attack": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 1,
+      "health": "(3xC)/2",
+      "attack": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 2,
+      "health": "(3xC)/2",
+      "attack": 4,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 3,
+      "health": "(4xC)/2",
+      "attack": 4,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 4,
+      "health": "(4xC)/2",
+      "attack": 4,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 4
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 5,
+      "health": "(5xC)/2",
+      "attack": 5,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 4
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 6,
+      "health": "(8xC)/2",
+      "attack": 5,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 4
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 7,
+      "health": "(10xC)/2",
+      "attack": 6,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 4
+        }
+      ]
+    }
+  ]
+}

--- a/data/fh/monster/vermling-scout-scenario-94.json
+++ b/data/fh/monster/vermling-scout-scenario-94.json
@@ -1,0 +1,85 @@
+{
+  "name": "vermling-scout-scenario-94",
+  "thumbnail": "fh-vermling-scout",
+  "edition": "fh",
+  "hidden": true,
+  "count": 8,
+  "baseStat": {
+    "type": "normal",
+    "movement": 3
+  },
+  "stats": [
+    {
+      "level": 0,
+      "health": 2
+    },
+    {
+      "level": 1,
+      "health": 3
+    },
+    {
+      "level": 2,
+      "health": 3
+    },
+    {
+      "level": 3,
+      "health": 4
+    },
+    {
+      "level": 4,
+      "health": 5
+    },
+    {
+      "level": 5,
+      "health": 7
+    },
+    {
+      "level": 6,
+      "health": 10
+    },
+    {
+      "level": 7,
+      "health": 15
+    },
+    {
+      "type": "elite",
+      "level": 0,
+      "health": 4
+    },
+    {
+      "type": "elite",
+      "level": 1,
+      "health": 5
+    },
+    {
+      "type": "elite",
+      "level": 2,
+      "health": 3
+    },
+    {
+      "type": "elite",
+      "level": 3,
+      "health": 7
+    },
+    {
+      "type": "elite",
+      "level": 4,
+      "health": 8
+    },
+    {
+      "type": "elite",
+      "level": 5,
+      "health": 11
+    },
+    {
+      "type": "elite",
+      "level": 6,
+      "health": 16
+    },
+    {
+      "type": "elite",
+      "level": 7,
+      "health": 23
+    }
+  ]
+}

--- a/data/fh/scenarios/094.json
+++ b/data/fh/scenarios/094.json
@@ -35,7 +35,19 @@
   "rules": [
     {
       "round": "true",
-      "note": "Spawn one Ruined Machine for each character adjacent to a Flaming Bladespinner in any empty starting hex. Normal for 2 or 3 characters, elite for 4 characters."
+      "note": "Spawn one Ruined Machine for each character adjacent to a Flaming Bladespinner in any empty starting hex.",
+      "spawns": [
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "count": "0",
+          "manual": true
+        }
+      ]
     },
     {
       "round": "R % 6 == 3",
@@ -111,10 +123,7 @@
         }
       ],
       "objectives": [
-        1,
-        1,
-        1,
-        1
+        "1:4"
       ]
     }
   ]

--- a/data/fh/scenarios/103.json
+++ b/data/fh/scenarios/103.json
@@ -23,6 +23,7 @@
   "rules": [
     {
       "round": "true",
+      "note": "If any ice pillars suffered damage this round, spawn the following monsters at each character's location based on number of tokens on their mat.<br>0 - 5: One normal Living Spirit<br>6 - 8: One normal Shrike Fiend <br>9 - 11: One normal Living Doom <br>12+: One elite Living Spirit and one normal Lurker Clawcrusher",
       "spawns": [
         {
           "monster": {

--- a/data/fh/scenarios/109.json
+++ b/data/fh/scenarios/109.json
@@ -14,6 +14,27 @@
     "rockroot": 2,
     "flamefruit": 1
   },
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "72.3"
+      ],
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Metal Cabinet"
+          },
+          "type": "killed",
+          "value": "4"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,

--- a/data/fh/scenarios/110.json
+++ b/data/fh/scenarios/110.json
@@ -12,7 +12,30 @@
   "objectives": [
     {
       "name": "Ice Pillar",
-      "count": 6,
+      "marker": "a",
+      "count": 2,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "Can only be destoyed when a Ruined Machine dies in an adjacent hex"
+        }
+      ]
+    },
+    {
+      "name": "Ice Pillar",
+      "marker": "b",
+      "count": 2,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "Can only be destoyed when a Ruined Machine dies in an adjacent hex"
+        }
+      ]
+    },
+    {
+      "name": "Ice Pillar",
+      "marker": "c",
+      "count": 2,
       "actions": [
         {
           "type": "custom",
@@ -48,17 +71,50 @@
     {
       "round": "R % 3 == 1",
       "start": true,
-      "note": "Ice Pillars %game.mapMarker.a% active"
+      "note": "Ice Pillars %game.mapMarker.a% active",
+      "figures": [
+        {
+          "type": "present",
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Ice Pillar",
+            "marker": "a"
+          }
+        }
+      ]
     },
     {
       "round": "R % 3 == 2",
       "start": true,
-      "note": "Ice Pillars %game.mapMarker.b% active"
+      "note": "Ice Pillars %game.mapMarker.b% active",
+      "figures": [
+        {
+          "type": "present",
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Ice Pillar",
+            "marker": "b"
+          }
+        }
+      ]
     },
     {
       "round": "R % 3 == 0",
       "start": true,
-      "note": "Ice Pillars %game.mapMarker.c% active"
+      "note": "Ice Pillars %game.mapMarker.c% active",
+      "figures": [
+        {
+          "type": "present",
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Ice Pillar",
+            "marker": "c"
+          }
+        }
+      ]
     },
     {
       "round": "R % 2 == 0",
@@ -146,10 +202,10 @@
       "objectives": [
         1,
         1,
-        1,
-        1,
-        1,
-        1
+        2,
+        2,
+        3,
+        3
       ]
     }
   ]

--- a/data/fh/sections/102-1.json
+++ b/data/fh/sections/102-1.json
@@ -15,6 +15,14 @@
     "lurker-mindsnipper",
     "shrike-fiend"
   ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "note": "All characters return one card from their hand or discard pile to their set-aside deck."
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 2,

--- a/data/fh/sections/106-2.json
+++ b/data/fh/sections/106-2.json
@@ -18,7 +18,7 @@
   ],
   "rules": [
     {
-      "round": "R % 2 == 0",
+      "round": "R % 4 == 2",
       "start": true,
       "figures": [
         {
@@ -44,7 +44,7 @@
       ]
     },
     {
-      "round": "R % 2 == 1",
+      "round": "R % 4 == 0",
       "start": true,
       "figures": [
         {

--- a/data/fh/sections/133-5.json
+++ b/data/fh/sections/133-5.json
@@ -6,6 +6,9 @@
   "parentSections": [
     [
       "51.2"
+    ],
+    [
+      "92.3"
     ]
   ],
   "marker": "5",

--- a/data/fh/sections/146-3.json
+++ b/data/fh/sections/146-3.json
@@ -37,7 +37,8 @@
         },
         {
           "type": "custom",
-          "value": "When this attack is performed, on the next round at initiative 99 perform: %game.action.heal%2 self"
+          "value": "When this attack is performed, on the next round at initiative 99 instead perform: %game.action.heal%2 self",
+          "small": true
         }
       ]
     }

--- a/data/fh/sections/149-3.json
+++ b/data/fh/sections/149-3.json
@@ -13,7 +13,7 @@
     "ice-wraith",
     "living-bones",
     "living-doom",
-    "reluctant-ghost"
+    "reluctant-ghost-section-149.3"
   ],
   "rooms": [
     {
@@ -41,7 +41,7 @@
           "player4": "elite"
         },
         {
-          "name": "reluctant-ghost",
+          "name": "reluctant-ghost-section-149.3",
           "type": "boss"
         }
       ]

--- a/data/fh/sections/150-2.json
+++ b/data/fh/sections/150-2.json
@@ -6,15 +6,27 @@
   "monsters": [
     "ruined-machine",
     "steel-automaton",
-    "vermling-scout"
+    "vermling-scout-scenario-94"
   ],
   "allies": [
-    "vermling-scout"
+    "vermling-scout-scenario-94"
   ],
   "rules": [
     {
       "round": "true",
-      "note": "Spawn one Ruined Machine for each character or Vermling Scout adjacent to a Flaming Bladespinner in any empty starting hex. Normal for 2 or 3 characters, elite for 4 characters."
+      "note": "Spawn one Ruined Machine for each character or Vermling Scout adjacent to a Flaming Bladespinner in any empty starting hex.",
+      "spawns": [
+        {
+          "monster": {
+            "name": "ruined-machine",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "count": "0",
+          "manual": true
+        }
+      ]
     },
     {
       "round": "true",
@@ -64,37 +76,37 @@
           "player4": "normal"
         },
         {
-          "name": "vermling-scout",
+          "name": "vermling-scout-scenario-94",
           "type": "elite"
         },
         {
-          "name": "vermling-scout",
+          "name": "vermling-scout-scenario-94",
           "type": "elite"
         },
         {
-          "name": "vermling-scout",
+          "name": "vermling-scout-scenario-94",
           "type": "elite"
         },
         {
-          "name": "vermling-scout",
+          "name": "vermling-scout-scenario-94",
           "type": "elite"
         },
         {
-          "name": "vermling-scout",
+          "name": "vermling-scout-scenario-94",
           "player3": "elite",
           "player4": "elite"
         },
         {
-          "name": "vermling-scout",
+          "name": "vermling-scout-scenario-94",
           "player3": "elite",
           "player4": "elite"
         },
         {
-          "name": "vermling-scout",
+          "name": "vermling-scout-scenario-94",
           "player4": "elite"
         },
         {
-          "name": "vermling-scout",
+          "name": "vermling-scout-scenario-94",
           "player4": "elite"
         }
       ]

--- a/data/fh/sections/162-1.json
+++ b/data/fh/sections/162-1.json
@@ -16,6 +16,16 @@
       "marker": "b"
     }
   ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "195.2"
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 3,

--- a/data/fh/sections/166-3.json
+++ b/data/fh/sections/166-3.json
@@ -15,6 +15,16 @@
       "marker": "b"
     }
   ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "195.2"
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 4,

--- a/data/fh/sections/172-5.json
+++ b/data/fh/sections/172-5.json
@@ -15,6 +15,16 @@
       "marker": "b"
     }
   ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "195.2"
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 5,

--- a/data/fh/sections/186-2.json
+++ b/data/fh/sections/186-2.json
@@ -15,6 +15,16 @@
       "marker": "b"
     }
   ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "sections": [
+        "195.2"
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 6,

--- a/data/fh/sections/186-3.json
+++ b/data/fh/sections/186-3.json
@@ -35,7 +35,7 @@
     {
       "round": "true",
       "start": true,
-      "note": "Remaining Ice Pillars active"
+      "note": "Remaining two Ice Pillars are always active"
     }
   ],
   "rooms": [

--- a/data/fh/sections/19-1.json
+++ b/data/fh/sections/19-1.json
@@ -3,6 +3,9 @@
   "name": "The Lurker Problem",
   "edition": "fh",
   "parent": "78",
+  "blockedSections": [
+    "59.2"
+  ],
   "marker": "1",
   "monsters": [
     "lightning-eel",

--- a/data/fh/sections/195-2.json
+++ b/data/fh/sections/195-2.json
@@ -1,7 +1,7 @@
 {
   "fromFile": true,
   "index": "195.2",
-  "name": "Furios Factory",
+  "name": "Furious Factory",
   "edition": "fh",
   "parent": "109",
   "monsters": [

--- a/data/fh/sections/29-2.json
+++ b/data/fh/sections/29-2.json
@@ -4,6 +4,14 @@
   "name": "The Tempus Forge",
   "edition": "fh",
   "parent": "106",
+  "parentSections": [
+    [
+      "8.1",
+      "183.1",
+      "184.4",
+      "189.2"
+    ]
+  ],
   "marker": "5",
   "monsters": [
     "blacksmith"

--- a/data/fh/sections/51-2.json
+++ b/data/fh/sections/51-2.json
@@ -8,6 +8,9 @@
       "19.1"
     ]
   ],
+  "blockedSections": [
+    "91.1"
+  ],
   "marker": "3",
   "monsters": [
     "abael-scout",

--- a/data/fh/sections/59-2.json
+++ b/data/fh/sections/59-2.json
@@ -3,6 +3,9 @@
   "name": "The Lurker Problem",
   "edition": "fh",
   "parent": "78",
+  "blockedSections": [
+    "19.1"
+  ],
   "marker": "2",
   "monsters": [
     "abael-herder",

--- a/data/fh/sections/84-1.json
+++ b/data/fh/sections/84-1.json
@@ -9,6 +9,7 @@
     "ice-wraith",
     "living-bones",
     "living-doom",
+    "living-spirit",
     "reluctant-ghost"
   ],
   "rooms": [

--- a/data/fh/sections/91-1.json
+++ b/data/fh/sections/91-1.json
@@ -8,6 +8,9 @@
       "19.1"
     ]
   ],
+  "blockedSections": [
+    "51.2"
+  ],
   "marker": "a",
   "rooms": [
     {


### PR DESCRIPTION
- Scenario 122 - Added missing boss specials
- Section 106.2 - Fixed spawning rules to be every second round
- Scenario 94, Section 150.2 - created custom monster and deck for special rules
- Scenario 95, Section 149.3 - created extra monster for special rules
- Added some section links with blocked sections
- Various other rule updates, fixes or improvements