### PR TITLE
Updated some scenario and unlock rules

### DIFF
--- a/data/fh/scenarios/083.json
+++ b/data/fh/scenarios/083.json
@@ -43,7 +43,8 @@
             "edition": "fh",
             "name": "giant-piranha-pig"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "1"
         },
         {
           "identifier": {

--- a/data/fh/scenarios/112.json
+++ b/data/fh/scenarios/112.json
@@ -35,7 +35,7 @@
             "edition": "fh",
             "name": "hound-scenario-112"
           },
-          "type": "dead",
+          "type": "killed",
           "value": "1"
         }
       ],

--- a/data/fh/scenarios/120.json
+++ b/data/fh/scenarios/120.json
@@ -3,9 +3,6 @@
   "index": "120",
   "name": "Under the Influence",
   "edition": "fh",
-  "unlocks": [
-    "121"
-  ],
   "rewards": {
     "morale": 1,
     "collectiveResources": [

--- a/data/fh/sections/54-1.json
+++ b/data/fh/sections/54-1.json
@@ -28,7 +28,8 @@
             "edition": "fh",
             "name": "algox-guard"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "1"
         }
       ],
       "finish": "lost"


### PR DESCRIPTION
- Changed monster `"type": "dead"` rules to `"type": "killed"` to work when "Automatic Standees" is off.
Excluded these scenarios/sections until a `"type": "killed", "value": "all"` function is added
FH scenarios/sections - 132, 102.2,  131.2, 165.2
GH scenarios - 79
JOTL scenarios - 16, 21, 23, 24
- Removed unlock from scenario 120 (unlocked via section link instead)