### PR TITLE
Updates to Crimson Scales scenarios 1 - 30

### DIFF
--- a/data/cs/deck/bone-archer.json
+++ b/data/cs/deck/bone-archer.json
@@ -1,0 +1,147 @@
+{
+  "name": "bone-archer",
+  "edition": "cs",
+  "abilities": [
+    {
+      "cardId": 516,
+      "initiative": 64,
+      "actions": [
+        {
+          "type": "move",
+          "value": 1,
+          "valueType": "minus"
+        },
+        {
+          "type": "attack",
+          "value": 1,
+          "valueType": "plus"
+        }
+      ]
+    },
+    {
+      "cardId": 517,
+      "initiative": 20,
+      "shuffle": true,
+      "actions": [
+        {
+          "type": "move",
+          "value": 2,
+          "valueType": "minus"
+        },
+        {
+          "type": "attack",
+          "value": 0,
+          "valueType": "plus"
+        },
+        {
+          "type": "heal",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "self",
+              "small": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "cardId": 518,
+      "initiative": 25,
+      "actions": [
+        {
+          "type": "move",
+          "value": 1,
+          "valueType": "plus"
+        },
+        {
+          "type": "attack",
+          "value": 1,
+          "valueType": "minus"
+        }
+      ]
+    },
+    {
+      "cardId": 519,
+      "initiative": 45,
+      "actions": [
+        {
+          "type": "move",
+          "value": 0,
+          "valueType": "plus"
+        },
+        {
+          "type": "attack",
+          "value": 0,
+          "valueType": "plus"
+        }
+      ]
+    },
+    {
+      "cardId": 520,
+      "initiative": 45,
+      "actions": [
+        {
+          "type": "move",
+          "value": 0,
+          "valueType": "plus"
+        },
+        {
+          "type": "attack",
+          "value": 0,
+          "valueType": "plus"
+        }
+      ]
+    },
+    {
+      "cardId": 521,
+      "initiative": 81,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "valueType": "plus"
+        }
+      ]
+    },
+    {
+      "cardId": 522,
+      "initiative": 74,
+      "actions": [
+        {
+          "type": "move",
+          "value": 0,
+          "valueType": "plus"
+        },
+        {
+          "type": "attack",
+          "value": 0,
+          "valueType": "plus"
+        }
+      ]
+    },
+    {
+      "cardId": 523,
+      "initiative": 12,
+      "shuffle": true,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        },
+        {
+          "type": "heal",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "self",
+              "small": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/cs/deck/the-cultist.json
+++ b/data/cs/deck/the-cultist.json
@@ -152,7 +152,7 @@
         },
         {
           "type": "sufferDamage",
-          "value": 1,
+          "value": 2,
           "small": true
         }
       ]
@@ -177,8 +177,8 @@
           ]
         },
         {
-          "type": "custom",
-          "value": "%data.custom.cs.the-cultist.1%",
+          "type": "sufferDamage",
+          "value": 2,
           "small": true
         }
       ]

--- a/data/cs/label-spoiler.json
+++ b/data/cs/label-spoiler.json
@@ -19,7 +19,7 @@
     "treasures": {
       "cs": {
         "4": "Recover one lost card",
-        "6": "Gdisarm all adjacent traps",
+        "6": "disarm all adjacent traps",
         "19": "generate a Wild Element",
         "43": "Refresh all spent items"
       }

--- a/data/cs/label.json
+++ b/data/cs/label.json
@@ -9,6 +9,7 @@
       "bandit-guard-hired-muscle": "Bandit Guard (Hired Muscle)",
       "black-bear": "Black Bear",
       "blood-ooze": "Blood Ooze",
+      "bone-archer": "Bone Archer",
       "brood-mother": "Brood Mother",
       "carrion-scavenger": "Carrion Scavenger",
       "cave-imp": "Cave Imp",

--- a/data/cs/monster/bone-archer.json
+++ b/data/cs/monster/bone-archer.json
@@ -1,0 +1,219 @@
+{
+  "name": "bone-archer",
+  "thumbnail": "gh-living-bones",
+  "edition": "cs",
+  "deck": "bone-archer",
+  "hidden": true,
+  "count": 10,
+  "standeeShare": "living-bones",
+  "standeeShareEdition": "gh",
+  "baseStat": {
+    "type": "normal"
+  },
+  "stats": [
+    {
+      "level": 0,
+      "health": 5,
+      "movement": 2,
+      "attack": 1,
+      "range": 3
+    },
+    {
+      "level": 1,
+      "health": 5,
+      "movement": 3,
+      "attack": 1,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "level": 2,
+      "health": 5,
+      "movement": 3,
+      "attack": 2,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "level": 3,
+      "health": 7,
+      "movement": 3,
+      "attack": 2,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "level": 4,
+      "health": 7,
+      "movement": 3,
+      "attack": 3,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "level": 5,
+      "health": 9,
+      "movement": 3,
+      "attack": 3,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "level": 6,
+      "health": 10,
+      "movement": 4,
+      "attack": 3,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "level": 7,
+      "health": 13,
+      "movement": 4,
+      "attack": 3,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 0,
+      "health": 6,
+      "movement": 4,
+      "attack": 2,
+      "range": 3
+    },
+    {
+      "type": "elite",
+      "level": 1,
+      "health": 6,
+      "movement": 4,
+      "attack": 2,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 2,
+      "health": 7,
+      "movement": 4,
+      "attack": 3,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 3,
+      "health": 10,
+      "movement": 4,
+      "attack": 3,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 4,
+      "health": 11,
+      "movement": 4,
+      "attack": 4,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 5,
+      "health": 11,
+      "movement": 4,
+      "attack": 4,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 6,
+      "health": 11,
+      "movement": 6,
+      "attack": 4,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 7,
+      "health": 14,
+      "movement": 6,
+      "attack": 4,
+      "range": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    }
+  ]
+}

--- a/data/cs/monster/cave-bear-scenario-9.json
+++ b/data/cs/monster/cave-bear-scenario-9.json
@@ -16,12 +16,8 @@
       "wound",
       "muddle",
       "poison",
-      "invisible",
-      "strengthen",
-      "regenerate",
       "chill",
       "infect",
-      "ward",
       "rupture",
       "poison_x",
       "wound_x"

--- a/data/cs/monster/living-corpse-scenario-13.json
+++ b/data/cs/monster/living-corpse-scenario-13.json
@@ -1,0 +1,239 @@
+{
+  "name": "living-corpse-scenario-13",
+  "thumbnail": "gh-living-corpse",
+  "edition": "cs",
+  "deck": "living-corpse",
+  "hidden": true,
+  "count": 6,
+  "standeeShare": "living-corpse",
+  "standeeShareEdition": "gh",
+  "baseStat": {
+    "type": "normal"
+  },
+  "stats": [
+    {
+      "level": 0,
+      "health": 5,
+      "movement": 1,
+      "attack": 3,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 1,
+      "health": 7,
+      "movement": 1,
+      "attack": 3,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 2,
+      "health": 9,
+      "movement": 1,
+      "attack": 3,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 3,
+      "health": 10,
+      "movement": 1,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 4,
+      "health": 11,
+      "movement": 2,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 5,
+      "health": 13,
+      "movement": 2,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 6,
+      "health": 14,
+      "movement": 2,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "condition",
+          "value": "poison"
+        },
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 7,
+      "health": 15,
+      "movement": 2,
+      "attack": 5,
+      "actions": [
+        {
+          "type": "condition",
+          "value": "poison"
+        },
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 0,
+      "health": 10,
+      "movement": 1,
+      "attack": 3,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 1,
+      "health": 10,
+      "movement": 1,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 2,
+      "health": 13,
+      "movement": 1,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 3,
+      "health": 13,
+      "movement": 2,
+      "attack": 5,
+      "actions": [
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 4,
+      "health": 15,
+      "movement": 2,
+      "attack": 5,
+      "actions": [
+        {
+          "type": "condition",
+          "value": "poison"
+        },
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 5,
+      "health": 17,
+      "movement": 2,
+      "attack": 6,
+      "actions": [
+        {
+          "type": "condition",
+          "value": "poison"
+        },
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 6,
+      "health": 21,
+      "movement": 2,
+      "attack": 6,
+      "actions": [
+        {
+          "type": "condition",
+          "value": "poison"
+        },
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 7,
+      "health": 25,
+      "movement": 2,
+      "attack": 6,
+      "actions": [
+        {
+          "type": "condition",
+          "value": "poison"
+        },
+        {
+          "type": "target",
+          "value": 2
+        }
+      ]
+    }
+  ]
+}

--- a/data/cs/monster/savvas-icebound.json
+++ b/data/cs/monster/savvas-icebound.json
@@ -21,14 +21,92 @@
     "special": [
       [
         {
-          "type": "custom",
-          "value": "%game.custom.scenarioBook%"
+          "type": "summon",
+          "value": "monsterStandee",
+          "valueObject": [
+            {
+              "monster": {
+                "name": "wind-demon",
+                "player2": "normal",
+                "player3": "normal",
+                "player4": "elite"
+              }
+            }
+          ],
+          "small": true
+        },
+        {
+          "type": "summon",
+          "value": "monsterStandee",
+          "valueObject": [
+            {
+              "monster": {
+                "name": "frost-demon",
+                "player2": "normal",
+                "player3": "elite",
+                "player4": "elite"
+              }
+            }
+          ],
+          "small": true
+        },
+        {
+          "type": "summon",
+          "value": "monsterStandee",
+          "valueObject": [
+            {
+              "monster": {
+                "name": "stone-golem",
+                "player2": "normal",
+                "player3": "elite",
+                "player4": "elite"
+              }
+            }
+          ],
+          "small": true
+        },
+        {
+          "type": "heal",
+          "value": 3,
+          "small": true,
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "self",
+              "small": true
+            }
+          ]
         }
       ],
       [
         {
+          "type": "attack",
+          "value": 0,
+          "valueType": "plus",
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "enemiesRange:3",
+              "small": true
+            }
+          ]
+        },
+        {
           "type": "custom",
-          "value": "%game.custom.scenarioBook%"
+          "value": "If occupying tile A2b, jump to %game.mapMarker.e% <br>If occupying tile A3a, jump to %game.mapMarker.d%",
+          "small": true
+        },
+        {
+          "type": "attack",
+          "value": 0,
+          "valueType": "plus",
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "enemiesRange:3",
+              "small": true
+            }
+          ]
         }
       ]
     ]

