### PR TITLE
Updated scenario rules to work when 'automatic standees' disabled

### DIFF
--- a/data/fh/buildings.json
+++ b/data/fh/buildings.json
@@ -815,7 +815,7 @@
         "prosperityUnlock": true
     },
     {
-        "id": "8",
+        "id": "88",
         "name": "stables",
         "costs": {
             "prosperity": 2,

--- a/data/fh/scenarios/060.json
+++ b/data/fh/scenarios/060.json
@@ -87,11 +87,12 @@
         {
           "identifier": {
             "type": "monster",
-            "name": ".*",
+            "edition": "fh",
+            "name": "lurker-wavethrower-scenario-60",
             "marker": "element:fire"
           },
           "type": "killed",
-          "value": 1
+          "value": "1"
         }
       ],
       "elements": [
@@ -108,11 +109,12 @@
         {
           "identifier": {
             "type": "monster",
-            "name": ".*",
+            "edition": "fh",
+            "name": "lurker-mindsnipper-scenario-60",
             "marker": "element:ice"
           },
           "type": "killed",
-          "value": 1
+          "value": "1"
         }
       ],
       "elements": [
@@ -129,11 +131,12 @@
         {
           "identifier": {
             "type": "monster",
-            "name": ".*",
+            "edition": "fh",
+            "name": "lurker-wavethrower-scenario-60",
             "marker": "element:air"
           },
           "type": "killed",
-          "value": 1
+          "value": "1"
         }
       ],
       "elements": [
@@ -150,11 +153,12 @@
         {
           "identifier": {
             "type": "monster",
-            "name": ".*",
+            "edition": "fh",
+            "name": "lurker-mindsnipper-scenario-60",
             "marker": "element:earth"
           },
           "type": "killed",
-          "value": 1
+          "value": "1"
         }
       ],
       "elements": [
@@ -171,11 +175,12 @@
         {
           "identifier": {
             "type": "monster",
-            "name": ".*",
+            "edition": "fh",
+            "name": "lurker-clawcrusher-scenario-60",
             "marker": "element:light"
           },
           "type": "killed",
-          "value": 1
+          "value": "1"
         }
       ],
       "elements": [
@@ -192,11 +197,12 @@
         {
           "identifier": {
             "type": "monster",
-            "name": ".*",
+            "edition": "fh",
+            "name": "lurker-clawcrusher-scenario-60",
             "marker": "element:dark"
           },
           "type": "killed",
-          "value": 1
+          "value": "1"
         }
       ],
       "elements": [

--- a/data/fh/scenarios/132.json
+++ b/data/fh/scenarios/132.json
@@ -61,9 +61,19 @@
           "identifier": {
             "type": "monster",
             "edition": "fh",
-            "name": ".*"
+            "name": "ice-wraith"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
+        },
+        {
+          "identifier": {
+            "type": "monster",
+            "edition": "fh",
+            "name": "snow-imp"
+          },
+          "type": "killed",
+          "value": "all"
         }
       ]
     }

--- a/data/fh/sections/102-2.json
+++ b/data/fh/sections/102-2.json
@@ -24,7 +24,8 @@
             "edition": "fh",
             "name": "night-demon"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
         }
       ]
     },

--- a/data/fh/sections/131-2.json
+++ b/data/fh/sections/131-2.json
@@ -19,7 +19,8 @@
             "edition": "fh",
             "name": "wind-demon"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
         }
       ]
     },

--- a/data/fh/sections/165-2.json
+++ b/data/fh/sections/165-2.json
@@ -24,7 +24,8 @@
             "edition": "fh",
             "name": "frost-demon"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
         }
       ]
     }

--- a/data/gh/scenarios/57.json
+++ b/data/gh/scenarios/57.json
@@ -31,7 +31,8 @@
             "name": "city-guard",
             "marker": "2"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "1"
         }
       ],
       "spawns": [

--- a/data/gh/scenarios/79.json
+++ b/data/gh/scenarios/79.json
@@ -52,7 +52,7 @@
       "always": true,
       "once": true,
       "rooms": [
-        2
+        "2"
       ],
       "figures": [
         {

--- a/data/jotl/scenarios/16.json
+++ b/data/jotl/scenarios/16.json
@@ -74,9 +74,10 @@
           "identifier": {
             "type": "monster",
             "edition": "jotl",
-            "name": ".+"
+            "name": "rat-monstrosity"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
         }
       ]
     },
@@ -141,9 +142,10 @@
           "identifier": {
             "type": "monster",
             "edition": "jotl",
-            "name": ".+"
+            "name": "rat-monstrosity"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
         }
       ]
     },

--- a/data/jotl/scenarios/21.json
+++ b/data/jotl/scenarios/21.json
@@ -62,7 +62,8 @@
             "name": "chaos-demon",
             "marker": "3"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "1"
         },
         {
           "identifier": {

--- a/data/jotl/scenarios/23.json
+++ b/data/jotl/scenarios/23.json
@@ -25,7 +25,8 @@
             "edition": "jotl",
             "name": "rat-monstrosity"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
         }
       ],
       "spawns": [
@@ -50,14 +51,6 @@
       "round": "true",
       "start": true,
       "once": true,
-      "requiredRules": [
-        {
-          "edition": "jotl",
-          "scenario": "23",
-          "index": 0,
-          "section": false
-        }
-      ],
       "figures": [
         {
           "identifier": {
@@ -65,7 +58,8 @@
             "edition": "jotl",
             "name": "giant-viper"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
         },
         {
           "identifier": {
@@ -73,7 +67,8 @@
             "edition": "jotl",
             "name": "vermling-raider"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
         }
       ],
       "spawns": [

--- a/data/jotl/scenarios/23.json
+++ b/data/jotl/scenarios/23.json
@@ -51,6 +51,14 @@
       "round": "true",
       "start": true,
       "once": true,
+      "requiredRules": [
+        {
+          "edition": "jotl",
+          "scenario": "23",
+          "index": 0,
+          "section": false
+        }
+      ],
       "figures": [
         {
           "identifier": {

--- a/data/jotl/scenarios/24.json
+++ b/data/jotl/scenarios/24.json
@@ -44,9 +44,19 @@
           "identifier": {
             "type": "monster",
             "edition": "jotl",
-            "name": ".*"
+            "name": "black-imp"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
+        },
+        {
+          "identifier": {
+            "type": "monster",
+            "edition": "jotl",
+            "name": "chaos-demon"
+          },
+          "type": "killed",
+          "value": "all"
         }
       ],
       "spawns": [
@@ -100,7 +110,8 @@
             "edition": "jotl",
             "name": "chaos-demon"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "all"
         }
       ],
       "spawns": [

--- a/data/solo/scenarios/solo3_spellweaver.json
+++ b/data/solo/scenarios/solo3_spellweaver.json
@@ -45,7 +45,8 @@
             "name": "stone-golem",
             "marker": "c"
           },
-          "type": "dead"
+          "type": "killed",
+          "value": "1"
         }
       ]
     }


### PR DESCRIPTION
- Updated remaining FH, GH and JOTL scenarios to use new `"type": "killed", "value": "all"` instead of `"type": "dead"`
- Fixed bug in GH Scenario 79 causing freeze when room 2 opened
- Fixed number for Building 88