### PR TITLE
Fix GH Scenario 27 spawn rules and rewards

### DIFF
--- a/data/gh/scenarios/27.json
+++ b/data/gh/scenarios/27.json
@@ -28,9 +28,10 @@
     "globalAchievements": [
       "The Rift Neutralized"
     ],
+    "gold": 100,
     "prosperity": 1,
     "hints": {
-      "gold": "+100 Gold this money must immediately be spent on enhancements"
+      "gold": "This money must immediately be spent on enhancements"
     }
   },
   "monsters": [
@@ -218,7 +219,7 @@
     },
     {
       "round": "R == 10",
-      "finish": "lost"
+      "finish": "win"
     }
   ],
   "rooms": [

--- a/data/gh/scenarios/27.json
+++ b/data/gh/scenarios/27.json
@@ -219,7 +219,7 @@
     },
     {
       "round": "R == 10",
-      "finish": "win"
+      "finish": "won"
     }
   ],
   "rooms": [

--- a/data/gh/scenarios/27.json
+++ b/data/gh/scenarios/27.json
@@ -28,10 +28,9 @@
     "globalAchievements": [
       "The Rift Neutralized"
     ],
-    "gold": 100,
     "prosperity": 1,
     "hints": {
-      "gold": "This money must immediately be spent on enhancements"
+      "gold": "+100 Gold this money must immediately be spent on enhancements"
     }
   },
   "monsters": [
@@ -61,7 +60,7 @@
             "player3": "normal",
             "player4": "elite"
           },
-          "marker": "a"
+          "marker": "b"
         }
       ]
     },
@@ -80,7 +79,7 @@
       ]
     },
     {
-      "round": "R == 3 || R == 6 || R == 9",
+      "round": "R == 3 || R == 9",
       "spawns": [
         {
           "monster": {
@@ -103,7 +102,7 @@
       ]
     },
     {
-      "round": "R == 4 || R == 7",
+      "round": "R == 4",
       "spawns": [
         {
           "monster": {
@@ -126,7 +125,7 @@
       ]
     },
     {
-      "round": "R == 5 || R == 8",
+      "round": "R == 5",
       "spawns": [
         {
           "monster": {
@@ -145,6 +144,75 @@
             "player4": "elite"
           },
           "marker": "e"
+        }
+      ]
+    },
+    {
+      "round": "R == 6",
+      "spawns": [
+        {
+          "monster": {
+            "name": "frost-demon",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "sun-demon",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "c"
+        }
+      ]
+    },
+    {
+      "round": "R == 7",
+      "spawns": [
+        {
+          "monster": {
+            "name": "earth-demon",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "flame-demon",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    },
+    {
+      "round": "R == 8",
+      "spawns": [
+        {
+          "monster": {
+            "name": "night-demon",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "b"
+        },
+        {
+          "monster": {
+            "name": "wind-demon",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "c"
         }
       ]
     },


### PR DESCRIPTION
I saw that the Gloomhaven Scenario 27 Rules where not correct.
Each even round the spawn should be on b + c and each odd round on d + e

When you finished round 10 the scenario was marked as lost, but actually that's the goal to survive those 10 rounds

Also, when the reward is marked as "gold" it will be added to the player's gold amount, but in this case it has to be spent immediately and is not rewarded to the player as gold, is it possible to add a generic hint? Because the gold hint is no longer shown when the given gold is removed.