### PR TITLE
Added remaining rewards for Frosthaven Scenarios 1 - 137

### DIFF
--- a/data/fh/scenarios/005.json
+++ b/data/fh/scenarios/005.json
@@ -9,6 +9,14 @@
   "blocks": [
     "6"
   ],
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 2
+      }
+    ]
+  },
   "monsters": [
     "ice-wraith"
   ],

--- a/data/fh/scenarios/006.json
+++ b/data/fh/scenarios/006.json
@@ -9,6 +9,14 @@
   "blocks": [
     "5"
   ],
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "metal",
+        "value": 2
+      }
+    ]
+  },
   "monsters": [
     "frost-demon",
     "snow-imp"

--- a/data/fh/scenarios/008.json
+++ b/data/fh/scenarios/008.json
@@ -7,6 +7,16 @@
     "16"
   ],
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 1
+      },
+      {
+        "type": "hide",
+        "value": 2
+      }
+    ],
     "custom": "Place map overlay sticker X on map in location X (C7)"
   },
   "monsters": [

--- a/data/fh/scenarios/009.json
+++ b/data/fh/scenarios/009.json
@@ -5,6 +5,14 @@
   "unlocks": [
     "17"
   ],
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "corpsecap",
+        "value": 2
+      }
+    ]
+  },
   "monsters": [
     "ice-wraith",
     "living-doom",

--- a/data/fh/scenarios/015.json
+++ b/data/fh/scenarios/015.json
@@ -10,6 +10,22 @@
     "23",
     "24"
   ],
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 1
+      },
+      {
+        "type": "metal",
+        "value": 1
+      },
+      {
+        "type": "hide",
+        "value": 1
+      }
+    ]
+  },
   "monsters": [
     "chaos-lieutenant",
     "robotic-boltshooter",

--- a/data/fh/scenarios/018.json
+++ b/data/fh/scenarios/018.json
@@ -4,6 +4,7 @@
   "edition": "fh",
   "rewards": {
     "morale": 1,
+    "randomItemBlueprint": 1,
     "calenderSection": [
       "122.3-4"
     ]

--- a/data/fh/scenarios/019.json
+++ b/data/fh/scenarios/019.json
@@ -4,6 +4,7 @@
   "edition": "fh",
   "rewards": {
     "morale": 1,
+    "randomItemBlueprint": 1,
     "calenderSection": [
       "54.3-4"
     ]

--- a/data/fh/scenarios/022.json
+++ b/data/fh/scenarios/022.json
@@ -6,7 +6,8 @@
     "calenderSection": [
       "62.2-2"
     ],
-    "experience": 15
+    "experience": 15,
+    "custom": "Lose 1 collective lumber for each set of five hexes with water tiles on tile 7-G"
   },
   "monsters": [
     "lurker-clawcrusher",

--- a/data/fh/scenarios/023.json
+++ b/data/fh/scenarios/023.json
@@ -8,6 +8,9 @@
   "links": [
     "34"
   ],
+  "rewards": {
+    "randomItemBlueprint": 1
+  },
   "monsters": [
     "living-bones",
     "living-spirit"

--- a/data/fh/scenarios/024.json
+++ b/data/fh/scenarios/024.json
@@ -8,6 +8,9 @@
   "links": [
     "34"
   ],
+  "rewards": {
+    "randomItemBlueprint": 1
+  },
   "monsters": [
     "chaos-demon",
     "living-bones"

--- a/data/fh/scenarios/025.json
+++ b/data/fh/scenarios/025.json
@@ -7,6 +7,16 @@
     "26"
   ],
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 2
+      },
+      {
+        "type": "metal",
+        "value": 2
+      }
+    ],
     "calenderSection": [
       "128.2-4"
     ]

--- a/data/fh/scenarios/029.json
+++ b/data/fh/scenarios/029.json
@@ -16,7 +16,8 @@
     ],
     "events": [
       "winter-outpost:WO-68"
-    ]
+    ],
+    "custom": "Remove all %game.action.custom.fh-algox% events from all outpost event decks"
   },
   "monsters": [
     "algox-icespeaker",

--- a/data/fh/scenarios/030.json
+++ b/data/fh/scenarios/030.json
@@ -16,7 +16,8 @@
     ],
     "events": [
       "winter-outpost:WO-69"
-    ]
+    ],
+    "custom": "Remove all %game.action.custom.fh-algox% events from all outpost event decks"
   },
   "monsters": [
     "algox-archer",

--- a/data/fh/scenarios/033.json
+++ b/data/fh/scenarios/033.json
@@ -8,7 +8,8 @@
     ],
     "items": [
       "244"
-    ]
+    ],
+    "custom": "Gain 5 experience for each unrevealed dowsing rune"
   },
   "monsters": [
     "black-imp",

--- a/data/fh/scenarios/035.json
+++ b/data/fh/scenarios/035.json
@@ -6,6 +6,22 @@
   "unlocks": [
     "43"
   ],
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 2
+      },
+      {
+        "type": "metal",
+        "value": 2
+      },
+      {
+        "type": "hide",
+        "value": 2
+      }
+    ]
+  },
   "monsters": [
     "living-bones",
     "ruined-machine",

--- a/data/fh/scenarios/036.json
+++ b/data/fh/scenarios/036.json
@@ -12,6 +12,18 @@
   "forcedLinks": [
     "44"
   ],
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 3
+      },
+      {
+        "type": "metal",
+        "value": 3
+      }
+    ]
+  },
   "monsters": [
     "flaming-bladespinner",
     "robotic-boltshooter",

--- a/data/fh/scenarios/037.json
+++ b/data/fh/scenarios/037.json
@@ -12,6 +12,18 @@
   "forcedLinks": [
     "44"
   ],
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 3
+      },
+      {
+        "type": "hide",
+        "value": 3
+      }
+    ]
+  },
   "monsters": [
     "living-bones",
     "living-spirit"

--- a/data/fh/scenarios/041.json
+++ b/data/fh/scenarios/041.json
@@ -7,6 +7,12 @@
     "campaignSticker": [
       "Coral Shard"
     ],
+    "collectiveResources": [
+      {
+        "type": "axenut",
+        "value": 2
+      }
+    ],
     "gold": 15,
     "custom": "Read Section #36.7 now"
   },