--- a/data/cs/scenarios/04.json
+++ b/data/cs/scenarios/04.json
@@ -32,6 +32,7 @@
         },
         {
           "name": "flaming-drake",
+          "player3": "elite",
           "player4": "elite"
         },
         {

--- a/data/cs/scenarios/05.json
+++ b/data/cs/scenarios/05.json
@@ -2,9 +2,6 @@
   "index": "5",
   "name": "Blood of the Oozes",
   "edition": "cs",
-  "unlocks": [
-    "6"
-  ],
   "rewards": {
     "partyAchievements": [
       "Ooze Destroyed"

--- a/data/cs/scenarios/06.json
+++ b/data/cs/scenarios/06.json
@@ -2,10 +2,12 @@
   "index": "6",
   "name": "Poisoned Water",
   "edition": "cs",
-  "requires": [
-    [
-      "5"
-    ]
+  "requiredAchievements": [
+    {
+      "party": [
+        "Ooze Destroyed"
+      ]
+    }
   ],
   "rewards": {
     "reputation": 2,
@@ -18,6 +20,23 @@
     "blood-ooze",
     "toxic-imp",
     "water-spirit"
+  ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "poison",
+          "scenarioEffect": true
+        }
+      ]
+    }
   ],
   "rooms": [
     {
@@ -55,6 +74,10 @@
           "name": "water-spirit",
           "player2": "normal",
           "player3": "elite",
+          "player4": "normal"
+        },
+        {
+          "name": "water-spirit",
           "player4": "elite"
         }
       ]

--- a/data/cs/scenarios/07.json
+++ b/data/cs/scenarios/07.json
@@ -3,8 +3,8 @@
   "name": "Golden Eggs",
   "edition": "cs",
   "unlocks": [
-    "10",
-    "8"
+    "8",
+    "10"
   ],
   "rewards": {
     "partyAchievements": [

--- a/data/cs/scenarios/08.json
+++ b/data/cs/scenarios/08.json
@@ -8,6 +8,11 @@
   "links": [
     "9"
   ],
+  "rewards": {
+    "items": [
+      "20"
+    ]
+  },
   "monsters": [
     "ancient-artillery",
     "living-spirit",
@@ -43,6 +48,10 @@
           "name": "living-spirit",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "living-spirit",
+          "player4": "normal"
         },
         {
           "name": "stone-golem",

--- a/data/cs/scenarios/10.json
+++ b/data/cs/scenarios/10.json
@@ -141,6 +141,21 @@
           "section": false
         }
       ]
+    },
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "discard",
+          "value": "1",
+          "scenarioEffect": true
+        }
+      ]
     }
   ],
   "rooms": [

--- a/data/cs/scenarios/12.json
+++ b/data/cs/scenarios/12.json
@@ -13,6 +13,13 @@
     "rending-drake",
     "spitting-drake"
   ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "note": "All characters consume one small item as a scenario effect"
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,
@@ -23,7 +30,7 @@
           "name": "giant-viper",
           "player2": "normal",
           "player3": "elite",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "giant-viper",
@@ -34,12 +41,17 @@
         {
           "name": "giant-viper",
           "player2": "normal",
-          "player3": "elite",
           "player4": "elite"
         },
         {
           "name": "giant-viper",
-          "player2": "normal"
+          "player2": "normal",
+          "player4": "elite"
+        },
+        {
+          "name": "giant-viper",
+          "player3": "elite",
+          "player4": "normal"
         },
         {
           "name": "rending-drake",

--- a/data/cs/scenarios/13.json
+++ b/data/cs/scenarios/13.json
@@ -2,10 +2,31 @@
   "index": "13",
   "name": "Corpse Cavern",
   "edition": "cs",
+  "rewards": {
+    "prosperity": 1,
+    "custom": "Each character gains one of the following:<br><br>\"Major Stamina Potion\" (Item 34) <br>\"Major Power Potion\" (Item 41) <br>\"Major Mana Potion\" (Item 48) <br>If there are none of these available in the shop, gain 20 gold instead"
+  },
   "monsters": [
-    "living-corpse",
+    "living-corpse-scenario-13",
     "lurker",
     "ooze"
+  ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "poison",
+          "scenarioEffect": true
+        }
+      ]
+    }
   ],
   "rooms": [
     {
@@ -14,20 +35,20 @@
       "initial": true,
       "monster": [
         {
-          "name": "living-corpse",
+          "name": "living-corpse-scenario-13",
           "type": "elite"
         },
         {
-          "name": "living-corpse",
+          "name": "living-corpse-scenario-13",
           "type": "elite"
         },
         {
-          "name": "living-corpse",
+          "name": "living-corpse-scenario-13",
           "player3": "normal",
           "player4": "normal"
         },
         {
-          "name": "living-corpse",
+          "name": "living-corpse-scenario-13",
           "player4": "elite"
         },
         {

--- a/data/cs/scenarios/14.json
+++ b/data/cs/scenarios/14.json
@@ -2,6 +2,9 @@
   "index": "14",
   "name": "Cultist Cave",
   "edition": "cs",
+  "rewards": {
+    "experience": 15
+  },
   "monsters": [
     "deep-terror",
     "living-corpse"

--- a/data/cs/scenarios/15.json
+++ b/data/cs/scenarios/15.json
@@ -5,6 +5,10 @@
   "unlocks": [
     "16"
   ],
+  "rewards": {
+    "gold": 15,
+    "custom": "Each character gains one random \"Orb\" item (1-10)"
+  },
   "monsters": [
     "cave-bear",
     "giant-viper",

--- a/data/cs/scenarios/16.json
+++ b/data/cs/scenarios/16.json
@@ -2,6 +2,10 @@
   "index": "16",
   "name": "Preto Krisanta",
   "edition": "cs",
+  "rewards": {
+    "gold": 10,
+    "custom": "One character gains one +1 enhancement to any Level 1 or X card"
+  },
   "monsters": [
     "flame-demon",
     "sun-demon"
@@ -28,13 +32,17 @@
           "name": "sun-demon",
           "player2": "normal",
           "player3": "elite",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "sun-demon",
           "player2": "normal",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "sun-demon",
+          "player4": "normal"
         }
       ]
     }

--- a/data/cs/scenarios/17.json
+++ b/data/cs/scenarios/17.json
@@ -8,6 +8,9 @@
   "links": [
     "18"
   ],
+  "rewards": {
+    "prosperity": 2
+  },
   "monsters": [
     "flame-demon",
     "frost-demon",
@@ -19,6 +22,9 @@
       "roomNumber": 1,
       "ref": "h1",
       "initial": true,
+      "treasures": [
+        6
+      ],
       "monster": [
         {
           "name": "flame-demon",

--- a/data/cs/scenarios/18.json
+++ b/data/cs/scenarios/18.json
@@ -6,8 +6,28 @@
     "20",
     "21"
   ],
+  "rewards": {
+    "custom": "Gain 100 gold each.<br>This money must be immediately spent on enhancements."
+  },
   "monsters": [
     "deep-terror"
+  ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "immobilize",
+          "scenarioEffect": true
+        }
+      ]
+    }
   ],
   "rooms": [
     {

--- a/data/cs/scenarios/19.json
+++ b/data/cs/scenarios/19.json
@@ -7,6 +7,11 @@
     "24",
     "25"
   ],
+  "rewards": {
+    "items": [
+      "48"
+    ]
+  },
   "monsters": [
     "earth-demon",
     "flame-demon",
@@ -21,6 +26,9 @@
       "roomNumber": 1,
       "ref": "i1",
       "initial": true,
+      "treasures": [
+        39
+      ],
       "monster": [
         {
           "name": "earth-demon",

--- a/data/cs/scenarios/20.json
+++ b/data/cs/scenarios/20.json
@@ -5,6 +5,18 @@
   "unlocks": [
     "22"
   ],
+  "requiredAchievements": [
+    {
+      "party": [
+        "!Fallen Lava"
+      ]
+    }
+  ],
+  "rewards": {
+    "reputation": 1,
+    "prosperity": 1,
+    "custom": "Each character gains one random \"Orb\" item (1-10)"
+  },
   "monsters": [
     "deep-terror",
     "living-spirit",

--- a/data/cs/scenarios/20.json
+++ b/data/cs/scenarios/20.json
@@ -12,6 +12,9 @@
       ]
     }
   ],
+  "links": [
+    "22"
+  ],
   "rewards": {
     "reputation": 1,
     "prosperity": 1,
@@ -37,6 +40,23 @@
       "name": "Altar",
       "health": "3x(C+L)",
       "marker": "c"
+    }
+  ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "muddle",
+          "scenarioEffect": true
+        }
+      ]
     }
   ],
   "rooms": [

--- a/data/cs/scenarios/21.json
+++ b/data/cs/scenarios/21.json
@@ -5,6 +5,14 @@
   "unlocks": [
     "27"
   ],
+  "rewards": {
+    "partyAchievements": [
+      "Fallen Lava"
+    ],
+    "items": [
+      "99"
+    ]
+  },
   "monsters": [
     "earth-demon",
     "flame-demon"
@@ -26,6 +34,10 @@
           "player4": "elite"
         },
         {
+          "name": "earth-demon",
+          "player4": "normal"
+        },
+        {
           "name": "flame-demon",
           "type": "normal"
         },
@@ -34,6 +46,10 @@
           "player2": "normal",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "flame-demon",
+          "player4": "normal"
         }
       ]
     }

