### PR TITLE
Added some scenario rewards for Scenarios 1 - 64

### DIFF
--- a/data/fh/scenarios/002.json
+++ b/data/fh/scenarios/002.json
@@ -13,7 +13,8 @@
     "4B"
   ],
   "rewards": {
-    "battleGoals": 1
+    "battleGoals": 1,
+    "custom": "Place map overlay sticker W on map in location W (M7)."
   },
   "monsters": [
     "algox-archer",

--- a/data/fh/scenarios/003.json
+++ b/data/fh/scenarios/003.json
@@ -22,7 +22,7 @@
     "algox-priest",
     "hound"
   ],
-  "allies": [
+  "allied": [
     "algox-priest",
     "hound"
   ],

--- a/data/fh/scenarios/004A.json
+++ b/data/fh/scenarios/004A.json
@@ -2,6 +2,10 @@
   "index": "4A",
   "name": "Heart of Ice A",
   "edition": "fh",
+  "rewards": {
+    "morale": 1,
+    "prosperity": 1
+  },
   "monsters": [
     "algox-guard",
     "algox-scout"

--- a/data/fh/scenarios/004A.json
+++ b/data/fh/scenarios/004A.json
@@ -10,7 +10,7 @@
     "algox-guard",
     "algox-scout"
   ],
-  "allies": [
+  "allied": [
     "algox-scout"
   ],
   "drawExtra": [

--- a/data/fh/scenarios/004B.json
+++ b/data/fh/scenarios/004B.json
@@ -2,6 +2,10 @@
   "index": "4B",
   "name": "Heart of Ice B",
   "edition": "fh",
+  "rewards": {
+    "morale": 1,
+    "prosperity": 1
+  },
   "monsters": [
     "algox-archer",
     "algox-guard"

--- a/data/fh/scenarios/008.json
+++ b/data/fh/scenarios/008.json
@@ -6,6 +6,9 @@
     "15",
     "16"
   ],
+  "rewards": {
+    "custom": "Place map overlay sticker X on map in location X (C7)"
+  },
   "monsters": [
     "polar-bear",
     "snow-imp"

--- a/data/fh/scenarios/010.json
+++ b/data/fh/scenarios/010.json
@@ -5,6 +5,10 @@
   "unlocks": [
     "18"
   ],
+  "rewards": {
+    "morale": 1,
+    "inspiration": 1
+  },
   "monsters": [
     "algox-guard",
     "algox-priest"

--- a/data/fh/scenarios/011.json
+++ b/data/fh/scenarios/011.json
@@ -8,6 +8,10 @@
   "forcedLinks": [
     "19"
   ],
+  "rewards": {
+    "morale": 1,
+    "inspiration": 1
+  },
   "monsters": [
     "algox-stormcaller",
     "frost-demon",

--- a/data/fh/scenarios/012.json
+++ b/data/fh/scenarios/012.json
@@ -5,6 +5,9 @@
   "unlocks": [
     "20"
   ],
+  "rewards": {
+    "experience": 15
+  },
   "monsters": [
     "ancient-artillery"
   ],

--- a/data/fh/scenarios/013.json
+++ b/data/fh/scenarios/013.json
@@ -6,6 +6,11 @@
     "21",
     "32"
   ],
+  "rewards": {
+    "items": [
+      "233"
+    ]
+  },
   "monsters": [
     "shrike-fiend"
   ],

--- a/data/fh/scenarios/016.json
+++ b/data/fh/scenarios/016.json
@@ -10,6 +10,11 @@
     "25",
     "26"
   ],
+  "rewards": {
+    "inspiration": 1,
+    "experience": 5,
+    "custom": "Place map overlay sticker Y on map in location Y (C10)"
+  },
   "monsters": [
     "ancient-artillery",
     "ruined-machine"

--- a/data/fh/scenarios/017.json
+++ b/data/fh/scenarios/017.json
@@ -5,6 +5,9 @@
   "unlocks": [
     "27"
   ],
+  "rewards": {
+    "battleGoals": 2
+  },
   "monsters": [],
   "objectives": [
     {

--- a/data/fh/scenarios/018.json
+++ b/data/fh/scenarios/018.json
@@ -2,10 +2,12 @@
   "index": "18",
   "name": "Crystal Fields",
   "edition": "fh",
-  "unlocks": [
-    "28",
-    "29"
-  ],
+  "rewards": {
+    "morale": 1,
+    "calenderSection": [
+      "122.3-4"
+    ]
+  },
   "monsters": [
     "frozen-corpse"
   ],

--- a/data/fh/scenarios/019.json
+++ b/data/fh/scenarios/019.json
@@ -2,10 +2,12 @@
   "index": "19",
   "name": "Skyhall",
   "edition": "fh",
-  "unlocks": [
-    "28",
-    "30"
-  ],
+  "rewards": {
+    "morale": 1,
+    "calenderSection": [
+      "54.3-4"
+    ]
+  },
   "monsters": [
     "earth-demon",
     "flame-demon",

--- a/data/fh/scenarios/020.json
+++ b/data/fh/scenarios/020.json
@@ -5,6 +5,9 @@
   "unlocks": [
     "31"
   ],
+  "rewards": {
+    "gold": 15
+  },
   "monsters": [
     "flaming-bladespinner",
     "ruined-machine",

--- a/data/fh/scenarios/021.json
+++ b/data/fh/scenarios/021.json
@@ -2,6 +2,9 @@
   "index": "21",
   "name": "Realm of Endless Frost",
   "edition": "fh",
+  "rewards": {
+    "prosperity": 2
+  },
   "monsters": [
     "frost-demon",
     "living-spirit",

--- a/data/fh/scenarios/022.json
+++ b/data/fh/scenarios/022.json
@@ -5,6 +5,9 @@
   "unlocks": [
     "33"
   ],
+  "rewards": {
+    "experience": 15
+  },
   "monsters": [
     "lurker-clawcrusher",
     "lurker-wavethrower"

--- a/data/fh/scenarios/022.json
+++ b/data/fh/scenarios/022.json
@@ -2,10 +2,10 @@
   "index": "22",
   "name": "Ice Floes",
   "edition": "fh",
-  "unlocks": [
-    "33"
-  ],
   "rewards": {
+    "calenderSection": [
+      "62.2-2"
+    ],
     "experience": 15
   },
   "monsters": [

--- a/data/fh/scenarios/025.json
+++ b/data/fh/scenarios/025.json
@@ -3,12 +3,14 @@
   "index": "25",
   "name": "Rusted Tunnels",
   "edition": "fh",
-  "unlocks": [
-    "35"
-  ],
   "blocks": [
     "26"
   ],
+  "rewards": {
+    "calenderSection": [
+      "128.2-4"
+    ]
+  },
   "monsters": [
     "flaming-bladespinner",
     "robotic-boltshooter"

--- a/data/fh/scenarios/026.json
+++ b/data/fh/scenarios/026.json
@@ -10,6 +10,9 @@
   "blocks": [
     "25"
   ],
+  "rewards": {
+    "experience": 10
+  },
   "monsters": [
     "ancient-artillery",
     "ruined-machine",

--- a/data/fh/scenarios/026.json
+++ b/data/fh/scenarios/026.json
@@ -11,6 +11,9 @@
     "25"
   ],
   "rewards": {
+    "calenderSection": [
+      "169.3-4"
+    ],
     "experience": 10
   },
   "monsters": [

--- a/data/fh/scenarios/028.json
+++ b/data/fh/scenarios/028.json
@@ -11,6 +11,9 @@
     "29",
     "30"
   ],
+  "rewards": {
+    "morale": -1
+  },
   "monsters": [
     "algox-archer",
     "algox-guard",

--- a/data/fh/scenarios/029.json
+++ b/data/fh/scenarios/029.json
@@ -9,6 +9,14 @@
   "blocks": [
     "28"
   ],
+  "rewards": {
+    "campaignSticker": [
+      "Destroyer of the Icespeakers"
+    ],
+    "events": [
+      "winter-outpost:WO-68"
+    ]
+  },
   "monsters": [
     "algox-icespeaker",
     "algox-priest",

--- a/data/fh/scenarios/029.json
+++ b/data/fh/scenarios/029.json
@@ -3,15 +3,16 @@
   "index": "29",
   "name": "War of the Spire A",
   "edition": "fh",
-  "unlocks": [
-    "39"
-  ],
   "blocks": [
     "28"
   ],
   "rewards": {
+    "morale": 3,
     "campaignSticker": [
       "Destroyer of the Icespeakers"
+    ],
+    "calenderSection": [
+      "46.3-5"
     ],
     "events": [
       "winter-outpost:WO-68"

--- a/data/fh/scenarios/030.json
+++ b/data/fh/scenarios/030.json
@@ -9,6 +9,14 @@
   "blocks": [
     "28"
   ],
+  "rewards": {
+    "campaignSticker": [
+      "Destroyer of the Snowspeakers"
+    ],
+    "events": [
+      "winter-outpost:WO-69"
+    ]
+  },
   "monsters": [
     "algox-archer",
     "algox-guard",

--- a/data/fh/scenarios/030.json
+++ b/data/fh/scenarios/030.json
@@ -3,15 +3,16 @@
   "index": "30",
   "name": "War of the Spire B",
   "edition": "fh",
-  "unlocks": [
-    "40"
-  ],
   "blocks": [
     "28"
   ],
   "rewards": {
+    "morale": 3,
     "campaignSticker": [
       "Destroyer of the Snowspeakers"
+    ],
+    "calenderSection": [
+      "34.2-5"
     ],
     "events": [
       "winter-outpost:WO-69"

--- a/data/fh/scenarios/031.json
+++ b/data/fh/scenarios/031.json
@@ -6,6 +6,10 @@
   "unlocks": [
     "41"
   ],
+  "rewards": {
+    "gold": 10,
+    "experience": 5
+  },
   "monsters": [
     "flaming-bladespinner",
     "steel-automaton"

--- a/data/fh/scenarios/032.json
+++ b/data/fh/scenarios/032.json
@@ -2,6 +2,11 @@
   "index": "32",
   "name": "Ravens' Roost",
   "edition": "fh",
+  "rewards": {
+    "campaignSticker": [
+      "Into the Forest"
+    ]
+  },
   "monsters": [
     "frozen-corpse-scenario-32"
   ],

--- a/data/fh/scenarios/033.json
+++ b/data/fh/scenarios/033.json
@@ -5,6 +5,11 @@
   "unlocks": [
     "42"
   ],
+  "rewards": {
+    "items": [
+      "244"
+    ]
+  },
   "monsters": [
     "black-imp",
     "shrike-fiend"

--- a/data/fh/scenarios/033.json
+++ b/data/fh/scenarios/033.json
@@ -2,10 +2,10 @@
   "index": "33",
   "name": "Thawed Wood",
   "edition": "fh",
-  "unlocks": [
-    "42"
-  ],
   "rewards": {
+    "calenderSection": [
+      "135.1-3"
+    ],
     "items": [
       "244"
     ]

--- a/data/fh/scenarios/034.json
+++ b/data/fh/scenarios/034.json
@@ -3,6 +3,11 @@
   "index": "34",
   "name": "Top of the Spire",
   "edition": "fh",
+  "rewards": {
+    "campaignSticker": [
+      "Coral Shard"
+    ]
+  },
   "monsters": [
     "chaos-spark",
     "lord-of-chaos"

--- a/data/fh/scenarios/038.json
+++ b/data/fh/scenarios/038.json
@@ -7,6 +7,11 @@
     "45",
     "46"
   ],
+  "rewards": {
+    "inspiration": 1,
+    "experience": 10,
+    "battleGoals": 1
+  },
   "monsters": [
     "hound",
     "polar-bear"

--- a/data/fh/scenarios/039.json
+++ b/data/fh/scenarios/039.json
@@ -6,6 +6,10 @@
   "unlocks": [
     "47"
   ],
+  "rewards": {
+    "inspiration": -1,
+    "custom": "Gain 2 additional loot cards each"
+  },
   "monsters": [
     "algox-guard",
     "algox-scout",

--- a/data/fh/scenarios/040.json
+++ b/data/fh/scenarios/040.json
@@ -6,6 +6,10 @@
   "unlocks": [
     "48"
   ],
+  "rewards": {
+    "inspiration": -1,
+    "custom": "Gain 2 additional loot cards each"
+  },
   "monsters": [
     "algox-guard",
     "ruined-machine",

--- a/data/fh/scenarios/041.json
+++ b/data/fh/scenarios/041.json
@@ -3,6 +3,13 @@
   "index": "41",
   "name": "Unfettered Shard",
   "edition": "fh",
+  "rewards": {
+    "campaignSticker": [
+      "Coral Shard"
+    ],
+    "gold": 15,
+    "custom": "Read Section #36.7 now"
+  },
   "monsters": [
     "deep-terror",
     "living-doom",

--- a/data/fh/scenarios/042.json
+++ b/data/fh/scenarios/042.json
@@ -6,6 +6,12 @@
     "49",
     "50"
   ],
+  "rewards": {
+    "campaignSticker": [
+      "Coral Shard"
+    ],
+    "battleGoals": 2
+  },
   "monsters": [
     "deep-terror",
     "ooze"

--- a/data/fh/scenarios/043.json
+++ b/data/fh/scenarios/043.json
@@ -9,6 +9,9 @@
   "forcedLinks": [
     "51"
   ],
+  "rewards": {
+    "experience": 10
+  },
   "monsters": [
     "robotic-boltshooter",
     "ruined-machine",

--- a/data/fh/scenarios/044.json
+++ b/data/fh/scenarios/044.json
@@ -11,6 +11,9 @@
     "58",
     "59"
   ],
+  "rewards": {
+    "gold": 5
+  },
   "monsters": [
     "flaming-bladespinner"
   ],

--- a/data/fh/scenarios/045.json
+++ b/data/fh/scenarios/045.json
@@ -6,6 +6,10 @@
   "unlocks": [
     "52"
   ],
+  "rewards": {
+    "morale": 1,
+    "battleGoals": 1
+  },
   "monsters": [
     "abael-herder",
     "abael-scout",

--- a/data/fh/scenarios/046.json
+++ b/data/fh/scenarios/046.json
@@ -6,6 +6,10 @@
   "unlocks": [
     "52"
   ],
+  "rewards": {
+    "morale": 1,
+    "experience": 10
+  },
   "monsters": [
     "burrowing-blade",
     "shrike-fiend"

--- a/data/fh/scenarios/047.json
+++ b/data/fh/scenarios/047.json
@@ -9,6 +9,9 @@
   "links": [
     "56"
   ],
+  "rewards": {
+    "gold": 10
+  },
   "monsters": [
     "algox-icespeaker",
     "shrike-fiend"

--- a/data/fh/scenarios/048.json
+++ b/data/fh/scenarios/048.json
@@ -9,6 +9,9 @@
   "links": [
     "57"
   ],
+  "rewards": {
+    "experience": 10
+  },
   "monsters": [
     "abael-scout",
     "wind-demon"

--- a/data/fh/scenarios/049.json
+++ b/data/fh/scenarios/049.json
@@ -8,6 +8,10 @@
   "forcedLinks": [
     "53"
   ],
+  "rewards": {
+    "inspiration": 1,
+    "experience": 5
+  },
   "monsters": [
     "deep-terror"
   ],

--- a/data/fh/scenarios/050.json
+++ b/data/fh/scenarios/050.json
@@ -9,6 +9,9 @@
   "forcedLinks": [
     "54"
   ],
+  "rewards": {
+    "inspiration": -2
+  },
   "monsters": [
     "lightning-eel",
     "lurker-clawcrusher",

--- a/data/fh/scenarios/051.json
+++ b/data/fh/scenarios/051.json
@@ -11,6 +11,9 @@
     "58",
     "59"
   ],
+  "rewards": {
+    "experience": 10
+  },
   "monsters": [
     "ancient-artillery",
     "steel-automaton"

--- a/data/fh/scenarios/052.json
+++ b/data/fh/scenarios/052.json
@@ -12,6 +12,10 @@
       "46"
     ]
   ],
+  "rewards": {
+    "morale": 1,
+    "inspiration": 1
+  },
   "monsters": [
     "frost-demon",
     "snow-imp"

--- a/data/fh/scenarios/053.json
+++ b/data/fh/scenarios/053.json
@@ -5,6 +5,12 @@
   "unlocks": [
     "60"
   ],
+  "rewards": {
+    "campaignSticker": [
+      "Coral Shard"
+    ],
+    "battleGoals": 2
+  },
   "monsters": [
     "lurker-clawcrusher",
     "lurker-mindsnipper",

--- a/data/fh/scenarios/054.json
+++ b/data/fh/scenarios/054.json
@@ -6,6 +6,12 @@
   "unlocks": [
     "60"
   ],
+  "rewards": {
+    "campaignSticker": [
+      "Coral Shard"
+    ],
+    "battleGoals": 2
+  },
   "monsters": [
     "lightning-eel",
     "lurker-clawcrusher",

--- a/data/fh/scenarios/055.json
+++ b/data/fh/scenarios/055.json
@@ -3,6 +3,18 @@
   "index": "55",
   "name": "Change of Heart",
   "edition": "fh",
+  "rewards": {
+    "morale": 2,
+    "campaignSticker": [
+      "Friend of the Frostspeakers"
+    ],
+    "prosperity": 2,
+    "events": [
+      "winter-outpost:WO-66",
+      "winter-outpost:WO-67"
+    ],
+    "custom": "Unlock whichever class box is still locked: <br>%game.characterIcon.fist% or %game.characterIcon.snowflake%"
+  },
   "monsters": [
     "algox-archer",
     "algox-guard",

--- a/data/fh/scenarios/056.json
+++ b/data/fh/scenarios/056.json
@@ -3,6 +3,14 @@
   "index": "56",
   "name": "Call of the Harbinger",
   "edition": "fh",
+  "rewards": {
+    "morale": 1,
+    "inspiration": 1,
+    "campaignSticker": [
+      "Friend of the Icespeakers"
+    ],
+    "custom": "Unlock %game.characterIcon.fist% class box"
+  },
   "monsters": [
     "black-imp",
     "harbinger-of-shadow",

--- a/data/fh/scenarios/057.json
+++ b/data/fh/scenarios/057.json
@@ -3,6 +3,17 @@
   "index": "57",
   "name": "Sanctuary of Snow",
   "edition": "fh",
+  "rewards": {
+    "morale": 1,
+    "inspiration": 1,
+    "campaignSticker": [
+      "Friend of the Snowspeakers"
+    ],
+    "events": [
+      "winter-outpost:WO-68"
+    ],
+    "custom": "Unlock %game.characterIcon.snowflake% class box"
+  },
   "monsters": [
     "render",
     "wind-demon"

--- a/data/fh/scenarios/058.json
+++ b/data/fh/scenarios/058.json
@@ -6,6 +6,20 @@
   "blocks": [
     "59"
   ],
+  "rewards": {
+    "morale": 1,
+    "campaignSticker": [
+      "Unfettered Deactivated"
+    ],
+    "items": [
+      "246"
+    ],
+    "events": [
+      "winter-outpost:WO-64",
+      "winter-outpost:WO-65"
+    ],
+    "custom": "Unlock %game.characterIcon.prism% class box"
+  },
   "monsters": [
     "flaming-bladespinner",
     "orphan",

--- a/data/fh/scenarios/059.json
+++ b/data/fh/scenarios/059.json
@@ -6,6 +6,20 @@
   "blocks": [
     "58"
   ],
+  "rewards": {
+    "morale": 2,
+    "campaignSticker": [
+      "Unfettered Allies"
+    ],
+    "prosperity": 2,
+    "items": [
+      "246"
+    ],
+    "events": [
+      "winter-outpost:WO-63"
+    ],
+    "custom": "Unlock %game.characterIcon.prism% class box"
+  },
   "monsters": [
     "flaming-bladespinner",
     "robotic-boltshooter",

--- a/data/fh/scenarios/060.json
+++ b/data/fh/scenarios/060.json
@@ -3,6 +3,15 @@
   "index": "60",
   "name": "Uniting the Crown",
   "edition": "fh",
+  "rewards": {
+    "morale": 2,
+    "campaignSticker": [
+      "Crown United"
+    ],
+    "experience": 30,
+    "prosperity": 1,
+    "custom": "Unlock whichever class box is still locked: <br>%game.characterIcon.coral% or %game.characterIcon.kelp%"
+  },
   "monsters": [
     "fracture-of-the-deep",
     "lightning-eel",

--- a/data/fh/scenarios/061.json
+++ b/data/fh/scenarios/061.json
@@ -6,6 +6,9 @@
   "unlocks": [
     "62"
   ],
+  "rewards": {
+    "custom": "Unlock %game.characterIcon.shackles% class box"
+  },
   "monsters": [
     "deep-terror",
     "harrower-infester"

--- a/data/fh/scenarios/062.json
+++ b/data/fh/scenarios/062.json
@@ -6,6 +6,9 @@
   "unlocks": [
     "63"
   ],
+  "rewards": {
+    "prosperity": 1
+  },
   "monsters": [
     "chaos-demon",
     "harrower-infester"

--- a/data/fh/scenarios/063.json
+++ b/data/fh/scenarios/063.json
@@ -9,6 +9,9 @@
   "forcedLinks": [
     "64"
   ],
+  "rewards": {
+    "prosperity": 2
+  },
   "monsters": [
     "earth-demon",
     "flame-demon",

--- a/data/fh/scenarios/064.json
+++ b/data/fh/scenarios/064.json
@@ -3,6 +3,12 @@
   "index": "64",
   "name": "The Frosthaven Seal",
   "edition": "fh",
+  "rewards": {
+    "morale": 3,
+    "prosperity": 3,
+    "battleGoals": 3,
+    "custom": "Open the scenario flowchart window to the right of The Frozen Seal (64) and apply the sticker over the completed scenario"
+  },
   "monsters": [
     "burrowing-blade",
     "guard-captain",

--- a/data/fh/scenarios/071.json
+++ b/data/fh/scenarios/071.json
@@ -10,6 +10,10 @@
     "abael-scout",
     "piranha-pig"
   ],
+  "allied": [
+    "abael-scout",
+    "piranha-pig"
+  ],
   "lootDeckConfig": {
     "money": 8,
     "lumber": 4,

--- a/data/fh/scenarios/081.json
+++ b/data/fh/scenarios/081.json
@@ -11,6 +11,10 @@
     "ruined-machine",
     "steel-automaton"
   ],
+  "allied": [
+    "aesther-ashblade",
+    "aesther-scout"
+  ],
   "objectives": [
     {
       "name": "Door 1",

--- a/data/fh/sections/122-3.json
+++ b/data/fh/sections/122-3.json
@@ -1,0 +1,10 @@
+{
+  "index": "122.3",
+  "name": "Decisive Action",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "28",
+    "29"
+  ]
+}

--- a/data/fh/sections/128-2.json
+++ b/data/fh/sections/128-2.json
@@ -1,0 +1,12 @@
+{
+  "index": "128.2",
+  "name": "Crain's Recovery",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "35"
+  ],
+  "rewards": {
+    "custom": "Open the Puzzle Book to the first page"
+  }
+}

--- a/data/fh/sections/135-1.json
+++ b/data/fh/sections/135-1.json
@@ -1,0 +1,9 @@
+{
+  "index": "135.1",
+  "name": "Bathysphere Ready",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "42"
+  ]
+}

--- a/data/fh/sections/15-2A.json
+++ b/data/fh/sections/15-2A.json
@@ -13,5 +13,8 @@
     "6",
     "7",
     "8"
-  ]
+  ],
+  "rewards": {
+    "custom": "Unlock %game.characterIcon.fist% class box"
+  }
 }

--- a/data/fh/sections/15-2B.json
+++ b/data/fh/sections/15-2B.json
@@ -13,5 +13,8 @@
     "6",
     "7",
     "8"
-  ]
+  ],
+  "rewards": {
+    "custom": "Unlock %game.characterIcon.fist% class box"
+  }
 }

--- a/data/fh/sections/169-3.json
+++ b/data/fh/sections/169-3.json
@@ -1,0 +1,13 @@
+{
+  "index": "169.3",
+  "name": "Crain's Recovery",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "36",
+    "37"
+  ],
+  "rewards": {
+    "custom": "Open the Puzzle Book to the first page"
+  }
+}

--- a/data/fh/sections/22-1A.json
+++ b/data/fh/sections/22-1A.json
@@ -13,5 +13,8 @@
     "5",
     "7",
     "8"
-  ]
+  ],
+  "rewards": {
+    "custom": "Unlock %game.characterIcon.snowflake% class box"
+  }
 }

--- a/data/fh/sections/22-1B.json
+++ b/data/fh/sections/22-1B.json
@@ -13,5 +13,8 @@
     "5",
     "7",
     "8"
-  ]
+  ],
+  "rewards": {
+    "custom": "Unlock %game.characterIcon.snowflake% class box"
+  }
 }

--- a/data/fh/sections/34-2.json
+++ b/data/fh/sections/34-2.json
@@ -1,0 +1,9 @@
+{
+  "index": "34.2",
+  "name": "Snowspeakers in Trouble",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "40"
+  ]
+}

--- a/data/fh/sections/46-3.json
+++ b/data/fh/sections/46-3.json
@@ -1,0 +1,9 @@
+{
+  "index": "46.3",
+  "name": "Icespeakers in Trouble",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "39"
+  ]
+}

--- a/data/fh/sections/54-3.json
+++ b/data/fh/sections/54-3.json
@@ -1,0 +1,10 @@
+{
+  "index": "54.3",
+  "name": "Decisive Action",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "28",
+    "30"
+  ]
+}

--- a/data/fh/sections/62-2.json
+++ b/data/fh/sections/62-2.json
@@ -1,0 +1,9 @@
+{
+  "index": "62.2",
+  "name": "Bathysphere Plans",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "33"
+  ]
+}


### PR DESCRIPTION
- Added the following rewards for Scenarios 1 - 64:

Morale - used `"morale":` for when it's ready
Inspiration - used `"inspiration":` for when it's ready
Prosperity
Gold and Collective Gold
Experience
Battle Goals
Items
Campaign stickers
Events (Winter Outpost events only - summer and boat not implemented yet)
Section links containing scenario unlocks
Custom text for extra rewards (class box, placing map stickers)

- Updated scenarios containing 'allied' monsters