--- a/data/fh/scenarios/042.json
+++ b/data/fh/scenarios/042.json
@@ -10,7 +10,13 @@
     "campaignSticker": [
       "Coral Shard"
     ],
-    "battleGoals": 2
+    "calenderSection": [
+      "114.2-3"
+    ],
+    "battleGoals": 2,
+    "events": [
+      "boat:B-16"
+    ]
   },
   "monsters": [
     "deep-terror",

--- a/data/fh/scenarios/044.json
+++ b/data/fh/scenarios/044.json
@@ -3,15 +3,15 @@
   "index": "44",
   "name": "Nerve Center",
   "edition": "fh",
-  "unlocks": [
-    "58",
-    "59"
-  ],
   "forcedLinks": [
     "58",
     "59"
   ],
   "rewards": {
+    "chooseLocation": [
+      "58",
+      "59"
+    ],
     "gold": 5
   },
   "monsters": [

--- a/data/fh/scenarios/047.json
+++ b/data/fh/scenarios/047.json
@@ -10,6 +10,12 @@
     "56"
   ],
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 2
+      }
+    ],
     "gold": 10
   },
   "monsters": [

--- a/data/fh/scenarios/048.json
+++ b/data/fh/scenarios/048.json
@@ -10,6 +10,12 @@
     "57"
   ],
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "metal",
+        "value": 2
+      }
+    ],
     "experience": 10
   },
   "monsters": [

--- a/data/fh/scenarios/050.json
+++ b/data/fh/scenarios/050.json
@@ -10,7 +10,17 @@
     "54"
   ],
   "rewards": {
-    "inspiration": -2
+    "inspiration": -2,
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 4
+      },
+      {
+        "type": "metal",
+        "value": 4
+      }
+    ]
   },
   "monsters": [
     "lightning-eel",

--- a/data/fh/scenarios/051.json
+++ b/data/fh/scenarios/051.json
@@ -3,15 +3,15 @@
   "index": "51",
   "name": "Orphan's Halls",
   "edition": "fh",
-  "unlocks": [
-    "58",
-    "59"
-  ],
   "forcedLinks": [
     "58",
     "59"
   ],
   "rewards": {
+    "chooseLocation": [
+      "58",
+      "59"
+    ],
     "experience": 10
   },
   "monsters": [

--- a/data/fh/scenarios/055.json
+++ b/data/fh/scenarios/055.json
@@ -16,7 +16,8 @@
     "events": [
       "winter-outpost:WO-66",
       "winter-outpost:WO-67"
-    ]
+    ],
+    "custom": "Remove all %game.action.custom.fh-algox% events from all outpost event decks"
   },
   "monsters": [
     "algox-archer",

--- a/data/fh/scenarios/056.json
+++ b/data/fh/scenarios/056.json
@@ -9,7 +9,10 @@
     "campaignSticker": [
       "Friend of the Icespeakers"
     ],
-    "unlockCharacter": "fist"
+    "unlockCharacter": "fist",
+    "events": [
+      "summer-outpost:SO-51"
+    ]
   },
   "monsters": [
     "black-imp",

--- a/data/fh/scenarios/058.json
+++ b/data/fh/scenarios/058.json
@@ -8,6 +8,20 @@
   ],
   "rewards": {
     "morale": 1,
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 3
+      },
+      {
+        "type": "metal",
+        "value": 3
+      },
+      {
+        "type": "hide",
+        "value": 3
+      }
+    ],
     "campaignSticker": [
       "Unfettered Deactivated"
     ],