--- a/data/cs/scenarios/22.json
+++ b/data/cs/scenarios/22.json
@@ -2,6 +2,9 @@
   "index": "22",
   "name": "Imp Temple",
   "edition": "cs",
+  "rewards": {
+    "custom": "Each character gains +2 gold and 2 experience for each money token looted"
+  },
   "monsters": [
     "black-imp",
     "forest-imp",
@@ -17,12 +20,20 @@
           "name": "black-imp",
           "player2": "normal",
           "player3": "elite",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "black-imp",
           "player2": "normal",
           "player3": "elite",
+          "player4": "normal"
+        },
+        {
+          "name": "black-imp",
+          "player4": "elite"
+        },
+        {
+          "name": "black-imp",
           "player4": "elite"
         },
         {

--- a/data/cs/scenarios/23.json
+++ b/data/cs/scenarios/23.json
@@ -8,6 +8,12 @@
   "links": [
     "26"
   ],
+  "rewards": {
+    "partyAchievements": [
+      "Frozen Warrior"
+    ],
+    "experience": 15
+  },
   "monsters": [
     "frozen-cadaver",
     "harrower-icecrawlers"

--- a/data/cs/scenarios/24.json
+++ b/data/cs/scenarios/24.json
@@ -8,6 +8,12 @@
   "links": [
     "26"
   ],
+  "rewards": {
+    "partyAchievements": [
+      "Frozen Warrior"
+    ],
+    "custom": "Each character gains one random \"Orb\" item (1-10)"
+  },
   "monsters": [
     "frozen-cadaver",
     "harrower-icecrawlers"

--- a/data/cs/scenarios/25.json
+++ b/data/cs/scenarios/25.json
@@ -5,6 +5,10 @@
   "unlocks": [
     "31"
   ],
+  "rewards": {
+    "reputation": 1,
+    "custom": "Add Road Event 57 to the deck"
+  },
   "monsters": [
     "giant-viper",
     "spitting-drake"
@@ -24,6 +28,25 @@
         {
           "type": "attack",
           "value": 1
+        },
+        {
+          "type": "element",
+          "value": "wild",
+          "valueType": "minus",
+          "subActions": [
+            {
+              "type": "heal",
+              "value": 2,
+              "small": true,
+              "subActions": [
+                {
+                  "type": "specialTarget",
+                  "value": "self",
+                  "small": true
+                }
+              ]
+            }
+          ]
         }
       ]
     }
@@ -50,12 +73,20 @@
           "name": "spitting-drake",
           "player2": "normal",
           "player3": "elite",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "spitting-drake",
           "player2": "normal",
           "player3": "elite",
+          "player4": "normal"
+        },
+        {
+          "name": "spitting-drake",
+          "player4": "elite"
+        },
+        {
+          "name": "spitting-drake",
           "player4": "elite"
         }
       ],

