### PR TITLE
Swap round to open rooms 3 and 4 in gloomhaven scenario 53. Fixes #259

### DIFF
--- a/data/gh/scenarios/53.json
+++ b/data/gh/scenarios/53.json
@@ -50,14 +50,14 @@
       "round": "R == 4",
       "start": true,
       "rooms": [
-        3
+        4
       ]
     },
     {
       "round": "R == 6",
       "start": true,
       "rooms": [
-        4
+        3
       ]
     },
     {


### PR DESCRIPTION
Room 4 is 'b', opening on round 4.
Room 3 is 'c', opening on round 6.