@@ -18,7 +32,8 @@
     "events": [
       "winter-outpost:WO-64",
       "winter-outpost:WO-65"
-    ]
+    ],
+    "custom": "Remove all %game.action.custom.fh-unfettered% events from all outpost event decks"
   },
   "monsters": [
     "flaming-bladespinner",

--- a/data/fh/scenarios/059.json
+++ b/data/fh/scenarios/059.json
@@ -17,8 +17,10 @@
       "246"
     ],
     "events": [
+      "summer-outpost:SO-49",
       "winter-outpost:WO-63"
-    ]
+    ],
+    "custom": "Remove all %game.action.custom.fh-unfettered% events from all outpost event decks"
   },
   "monsters": [
     "flaming-bladespinner",

--- a/data/fh/scenarios/060.json
+++ b/data/fh/scenarios/060.json
@@ -13,7 +13,12 @@
       "kelp"
     ],
     "experience": 30,
-    "prosperity": 1
+    "prosperity": 1,
+    "events": [
+      "summer-outpost:SO-48",
+      "boat:B-17"
+    ],
+    "custom": "Remove all %game.action.custom.fh-lurkers% events from all outpost event decks"
   },
   "monsters": [
     "fracture-of-the-deep",

--- a/data/fh/scenarios/061.json
+++ b/data/fh/scenarios/061.json
@@ -3,11 +3,11 @@
   "index": "61",
   "name": "Life and Death",
   "edition": "fh",
-  "unlocks": [
-    "62"
-  ],
   "rewards": {
-    "unlockCharacter": "shackles"
+    "unlockCharacter": "shackles",
+    "calenderSection": [
+      "140.3-1"
+    ]
   },
   "monsters": [
     "deep-terror",

--- a/data/fh/scenarios/065.json
+++ b/data/fh/scenarios/065.json
@@ -4,6 +4,16 @@
   "name": "A Strong Foundation",
   "edition": "fh",
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 2
+      },
+      {
+        "type": "metal",
+        "value": 2
+      }
+    ],
     "calenderSection": [
       "95.4-6"
     ]

--- a/data/fh/scenarios/069.json
+++ b/data/fh/scenarios/069.json
@@ -4,6 +4,20 @@
   "name": "Sacred Soil",
   "edition": "fh",
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "arrowvine",
+        "value": 1
+      },
+      {
+        "type": "axenut",
+        "value": 1
+      },
+      {
+        "type": "flamefruit",
+        "value": 1
+      }
+    ],
     "calenderSection": [
       "15.4-3"
     ]

--- a/data/fh/scenarios/074A.json
+++ b/data/fh/scenarios/074A.json
@@ -6,6 +6,9 @@
   "unlocks": [
     "76"
   ],