--- a/data/cs/scenarios/26.json
+++ b/data/cs/scenarios/26.json
@@ -2,11 +2,17 @@
   "index": "26",
   "name": "Thermal Stone Peak",
   "edition": "cs",
-  "requires": [
-    [
-      "23"
-    ]
+  "requiredAchievements": [
+    {
+      "party": [
+        "Frozen Warrior"
+      ]
+    }
   ],
+  "rewards": {
+    "experience": 20,
+    "battleGoals": 1
+  },
   "monsters": [
     "hail-demon",
     "harrower-icecrawlers"
@@ -17,6 +23,23 @@
       "health": "C+3",
       "marker": "a",
       "count": 2
+    }
+  ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "chill",
+          "scenarioEffect": true
+        }
+      ]
     }
   ],
   "rooms": [
@@ -43,6 +66,10 @@
           "player2": "normal",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "harrower-icecrawlers",
+          "player4": "normal"
         }
       ],
       "objectives": [

--- a/data/cs/scenarios/27.json
+++ b/data/cs/scenarios/27.json
@@ -5,10 +5,33 @@
   "unlocks": [
     "28"
   ],
+  "rewards": {
+    "gold": 10,
+    "items": [
+      "58"
+    ]
+  },
   "monsters": [
     "frost-demon",
     "stone-golem",
     "wind-demon"
+  ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "immobilize",
+          "scenarioEffect": true
+        }
+      ]
+    }
   ],
   "rooms": [
     {

--- a/data/cs/scenarios/28.json
+++ b/data/cs/scenarios/28.json
@@ -5,6 +5,9 @@
   "unlocks": [
     "29"
   ],
+  "rewards": {
+    "battleGoals": 1
+  },
   "monsters": [
     "living-bones",
     "ooze"
@@ -22,11 +25,12 @@
         {
           "name": "living-bones",
           "player2": "normal",
-          "player3": "normal",
+          "player3": "elite",
           "player4": "elite"
         },
         {
           "name": "living-bones",
+          "player3": "normal",
           "player4": "elite"
         },
         {

--- a/data/cs/scenarios/29.json
+++ b/data/cs/scenarios/29.json
@@ -9,21 +9,41 @@
     "30"
   ],
   "monsters": [
-    "living-bones",
+    "bone-archer",
     "living-corpse"
+  ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "amAdd",
+          "value": "curse:3",
+          "scenarioEffect": true
+        }
+      ]
+    }
   ],
   "rooms": [
     {
       "roomNumber": 1,
       "ref": "h3",
       "initial": true,
+      "treasures": [
+        3
+      ],
       "monster": [
         {
-          "name": "living-bones",
+          "name": "bone-archer",
           "type": "elite"
         },
         {
-          "name": "living-bones",
+          "name": "bone-archer",
           "player3": "elite",
           "player4": "elite"
         },

--- a/data/cs/scenarios/30.json
+++ b/data/cs/scenarios/30.json
@@ -5,9 +5,29 @@
   "unlocks": [
     "32"
   ],
+  "rewards": {
+    "custom": "Make a decision: <br><br>Give the potion to Selandre (Read Section 34A) <br>Tell Selandre the potion was destroyed (Read Section 32C)"
+  },
   "monsters": [
     "living-corpse",
     "stone-golem"
+  ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "character",
+            "name": ".*"
+          },
+          "type": "gainCondition",
+          "value": "immobilize",
+          "scenarioEffect": true
+        }
+      ]
+    }
   ],
   "rooms": [
     {
@@ -27,12 +47,16 @@
           "name": "living-corpse",
           "player2": "normal",
           "player3": "elite",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "living-corpse",
           "player3": "elite",
           "player4": "normal"
+        },
+        {
+          "name": "living-corpse",
+          "player4": "elite"
         },
         {
           "name": "stone-golem",

--- a/data/cs/sections/10A.json
+++ b/data/cs/sections/10A.json
@@ -3,6 +3,12 @@
   "name": "Rescue Mission",
   "edition": "cs",
   "parent": "9",
+  "parentSections": [
+    [
+      "8C"
+    ]
+  ],
+  "marker": "1",
   "monsters": [
     "ancient-artillery",
     "city-archer",
@@ -49,6 +55,10 @@
           "player4": "normal"
         },
         {
+          "name": "city-archer",
+          "player4": "normal"
+        },
+        {
           "name": "city-guard",
           "type": "normal"
         },
@@ -64,6 +74,10 @@
           "name": "city-guard",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "city-guard",
+          "player4": "normal"
         }
       ]
     }

--- a/data/cs/sections/11B.json
+++ b/data/cs/sections/11B.json
@@ -3,6 +3,12 @@
   "name": "Rescue Mission",
   "edition": "cs",
   "parent": "9",