+  "rewards": {
+    "randomItemBlueprint": 1
+  },
   "monsters": [
     "algox-archer",
     "piranha-pig"

--- a/data/fh/scenarios/074B.json
+++ b/data/fh/scenarios/074B.json
@@ -6,6 +6,9 @@
   "unlocks": [
     "75"
   ],
+  "rewards": {
+    "randomItemBlueprint": 1
+  },
   "monsters": [
     "algox-archer"
   ],

--- a/data/fh/scenarios/077.json
+++ b/data/fh/scenarios/077.json
@@ -7,6 +7,9 @@
     "items": [
       "201"
     ],
+    "events": [
+      "boat:B-19"
+    ],
     "custom": "Threat from the Deep quest complete"
   },
   "monsters": [

--- a/data/fh/scenarios/080.json
+++ b/data/fh/scenarios/080.json
@@ -4,7 +4,21 @@
   "name": "Relic Renewed",
   "edition": "fh",
   "rewards": {
-    "morale": 2
+    "morale": 2,
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 2
+      },
+      {
+        "type": "metal",
+        "value": 2
+      },
+      {
+        "type": "hide",
+        "value": 2
+      }
+    ]
   },
   "monsters": [
     "robotic-boltshooter",

--- a/data/fh/scenarios/089.json
+++ b/data/fh/scenarios/089.json
@@ -3,6 +3,18 @@
   "index": "89",
   "name": "A Contained Fire",
   "edition": "fh",
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "rockroot",
+        "value": 2
+      },
+      {
+        "type": "lumber",
+        "value": 2
+      }
+    ]
+  },
   "monsters": [
     "algox-guard"
   ],

--- a/data/fh/scenarios/091.json
+++ b/data/fh/scenarios/091.json
@@ -4,7 +4,13 @@
   "name": "Shoreline Scramble",
   "edition": "fh",
   "rewards": {
-    "morale": 1
+    "morale": 1,
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 2
+      }
+    ]
   },
   "monsters": [
     "lightning-eel",

--- a/data/fh/scenarios/092.json
+++ b/data/fh/scenarios/092.json
@@ -3,6 +3,12 @@
   "index": "92",
   "name": "Sinking Ship",
   "edition": "fh",
+  "rewards": {
+    "calenderSection": [
+      "181.2-1"
+    ],
+    "custom": "Collectively lose 5xC/2 loot tokens (rounded down), first taken from HE-RO-IC-S' pile, then taken as evenly as possible from the characters' collected loot tokens. If any loot tokens remain in the HE-RO-IC-S pile, distribute them as evenly as possible to all characters. Loot tokens are then traded in for loot cards"
+  },
   "monsters": [
     "lurker-clawcrusher",
     "lurker-mindsnipper",

--- a/data/fh/scenarios/097.json
+++ b/data/fh/scenarios/097.json
@@ -9,6 +9,15 @@
   "forcedLinks": [
     "98"
   ],
+  "rewards": {
+    "morale": 1,
+    "collectiveResources": [
+      {
+        "type": "metal",
+        "value": 5
+      }
+    ]
+  },
   "monsters": [
     "flaming-bladespinner",
     "program-director",

--- a/data/fh/scenarios/104.json
+++ b/data/fh/scenarios/104.json
@@ -5,6 +5,12 @@
   "edition": "fh",
   "random": true,
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "snowthistle",
+        "value": 2
+      }
+    ],
     "events": [
       "winter-road:WR-49"
     ]

--- a/data/fh/scenarios/105.json
+++ b/data/fh/scenarios/105.json
@@ -4,6 +4,12 @@
   "name": "Ruins of the Equinox",
   "edition": "fh",
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "flamefruit",
+        "value": 2
+      }
+    ],
     "calenderSection": [
       "159.4-4"
     ]

--- a/data/fh/scenarios/108.json
+++ b/data/fh/scenarios/108.json
@@ -4,6 +4,10 @@
   "name": "Lustrous Pit",
   "edition": "fh",
   "random": true,
+  "rewards": {
+    "morale": 2,
+    "inspiration": 2
+  },
   "monsters": [
     "ice-wraith",
     "snow-imp"

--- a/data/fh/scenarios/109.json
+++ b/data/fh/scenarios/109.json
@@ -4,6 +4,14 @@
   "name": "Furious Factory",
   "edition": "fh",
   "random": true,
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "metal",
+        "value": 5
+      }
+    ]
+  },
   "monsters": [
     "ancient-artillery"
   ],

--- a/data/fh/scenarios/111.json
+++ b/data/fh/scenarios/111.json
@@ -4,6 +4,11 @@
   "name": "Ice Cave",
   "edition": "fh",
   "random": true,
+  "rewards": {
+    "items": [
+      "236"
+    ]
+  },
   "monsters": [
     "frost-demon",
     "hound"

--- a/data/fh/scenarios/112.json
+++ b/data/fh/scenarios/112.json
@@ -4,6 +4,9 @@
   "name": "Raised by Wolves",
   "edition": "fh",
   "random": true,
+  "rewards": {
+    "experience": 15
+  },
   "monsters": [
     "burrowing-blade",
     "earth-demon",

--- a/data/fh/scenarios/113.json
+++ b/data/fh/scenarios/113.json
@@ -3,6 +3,9 @@
   "index": "113",
   "name": "Lush Grotto",
   "edition": "fh",
+  "rewards": {
+    "custom": "Gain any 4 collective herb resources"
+  },
   "monsters": [
     "chaos-demon",
     "forest-imp"

--- a/data/fh/scenarios/114.json
+++ b/data/fh/scenarios/114.json
@@ -3,6 +3,12 @@
   "name": "Work Freeze",
   "edition": "fh",
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "hide",
+        "value": 5
+      }
+    ],
     "calenderSection": [
       "86.1-4"
     ]

--- a/data/fh/scenarios/115.json
+++ b/data/fh/scenarios/115.json
@@ -5,6 +5,9 @@
   "unlocks": [
     "116"
   ],
+  "rewards": {
+    "experience": 15
+  },
   "monsters": [
     "algox-guard",
     "algox-snowspeaker",

--- a/data/fh/scenarios/116.json
+++ b/data/fh/scenarios/116.json
@@ -3,6 +3,9 @@
   "index": "116",
   "name": "Caravan Guards",
   "edition": "fh",
+  "rewards": {
+    "custom": "Gain rewards based on the number of wagons that escaped. All rewards are cumulative.<br>1. Gain 1 morale <br>2. Gain 1 collective lumber, 1 collective metal, and 1 collective hide <br>3. Gain any 2 material resources each and 10 XP each <br> 4. Gain one random item blueprint <br> 5. Gain 1 prosperity and 2 morale"
+  },
   "monsters": [
     "algox-archer",
     "algox-guard",

--- a/data/fh/scenarios/117.json
+++ b/data/fh/scenarios/117.json
@@ -3,6 +3,15 @@
   "index": "117",
   "name": "A Waiting Game",
   "edition": "fh",
+  "rewards": {
+    "collectiveResources": [
+      {
+        "type": "hide",
+        "value": 4
+      }
+    ],
+    "gold": 10
+  },
   "monsters": [
     "hound",
     "polar-bear-scenario-117",

--- a/data/fh/scenarios/118.json
+++ b/data/fh/scenarios/118.json
@@ -3,6 +3,9 @@
   "index": "118",
   "name": "Lurker Necromancy",
   "edition": "fh",
+  "rewards": {
+    "custom": "Trade all numbered and lettered tokens in for loot cards"
+  },
   "monsters": [
     "frozen-corpse",
     "living-bones"

--- a/data/fh/scenarios/119.json
+++ b/data/fh/scenarios/119.json
@@ -3,6 +3,9 @@
   "index": "119",
   "name": "Radiant Dust",
   "edition": "fh",
+  "rewards": {
+    "custom": "Spend any remaining dust to gain the following: <br><br> Spend seven (once only): Scepter of Control Item #203 <br>Spend one: Any 1 material resource <br>Spend two: Any 1 herb resource"
+  },
   "monsters": [
     "burrowing-blade",
     "rending-drake",

--- a/data/fh/scenarios/120.json
+++ b/data/fh/scenarios/120.json
@@ -6,6 +6,18 @@
   "unlocks": [
     "121"
   ],
+  "rewards": {
+    "morale": 1,
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 2
+      }
+    ],
+    "calenderSection": [
+      "76.3-10"
+    ]
+  },
   "monsters": [
     "city-guard",
     "hound"

--- a/data/fh/scenarios/121.json
+++ b/data/fh/scenarios/121.json
@@ -3,11 +3,6 @@
   "index": "121",
   "name": "Black Memories",
   "edition": "fh",
-  "rewards": {
-    "items": [
-      "193"
-    ]
-  },
   "monsters": [
     "vermling-priest",
     "vermling-scout"

--- a/data/fh/scenarios/122.json
+++ b/data/fh/scenarios/122.json
@@ -3,6 +3,9 @@
   "index": "122",
   "name": "The Eternal Crave",
   "edition": "fh",
+  "rewards": {
+    "gold": 10
+  },
   "lootDeckConfig": {
     "money": 6,
     "lumber": 3,

--- a/data/fh/scenarios/123.json
+++ b/data/fh/scenarios/123.json
@@ -3,6 +3,10 @@
   "index": "123",
   "name": "The Titan",
   "edition": "fh",
+  "rewards": {
+    "morale": 1,
+    "inspiration": 1
+  },
   "monsters": [
     "ancient-artillery"
   ],

--- a/data/fh/scenarios/124.json
+++ b/data/fh/scenarios/124.json
@@ -6,6 +6,9 @@
   "unlocks": [
     "125"
   ],
+  "rewards": {
+    "experience": 15
+  },
   "monsters": [
     "living-bones",
     "living-spirit"

--- a/data/fh/scenarios/125.json
+++ b/data/fh/scenarios/125.json
@@ -3,6 +3,11 @@
   "index": "125",
   "name": "The Longest Second",
   "edition": "fh",
+  "rewards": {
+    "items": [
+      "194"
+    ]
+  },
   "monsters": [
     "robotic-boltshooter",
     "ruined-machine"

--- a/data/fh/scenarios/126.json
+++ b/data/fh/scenarios/126.json
@@ -3,6 +3,9 @@
   "index": "126",
   "name": "Joseph the Lion",
   "edition": "fh",
+  "rewards": {
+    "gold": 10
+  },
   "monsters": [
     "ice-wraith",
     "living-spirit",

--- a/data/fh/scenarios/127.json
+++ b/data/fh/scenarios/127.json
@@ -3,6 +3,9 @@
   "index": "127",
   "name": "Derelict Freighter",
   "edition": "fh",
+  "rewards": {
+    "custom": "Gain rewards based on the number of crates looted. Rewards are cumulative. <br><br>1: Gain 10 collective gold <br>2: Gain 2 collective lumber <br> 3: Gain Tri-Corner Hat Item #195 <br>4: Gain 1 prosperity"
+  },
   "monsters": [
     "ancient-artillery",
     "ice-wraith"

--- a/data/fh/scenarios/128.json
+++ b/data/fh/scenarios/128.json
@@ -3,9 +3,12 @@
   "index": "128",
   "name": "A Tall Drunken Tale",
   "edition": "fh",
-  "unlocks": [
-    "129"
-  ],
+  "rewards": {
+    "calenderSection": [
+      "100.3-3"
+    ],
+    "custom": "Completed seven or less embellishments: <br>Gain 1 morale <br><br>Completed eight to fifteen embellishment: <br>Gain 2 morale <br><br>Completed sixteen or more embellishments: <br>Gain 3 morale and Befuddling Mug Item #215"
+  },
   "monsters": [
     "abael-scout",
     "lurker-wavethrower-scenario-128",

--- a/data/fh/scenarios/129.json
+++ b/data/fh/scenarios/129.json
@@ -9,6 +9,10 @@
   "forcedLinks": [
     "130"
   ],
+  "rewards": {
+    "battleGoals": 1,
+    "custom": "Note the amount of remaining sun agates"
+  },
   "monsters": [
     "city-guard-scenario-129"
   ],

--- a/data/fh/scenarios/130.json
+++ b/data/fh/scenarios/130.json
@@ -3,6 +3,9 @@
   "index": "130",
   "name": "And Then, a Stream",
   "edition": "fh",
+  "rewards": {
+    "custom": "If you choose to return the sun agates to Derrick, read Section #171.5 now. <br>Otherwise, read Section #182.1 now."
+  },
   "monsters": [
     "frozen-corpse",
     "lightning-eel",

--- a/data/fh/scenarios/132.json
+++ b/data/fh/scenarios/132.json
@@ -9,6 +9,9 @@
   "forcedLinks": [
     "133"
   ],
+  "rewards": {
+    "inspiration": 1
+  },
   "monsters": [
     "ice-wraith",
     "snow-imp"

--- a/data/fh/scenarios/133.json
+++ b/data/fh/scenarios/133.json
@@ -3,6 +3,11 @@
   "index": "133",
   "name": "Bolt",
   "edition": "fh",
+  "rewards": {
+    "items": [
+      "238"
+    ]
+  },
   "monsters": [
     "forest-imp",
     "rending-drake",

--- a/data/fh/scenarios/134.json
+++ b/data/fh/scenarios/134.json
@@ -3,6 +3,11 @@
   "index": "134",
   "name": "Tower of Knowledge",
   "edition": "fh",
+  "rewards": {
+    "items": [
+      "219"
+    ]
+  },
   "monsters": [
     "flaming-bladespinner",
     "robotic-boltshooter",

--- a/data/fh/scenarios/135.json
+++ b/data/fh/scenarios/135.json
@@ -3,6 +3,14 @@
   "index": "135",
   "name": "Belara's Keep",
   "edition": "fh",
+  "rewards": {
+    "morale": 2,
+    "inspiration": 1,
+    "prosperity": 2,
+    "items": [
+      "220"
+    ]
+  },
   "monsters": [
     "earth-demon",
     "flame-demon",

--- a/data/fh/scenarios/136.json
+++ b/data/fh/scenarios/136.json
@@ -3,6 +3,12 @@
   "index": "136",
   "name": "Abandoned Hideout",
   "edition": "fh",
+  "rewards": {
+    "gold": 20,
+    "items": [
+      "245"
+    ]
+  },
   "monsters": [
     "lightning-eel",
     "lurker-wavethrower"

--- a/data/fh/scenarios/137.json
+++ b/data/fh/scenarios/137.json
@@ -3,6 +3,12 @@
   "index": "137",
   "name": "Pirate Queen's Haul",
   "edition": "fh",
+  "rewards": {
+    "morale": 3,
+    "gold": 30,
+    "prosperity": 2,
+    "custom": "Add one +1 sticker to a money loot card (the card gives one extra money token when resolved)"
+  },
   "monsters": [
     "forest-imp",
     "piranha-pig",

--- a/data/fh/sections/100-3.json
+++ b/data/fh/sections/100-3.json
@@ -1,0 +1,9 @@
+{
+  "index": "100.3",
+  "name": "Business Proposal",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "129"
+  ]
+}

--- a/data/fh/sections/108-3.json
+++ b/data/fh/sections/108-3.json
@@ -1,0 +1,11 @@
+{
+  "index": "108.3",
+  "name": "Black Memories",
+  "edition": "fh",
+  "parent": "121",
+  "parentSections": [
+    [
+      "123.1"
+    ]
+  ]
+}

--- a/data/fh/sections/114-2.json
+++ b/data/fh/sections/114-2.json
@@ -1,0 +1,13 @@
+{
+  "index": "114.2",
+  "name": "Sunless Trench",
+  "edition": "fh",
+  "conclusion": true,
+  "rewards": {
+    "chooseLocation": [
+      "49",
+      "50"
+    ],
+    "custom": "Place map overlay sticker Z on map in location Z (F2).<br>Do not resolve an outpost event this week."
+  }
+}

--- a/data/fh/sections/116-1.json
+++ b/data/fh/sections/116-1.json
@@ -8,6 +8,9 @@
       "149.4"
     ]
   ],
+  "blockedSections": [
+    "177.5"
+  ],
   "marker": "d",
   "monsters": [
     "living-bones",

--- a/data/fh/sections/123-1.json
+++ b/data/fh/sections/123-1.json
@@ -18,7 +18,9 @@
       "round": "true",
       "always": true,
       "once": true,
-      "note": "Read Section #108.3",
+      "sections": [
+        "108.3"
+      ],
       "figures": [
         {
           "identifier": {

--- a/data/fh/sections/125-4.json
+++ b/data/fh/sections/125-4.json
@@ -1,0 +1,15 @@
+{
+  "index": "125.4",
+  "name": "Disable the mind control device",
+  "edition": "fh",
+  "parent": "121",
+  "parentSections": [
+    [
+      "108.3"
+    ]
+  ],
+  "conclusion": true,
+  "rewards": {
+    "morale": 2
+  }
+}

--- a/data/fh/sections/140-3.json
+++ b/data/fh/sections/140-3.json
@@ -1,0 +1,9 @@
+{
+  "index": "140.3",
+  "name": "The Work Continues",
+  "edition": "fh",
+  "conclusion": true,
+  "rewards": {
+    "custom": "Do not turn to the next page in the puzzle book. Instead write the solution to the next puzzle on the same page"
+  }
+}

--- a/data/fh/sections/177-5.json
+++ b/data/fh/sections/177-5.json
@@ -1,0 +1,18 @@
+{
+  "index": "177.5",
+  "name": "My Private Empire",
+  "edition": "fh",
+  "parent": "107",
+  "parentSections": [
+    [
+      "150.3"
+    ]
+  ],
+  "conclusion": true,
+  "blockedSections": [
+    "116.1"
+  ],
+  "rewards": {
+    "custom": "Gain any X collective material resources, where X is the number of episodes overcome"
+  }
+}

--- a/data/fh/sections/181-2.json
+++ b/data/fh/sections/181-2.json
@@ -1,0 +1,9 @@
+{
+  "index": "181.2",
+  "name": "HE-RO-IC-S",
+  "edition": "fh",
+  "conclusion": true,
+  "rewards": {
+    "custom": "If building 88 is built, read Section #135.4 now.<br>Otherwise, read Section #33.1 now."
+  }
+}

--- a/data/fh/sections/184-2.json
+++ b/data/fh/sections/184-2.json
@@ -1,0 +1,15 @@
+{
+  "index": "184.2",
+  "name": "Destroy the automation",
+  "edition": "fh",
+  "parent": "121",
+  "parentSections": [
+    [
+      "108.3"
+    ]
+  ],
+  "conclusion": true,
+  "rewards": {
+    "custom": "If you agree to pass along the technology to the Vermling, read Section #166.5 now. <br>Otherwise read Section #9.2 now."
+  }
+}

--- a/data/fh/sections/188-3.json
+++ b/data/fh/sections/188-3.json
@@ -1,0 +1,18 @@
+{
+  "index": "188.3",
+  "name": "My Private Empire",
+  "edition": "fh",
+  "parent": "107",
+  "parentSections": [
+    [
+      "116.1"
+    ]
+  ],
+  "conclusion": true,
+  "rewards": {
+    "items": [
+      "214"
+    ],
+    "custom": "Gain any 5 collective material resources"
+  }
+}

--- a/data/fh/sections/71-4.json
+++ b/data/fh/sections/71-4.json
@@ -10,6 +10,12 @@
   ],
   "conclusion": true,
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 3
+      }
+    ],
     "calenderSection": [
       "146.1B-5"
     ]

--- a/data/fh/sections/76-3.json
+++ b/data/fh/sections/76-3.json
@@ -1,0 +1,9 @@
+{
+  "index": "76.3",
+  "name": "Mindthief Found",
+  "edition": "fh",
+  "conclusion": true,
+  "unlocks": [
+    "121"
+  ]
+}

--- a/data/fh/sections/90-1.json
+++ b/data/fh/sections/90-1.json
@@ -10,6 +10,12 @@
   ],
   "conclusion": true,
   "rewards": {
+    "collectiveResources": [
+      {
+        "type": "lumber",
+        "value": 3
+      }
+    ],
     "campaignSticker": [
       "Friend of the Fish King"
     ],

--- a/data/fh/sections/96-3.json
+++ b/data/fh/sections/96-3.json
@@ -13,6 +13,9 @@
     "items": [
       "201"
     ],
+    "events": [
+      "boat:B-18"
+    ],
     "custom": "Threat from the Deep quest complete"
   }
 }


### PR DESCRIPTION
- Added or updated all rewards for Scenarios 1 - 137

Some exceptions:

- Multiple choice rewards pointing to different sections (set to manually Read Section XX.X or Section YY.Y for now)
- Gain X item blueprint