+  "parentSections": [
+    [
+      "10A"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "ancient-artillery",
     "city-archer",

--- a/data/cs/sections/12A.json
+++ b/data/cs/sections/12A.json
@@ -8,6 +8,54 @@
     "black-imp",
     "lurker"
   ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Supply Crate"
+          },
+          "type": "killed",
+          "value": "3"
+        }
+      ],
+      "disableRules": [
+        {
+          "edition": "cs",
+          "scenario": "10",
+          "index": 2,
+          "section": false
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Supply Crate"
+          },
+          "type": "killed",
+          "value": "4"
+        }
+      ],
+      "disableRules": [
+        {
+          "edition": "cs",
+          "scenario": "10",
+          "index": 3,
+          "section": false
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 2,
@@ -28,6 +76,7 @@
         },
         {
           "name": "black-imp",
+          "player3": "elite",
           "player4": "elite"
         },
         {

--- a/data/cs/sections/12D.json
+++ b/data/cs/sections/12D.json
@@ -17,6 +17,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        10
+      ],
       "monster": [
         {
           "name": "black-imp",

--- a/data/cs/sections/13C.json
+++ b/data/cs/sections/13C.json
@@ -3,6 +3,11 @@
   "name": "Voyage Abound",
   "edition": "cs",
   "parent": "11",
+  "parentSections": [
+    [
+      "13B"
+    ]
+  ],
   "monsters": [
     "flame-demon",
     "night-demon"

--- a/data/cs/sections/13E.json
+++ b/data/cs/sections/13E.json
@@ -3,6 +3,7 @@
   "name": "Uncovering the Source",
   "edition": "cs",
   "parent": "12",
+  "marker": "1",
   "monsters": [
     "flame-demon",
     "giant-viper",

--- a/data/cs/sections/14A.json
+++ b/data/cs/sections/14A.json
@@ -3,8 +3,9 @@
   "name": "Corpse Cavern",
   "edition": "cs",
   "parent": "13",
+  "marker": "1",
   "monsters": [
-    "living-corpse",
+    "living-corpse-scenario-13",
     "lurker",
     "ooze"
   ],
@@ -14,13 +15,14 @@
       "initial": true,
       "monster": [
         {
-          "name": "living-corpse",
+          "name": "living-corpse-scenario-13",
           "player2": "normal",
-          "player3": "normal",
+          "player3": "elite",
           "player4": "elite"
         },
         {
-          "name": "living-corpse",
+          "name": "living-corpse-scenario-13",
+          "player3": "normal",
           "player4": "elite"
         },
         {
@@ -34,6 +36,10 @@
           "player4": "elite"
         },
         {
+          "name": "lurker",
+          "player4": "normal"
+        },
+        {
           "name": "ooze",
           "player2": "normal",
           "player3": "elite",
@@ -42,6 +48,10 @@
         {
           "name": "ooze",
           "player2": "normal",
+          "player4": "normal"
+        },
+        {
+          "name": "ooze",
           "player4": "normal"
         }
       ]

--- a/data/cs/sections/14C.json
+++ b/data/cs/sections/14C.json
@@ -3,17 +3,26 @@
   "name": "Corpse Cavern",
   "edition": "cs",
   "parent": "13",
+  "parentSections": [
+    [
+      "14A"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
-    "living-corpse",
+    "living-corpse-scenario-13",
     "lurker"
   ],
   "rooms": [
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        7
+      ],
       "monster": [
         {
-          "name": "living-corpse",
+          "name": "living-corpse-scenario-13",
           "player2": "normal",
           "player3": "normal",
           "player4": "elite"
@@ -22,17 +31,22 @@
           "name": "lurker",
           "player2": "normal",
           "player3": "elite",
-          "player4": "elite"
+          "player4": "normal"
         },
         {
           "name": "lurker",
           "player2": "normal",
           "player3": "elite",
+          "player4": "normal"
+        },
+        {
+          "name": "lurker",
+          "player2": "normal",
           "player4": "elite"
         },
         {
           "name": "lurker",
-          "player2": "normal"
+          "player4": "elite"
         }
       ]
     }

--- a/data/cs/sections/15A.json
+++ b/data/cs/sections/15A.json
@@ -3,6 +3,7 @@
   "name": "Cultist Cave",
   "edition": "cs",
   "parent": "14",
+  "marker": "1",
   "monsters": [
     "cultist-scenario-14",
     "deep-terror",

--- a/data/cs/sections/15B.json
+++ b/data/cs/sections/15B.json
@@ -3,6 +3,12 @@
   "name": "Cultist Cave",
   "edition": "cs",
   "parent": "14",
+  "parentSections": [
+    [
+      "15A"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "cultist-scenario-14",
     "deep-terror",
@@ -12,6 +18,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        8
+      ],
       "monster": [
         {
           "name": "cultist-scenario-14",

--- a/data/cs/sections/15C.json
+++ b/data/cs/sections/15C.json
@@ -3,6 +3,12 @@
   "name": "Cultist Cave",
   "edition": "cs",
   "parent": "14",
+  "parentSections": [
+    [
+      "15A"
+    ]
+  ],
+  "marker": "3",
   "monsters": [
     "cultist-scenario-14",
     "deep-terror",
@@ -12,6 +18,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        9
+      ],
       "monster": [
         {
           "name": "cultist-scenario-14",
@@ -25,6 +34,7 @@
         },
         {
           "name": "deep-terror",
+          "player3": "elite",
           "player4": "elite"
         }
       ]

--- a/data/cs/sections/17A.json
+++ b/data/cs/sections/17A.json
@@ -3,6 +3,7 @@
   "name": "Preto Krisanta",
   "edition": "cs",
   "parent": "16",
+  "marker": "2",
   "monsters": [
     "black-imp",
     "night-demon"

--- a/data/cs/sections/17C.json
+++ b/data/cs/sections/17C.json
@@ -3,6 +3,7 @@
   "name": "Preto Krisanta",
   "edition": "cs",
   "parent": "16",
+  "marker": "3",
   "monsters": [
     "black-imp",
     "night-demon"

--- a/data/cs/sections/17D.json
+++ b/data/cs/sections/17D.json
@@ -1,8 +1,14 @@
 {
   "index": "17D",
-  "name": "Scenario 16",
+  "name": "Preto Krisanta",
   "edition": "cs",
   "parent": "16",
+  "parentSections": [
+    [
+      "17A",
+      "17C"
+    ]
+  ],
   "marker": "1",
   "monsters": [
     "apex-demon"
@@ -12,6 +18,9 @@
       "roomNumber": 4,
       "ref": "c1",
       "initial": true,
+      "treasures": [
+        34
+      ],
       "monster": [
         {
           "name": "apex-demon",

--- a/data/cs/sections/18A.json
+++ b/data/cs/sections/18A.json
@@ -3,6 +3,7 @@
   "name": "Orb Extraction",
   "edition": "cs",
   "parent": "17",
+  "marker": "1",
   "monsters": [
     "frost-demon",
     "savvas-icestorm",

--- a/data/cs/sections/18B.json
+++ b/data/cs/sections/18B.json
@@ -3,6 +3,12 @@
   "name": "Grab and Go",
   "edition": "cs",
   "parent": "18",
+  "parentSections": [
+    [
+      "19C"
+    ]
+  ],
+  "marker": "3",
   "monsters": [
     "deep-terror"
   ],

--- a/data/cs/sections/18C.json
+++ b/data/cs/sections/18C.json
@@ -3,6 +3,12 @@
   "name": "Orb Extraction",
   "edition": "cs",
   "parent": "17",
+  "parentSections": [
+    [
+      "18A"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "earth-demon",
     "flame-demon"
@@ -11,6 +17,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        43
+      ],
       "monster": [
         {
           "name": "earth-demon",

--- a/data/cs/sections/19A.json
+++ b/data/cs/sections/19A.json
@@ -3,6 +3,7 @@
   "name": "Grab and Go",
   "edition": "cs",
   "parent": "18",
+  "marker": "1",
   "monsters": [
     "black-imp",
     "harrower-infester",

--- a/data/cs/sections/19C.json
+++ b/data/cs/sections/19C.json
@@ -3,6 +3,12 @@
   "name": "Grab and Go",
   "edition": "cs",
   "parent": "18",
+  "parentSections": [
+    [
+      "19A"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "black-imp",
     "harrower-infester",
@@ -12,6 +18,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        22
+      ],
       "monster": [
         {
           "name": "black-imp",

--- a/data/cs/sections/20A.json
+++ b/data/cs/sections/20A.json
@@ -3,6 +3,7 @@
   "name": "Elemental Experiments",
   "edition": "cs",
   "parent": "19",
+  "marker": "1",
   "monsters": [
     "flame-demon",
     "night-demon",

--- a/data/cs/sections/20C.json
+++ b/data/cs/sections/20C.json
@@ -3,6 +3,12 @@
   "name": "Elemental Experiments",
   "edition": "cs",
   "parent": "19",
+  "parentSections": [
+    [
+      "20A"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "earth-demon",
     "flame-demon",
@@ -16,6 +22,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        16
+      ],
       "monster": [
         {
           "name": "earth-demon",

--- a/data/cs/sections/21B.json
+++ b/data/cs/sections/21B.json
@@ -3,6 +3,7 @@
   "name": "Scenario 21",
   "edition": "cs",
   "parent": "21",
+  "marker": "1",
   "monsters": [
     "earth-demon",
     "flame-demon",
@@ -12,6 +13,10 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        4,
+        36
+      ],
       "monster": [
         {
           "name": "earth-demon",

--- a/data/cs/sections/22A.json
+++ b/data/cs/sections/22A.json
@@ -3,6 +3,7 @@
   "name": "Imp Temple",
   "edition": "cs",
   "parent": "22",
+  "marker": "2",
   "monsters": [
     "black-imp",
     "forest-imp",

--- a/data/cs/sections/22B.json
+++ b/data/cs/sections/22B.json
@@ -3,6 +3,12 @@
   "name": "Imp Temple",
   "edition": "cs",
   "parent": "22",
+  "parentSections": [
+    [
+      "23A"
+    ]
+  ],
+  "marker": "6",
   "monsters": [
     "black-imp",
     "forest-imp"
@@ -11,6 +17,9 @@
     {
       "roomNumber": 7,
       "initial": true,
+      "treasures": [
+        15
+      ],
       "monster": [
         {
           "name": "black-imp",

--- a/data/cs/sections/22C.json
+++ b/data/cs/sections/22C.json
@@ -3,6 +3,12 @@
   "name": "Imp Temple",
   "edition": "cs",
   "parent": "22",
+  "parentSections": [
+    [
+      "23A"
+    ]
+  ],
+  "marker": "5",
   "monsters": [
     "black-imp",
     "harrower-infester"

--- a/data/cs/sections/22D.json
+++ b/data/cs/sections/22D.json
@@ -3,6 +3,12 @@
   "name": "Imp Temple",
   "edition": "cs",
   "parent": "22",
+  "parentSections": [
+    [
+      "22A"
+    ]
+  ],
+  "marker": "4",
   "monsters": [
     "black-imp",
     "forest-imp"
@@ -11,6 +17,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        32
+      ],
       "monster": [
         {
           "name": "black-imp",

--- a/data/cs/sections/22E.json
+++ b/data/cs/sections/22E.json
@@ -3,6 +3,7 @@
   "name": "Imp Temple",
   "edition": "cs",
   "parent": "22",
+  "marker": "1",
   "monsters": [
     "forest-imp",
     "harrower-infester"

--- a/data/cs/sections/23A.json
+++ b/data/cs/sections/23A.json
@@ -3,6 +3,7 @@
   "name": "Imp Temple",
   "edition": "cs",
   "parent": "22",
+  "marker": "3",
   "monsters": [
     "black-imp",
     "forest-imp",

--- a/data/cs/sections/23C.json
+++ b/data/cs/sections/23C.json
@@ -3,6 +3,7 @@
   "name": "Icicle Chambers",
   "edition": "cs",
   "parent": "23",
+  "marker": "1",
   "monsters": [
     "frozen-cadaver",
     "hail-demon"
@@ -32,7 +33,6 @@
         },
         {
           "name": "frozen-cadaver",
-          "player3": "elite",
           "player4": "elite"
         },
         {
@@ -44,6 +44,10 @@
           "player2": "normal",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "hail-demon",
+          "player4": "normal"
         }
       ]
     }

--- a/data/cs/sections/24A.json
+++ b/data/cs/sections/24A.json
@@ -3,6 +3,12 @@
   "name": "Icicle Chambers",
   "edition": "cs",
   "parent": "23",
+  "parentSections": [
+    [
+      "23C"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "hail-demon",
     "harrower-icecrawlers"
@@ -11,6 +17,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        25
+      ],
       "monster": [
         {
           "name": "hail-demon",
@@ -25,7 +34,8 @@
         },
         {
           "name": "hail-demon",
-          "player3": "normal"
+          "player3": "normal",
+          "player4": "normal"
         },
         {
           "name": "harrower-icecrawlers",

--- a/data/cs/sections/24C.json
+++ b/data/cs/sections/24C.json
@@ -3,6 +3,12 @@
   "name": "Eerie Grotto",
   "edition": "cs",
   "parent": "24",
+  "parentSections": [
+    [
+      "25A"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "frozen-cadaver",
     "hail-demon"

--- a/data/cs/sections/25A.json
+++ b/data/cs/sections/25A.json
@@ -3,6 +3,7 @@
   "name": "Eerie Grotto",
   "edition": "cs",
   "parent": "24",
+  "marker": "1",
   "monsters": [
     "frozen-cadaver",
     "hail-demon"

--- a/data/cs/sections/25B.json
+++ b/data/cs/sections/25B.json
@@ -3,6 +3,12 @@
   "name": "Eerie Grotto",
   "edition": "cs",
   "parent": "24",
+  "parentSections": [
+    [
+      "24C"
+    ]
+  ],
+  "marker": "3",
   "monsters": [
     "hail-demon",
     "harrower-icecrawlers"
@@ -11,6 +17,9 @@
     {
       "roomNumber": 4,
       "initial": true,
+      "treasures": [
+        35
+      ],
       "monster": [
         {
           "name": "hail-demon",

--- a/data/cs/sections/26C.json
+++ b/data/cs/sections/26C.json
@@ -3,6 +3,7 @@
   "name": "Brightspark, Behold!",
   "edition": "cs",
   "parent": "25",
+  "marker": "1",
   "monsters": [
     "spitting-drake",
     "sun-demon"

--- a/data/cs/sections/26D.json
+++ b/data/cs/sections/26D.json
@@ -3,6 +3,7 @@
   "name": "Brightspark, Behold!",
   "edition": "cs",
   "parent": "25",
+  "marker": "3",
   "monsters": [
     "giant-viper",
     "lurker"
@@ -21,6 +22,10 @@
           "player2": "normal",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "giant-viper",
+          "player4": "normal"
         },
         {
           "name": "giant-viper",

--- a/data/cs/sections/27A.json
+++ b/data/cs/sections/27A.json
@@ -3,6 +3,7 @@
   "name": "Brightspark, Behold!",
   "edition": "cs",
   "parent": "25",
+  "marker": "2",
   "monsters": [
     "forest-imp",
     "sun-demon"

--- a/data/cs/sections/27B.json
+++ b/data/cs/sections/27B.json
@@ -3,6 +3,12 @@
   "name": "Brightspark, Behold!",
   "edition": "cs",
   "parent": "25",
+  "parentSections": [
+    [
+      "27A"
+    ]
+  ],
+  "marker": "4",
   "monsters": [
     "giant-viper",
     "lurker"

--- a/data/cs/sections/27C.json
+++ b/data/cs/sections/27C.json
@@ -1,8 +1,9 @@
 {
   "index": "27C",
-  "name": "Scenario 26",
+  "name": "Thermal Stone Peak",
   "edition": "cs",
   "parent": "26",
+  "marker": "1",
   "monsters": [
     "frozen-cadaver",
     "harrower-icecrawlers"
@@ -43,6 +44,10 @@
           "name": "harrower-icecrawlers",
           "player2": "normal",
           "player3": "elite",
+          "player4": "normal"
+        },
+        {
+          "name": "harrower-icecrawlers",
           "player4": "elite"
         }
       ],

--- a/data/cs/sections/28A.json
+++ b/data/cs/sections/28A.json
@@ -1,8 +1,14 @@
 {
   "index": "28A",
-  "name": "Scenario 26",
+  "name": "Thermal Stone Peak",
   "edition": "cs",
   "parent": "26",
+  "parentSections": [
+    [
+      "27C"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "frozen-cadaver",
     "hail-demon"
@@ -18,6 +24,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        13
+      ],
       "monster": [
         {
           "name": "frozen-cadaver",
@@ -35,6 +44,7 @@
         },
         {
           "name": "frozen-cadaver",
+          "player3": "elite",
           "player4": "elite"
         },
         {

--- a/data/cs/sections/29A.json
+++ b/data/cs/sections/29A.json
@@ -1,8 +1,9 @@
 {
   "index": "29A",
-  "name": "Scenario 27",
+  "name": "Frostbite Cavern",
   "edition": "cs",
   "parent": "27",
+  "marker": "1",
   "monsters": [
     "savvas-icebound",
     "stone-golem"

--- a/data/cs/sections/2A.json
+++ b/data/cs/sections/2A.json
@@ -1,6 +1,6 @@
 {
   "index": "2A",
-  "name": "Scenario 1",
+  "name": "The Dark Lake",
   "edition": "cs",
   "parent": "1",
   "marker": "1",
@@ -31,6 +31,10 @@
           "name": "vermling-scout",
           "player3": "elite",
           "player4": "elite"
+        },
+        {
+          "name": "vermling-scout",
+          "player4": "normal"
         },
         {
           "name": "vermling-scout",

--- a/data/cs/sections/2B.json
+++ b/data/cs/sections/2B.json
@@ -1,6 +1,6 @@
 {
   "index": "2B",
-  "name": "Scenario 1",
+  "name": "The Dark Lake",
   "edition": "cs",
   "parent": "1",
   "parentSections": [

--- a/data/cs/sections/30A.json
+++ b/data/cs/sections/30A.json
@@ -3,6 +3,7 @@
   "name": "Fountain of Bones",
   "edition": "cs",
   "parent": "28",
+  "marker": "1",
   "monsters": [
     "cultist",
     "living-bones",
@@ -19,9 +20,7 @@
         },
         {
           "name": "living-bones",
-          "player2": "normal",
-          "player3": "normal",
-          "player4": "elite"
+          "type": "normal"
         },
         {
           "name": "living-bones",
@@ -31,6 +30,7 @@
         },
         {
           "name": "living-bones",
+          "player3": "elite",
           "player4": "elite"
         },
         {

--- a/data/cs/sections/30B.json
+++ b/data/cs/sections/30B.json
@@ -1,8 +1,14 @@
 {
   "index": "30B",
-  "name": "Scenario 28",
+  "name": "Fountain of Bones",
   "edition": "cs",
   "parent": "28",
+  "parentSections": [
+    [
+      "30A"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "cultist",
     "living-bones",
@@ -19,6 +25,9 @@
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        12
+      ],
       "monster": [
         {
           "name": "cultist",

--- a/data/cs/sections/31B.json
+++ b/data/cs/sections/31B.json
@@ -3,8 +3,9 @@
   "name": "Burial Chamber",
   "edition": "cs",
   "parent": "29",
+  "marker": "1",
   "monsters": [
-    "living-bones",
+    "bone-archer",
     "living-corpse",
     "living-spirit"
   ],
@@ -14,19 +15,19 @@
       "initial": true,
       "monster": [
         {
-          "name": "living-bones",
+          "name": "bone-archer",
           "type": "elite"
         },
         {
-          "name": "living-bones",
+          "name": "bone-archer",
           "type": "elite"
         },
         {
-          "name": "living-bones",
+          "name": "bone-archer",
           "player4": "elite"
         },
         {
-          "name": "living-bones",
+          "name": "bone-archer",
           "player4": "elite"
         },
         {

--- a/data/cs/sections/31C.json
+++ b/data/cs/sections/31C.json
@@ -3,8 +3,9 @@
   "name": "Burial Chamber",
   "edition": "cs",
   "parent": "29",
+  "marker": "2",
   "monsters": [
-    "living-bones",
+    "bone-archer",
     "living-corpse"
   ],
   "rooms": [
@@ -13,11 +14,11 @@
       "initial": true,
       "monster": [
         {
-          "name": "living-bones",
+          "name": "bone-archer",
           "type": "elite"
         },
         {
-          "name": "living-bones",
+          "name": "bone-archer",
           "player3": "elite",
           "player4": "elite"
         },

--- a/data/cs/sections/32A.json
+++ b/data/cs/sections/32A.json
@@ -1,8 +1,9 @@
 {
   "index": "32A",
-  "name": "Scenario 30",
+  "name": "Undead Terrors",
   "edition": "cs",
   "parent": "30",
+  "marker": "1",
   "monsters": [
     "black-imp",
     "shadow-demon"
@@ -11,6 +12,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        38
+      ],
       "monster": [
         {
           "name": "black-imp",

--- a/data/cs/sections/32B.json
+++ b/data/cs/sections/32B.json
@@ -1,23 +1,94 @@
 {
   "index": "32B",
-  "name": "Scenario 30",
+  "name": "Undead Terrors",
   "edition": "cs",
   "parent": "30",
+  "parentSections": [
+    [
+      "32A"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "twin-corpse"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "edition": "cs",
+            "name": "twin-corpse",
+            "tags": [
+              "twin-corpse-1"
+            ]
+          },
+          "type": "killed"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "living-corpse",
+            "type": "normal"
+          },
+          "count": "C+2"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "edition": "cs",
+            "name": "twin-corpse",
+            "tags": [
+              "twin-corpse-2"
+            ]
+          },
+          "type": "killed"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "living-corpse",
+            "type": "normal"
+          },
+          "count": "C+2"
+        }
+      ]
+    }
   ],
   "rooms": [
     {
       "roomNumber": 3,
       "initial": true,
+      "treasures": [
+        17
+      ],
       "monster": [
         {
           "name": "twin-corpse",
-          "type": "boss"
+          "type": "boss",
+          "tags": [
+            "twin-corpse-1"
+          ]
         },
         {
           "name": "twin-corpse",
-          "type": "boss"
+          "type": "boss",
+          "tags": [
+            "twin-corpse-2"
+          ]
         }
       ]
     }

--- a/data/cs/sections/3A.json
+++ b/data/cs/sections/3A.json
@@ -1,6 +1,6 @@
 {
   "index": "3A",
-  "name": "Scenario 2",
+  "name": "Underground Channels",
   "edition": "cs",
   "parent": "2",
   "marker": "1",

--- a/data/cs/sections/3B.json
+++ b/data/cs/sections/3B.json
@@ -1,6 +1,6 @@
 {
   "index": "3B",
-  "name": "Scenario 2",
+  "name": "Underground Channels",
   "edition": "cs",
   "parent": "2",
   "parentSections": [
@@ -20,6 +20,9 @@
       "roomNumber": 3,
       "ref": "e1",
       "initial": true,
+      "treasures": [
+        24
+      ],
       "monster": [
         {
           "name": "deep-terror",

--- a/data/cs/sections/5A.json
+++ b/data/cs/sections/5A.json
@@ -1,6 +1,6 @@
 {
   "index": "5A",
-  "name": "Scenario ",
+  "name": "Infected Warriors",
   "edition": "cs",
   "parent": "4",
   "marker": "1",

--- a/data/cs/sections/5B.json
+++ b/data/cs/sections/5B.json
@@ -1,6 +1,6 @@
 {
   "index": "5B",
-  "name": "Scenario ",
+  "name": "Infected Warriors",
   "edition": "cs",
   "parent": "4",
   "marker": "2",

--- a/data/cs/sections/5C.json
+++ b/data/cs/sections/5C.json
@@ -1,6 +1,6 @@
 {
   "index": "5C",
-  "name": "Scenario ",
+  "name": "Infected Warriors",
   "edition": "cs",
   "parent": "4",
   "marker": "3",

--- a/data/cs/sections/7C.json
+++ b/data/cs/sections/7C.json
@@ -12,6 +12,9 @@
     {
       "roomNumber": 2,
       "initial": true,
+      "treasures": [
+        1
+      ],
       "monster": [
         {
           "name": "ancient-artillery",

--- a/data/cs/sections/8A.json
+++ b/data/cs/sections/8A.json
@@ -1,6 +1,6 @@
 {
   "index": "8A",
-  "name": "Scenario 5",
+  "name": "Blood of the Oozes",
   "edition": "cs",
   "parent": "5",
   "resetRound": "hidden",
@@ -53,6 +53,32 @@
           "value": "gelatinous-giant"
         }
       ]
+    },
+    {
+      "round": "true",
+      "always": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "edition": "cs",
+            "name": "blood-ooze",
+            "tags": [
+              "water-a"
+            ]
+          },
+          "type": "killed",
+          "value": "C"
+        }
+      ],
+      "disableRules": [
+        {
+          "edition": "cs",
+          "scenario": "8A",
+          "index": 0,
+          "section": true
+        }
+      ]
     }
   ],
   "rooms": [
@@ -60,6 +86,9 @@
       "roomNumber": 2,
       "ref": "m1",
       "initial": true,
+      "treasures": [
+        45
+      ],
       "monster": [
         {
           "name": "earth-demon",

--- a/data/fh/scenarios/026.json
+++ b/data/fh/scenarios/026.json
@@ -3,10 +3,6 @@
   "index": "26",
   "name": "Quatryl Library",
   "edition": "fh",
-  "unlocks": [
-    "36",
-    "37"
-  ],
   "blocks": [
     "25"
   ],

--- a/data/fh/scenarios/042.json
+++ b/data/fh/scenarios/042.json
@@ -2,10 +2,6 @@
   "index": "42",
   "name": "Sunless Trench",
   "edition": "fh",
-  "unlocks": [
-    "49",
-    "50"
-  ],
   "requiredAchievements": [
     {
       "buildings": [

--- a/data/fh/scenarios/068.json
+++ b/data/fh/scenarios/068.json
@@ -7,7 +7,7 @@
     "calenderSection": [
       "133.1-1"
     ],
-    "custom": "Aesther Outpost quest complete"
+    "custom": "\"Aesther Outpost\" quest complete"
   },
   "monsters": [
     "chaos-demon",

--- a/data/fh/scenarios/070.json
+++ b/data/fh/scenarios/070.json
@@ -5,7 +5,7 @@
   "edition": "fh",
   "rewards": {
     "prosperity": 1,
-    "custom": "The True Oak quest complete"
+    "custom": "\"The True Oak\" quest complete"
   },
   "monsters": [
     "city-guard",

--- a/data/fh/scenarios/077.json
+++ b/data/fh/scenarios/077.json
@@ -17,7 +17,7 @@
     "events": [
       "boat:B-19"
     ],
-    "custom": "Threat from the Deep quest complete"
+    "custom": "\"Threat from the Deep\" quest complete"
   },
   "monsters": [
     "fish-king-scenario-77",

--- a/data/fh/sections/114-2.json
+++ b/data/fh/sections/114-2.json
@@ -1,6 +1,6 @@
 {
   "index": "114.2",
-  "name": "Sunless Trench",
+  "name": "Attacking the Lurkers",
   "edition": "fh",
   "conclusion": true
 }

--- a/data/fh/sections/96-3.json
+++ b/data/fh/sections/96-3.json
@@ -16,6 +16,6 @@
     "events": [
       "boat:B-18"
     ],
-    "custom": "Threat from the Deep quest complete"
+    "custom": "\"Threat from the Deep\" quest complete"
   }
 }

--- a/data/gh/deck/living-corpse.json
+++ b/data/gh/deck/living-corpse.json
@@ -158,8 +158,8 @@
           ]
         },
         {
-          "type": "custom",
-          "value": "%data.custom.gh.living-corpse.1%",
+          "type": "sufferDamage",
+          "value": 1,
           "small": true
         }
       ]

--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -770,7 +770,7 @@
       "setPartyLocation": "Lieu de la compagnie '{0}'",
       "setPartyName": "Nom de la compagnie '{0}'",
       "setPartyNotes": "Notes de la compagnie",
-      "setPartyProperity": "Prosperité passée à {0}",
+      "setPartyProsperity": "Prosperité passée à {0}",
       "setPartyReputation": "Réputation passée à {0}",
       "setPerk": "Bénéfice {1} to {2} pour {0}",
       "setPQ": "Quête Personnelle {1} pour {0} ",


### PR DESCRIPTION
First batch of updates to the Crimson Scales scenarios.

This has been completed for Scenarios 1 - 30:
- Updated any missing section names, links and markers
- Added treasures
- Added scenario effects
- Added scenario rewards and requirements
- Added scenario special rules where needed
- Checked and updated monster counts
- Created custom Living Corpse for CS 13
- Created Bone Archer monster and deck for CS 29 and updated label
- Added CS 29 boss special abilities

Also:
- Fixed a typo in fr.json - setPartyProperity > setPartyProsperity
- Fixed a typo in label-spoiler.json
- Fixed Living Corpse and Cultist ability card to show suffer damage action
- Updated some FH scenario unlocks where calenderSection should do the unlocking
- Added missing quote marks to some FH custom rewards (didn't know you could use `\"`)