### PR TITLE
Entity menu dialog show totals and offsets

### DIFF
--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.html
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.html
@@ -98,8 +98,8 @@
         <span class="item" [ghs-label]="'game.health'" [ghs-label-attribute]="'title'">
           <span class="badge badge-left">{{data.entity.health + health}}</span>
           <img src="./assets/images/status/health.svg" />
-          <span class="badge health-count"
-            [ngClass]="{'negative-value' : health < 0, 'positive-value' : health > 0}">{{health | ghsValueSign}}</span>
+          <span class="badge badge-right health-count"
+            [ngClass]="{'negative-value' : health < 0, 'zero-value' : health == 0, 'positive-value' : health > 0}">{{health | ghsValueSign}}</span>
         </span>
         <span class="item">
           <ghs-pointer-input class="button"
@@ -120,8 +120,8 @@
           <span class="item" [ghs-label]="'game.experience'" [ghs-label-attribute]="'title'">
             <span class="badge badge-left">{{gameManager.toCharacter(data.entity).experience + experience}}</span>
             <img src="./assets/images/status/experience.svg" />
-            <span class="badge"
-                  [ngClass]="{'negative-value' : experience < 0, 'positive-value' : experience > 0}">{{experience | ghsValueSign}}</span>
+            <span class="badge badge-right"
+              [ngClass]="{'negative-value' : experience < 0, 'zero-value' : experience == 0, 'positive-value' : experience > 0}">{{experience | ghsValueSign}}</span>
           </span>
           <span class="item">
             <ghs-pointer-input class="button" (singleClick)="changeExperience(1)" [repeat]="true">
@@ -129,7 +129,6 @@
             </ghs-pointer-input>
           </span>
 
-          <!-- TODO: What is this used for? Not in character or monster dialog! If used, should augment this too? -->
           <ng-container *ngIf="!settingsManager.settings.alwaysLootDeck && !gameManager.fhRules()">
             <span class="item">
               <ghs-pointer-input class="button"
@@ -139,8 +138,10 @@
               </ghs-pointer-input>
             </span>
             <span class="item" [ghs-label]="'game.loot'" [ghs-label-attribute]="'title'">
+              <span class="badge badge-left">{{gameManager.toCharacter(data.entity).loot + loot}}</span>
               <img src="./assets/images/status/loot.svg" />
-              <span class="badge">{{loot | ghsValueSign}}</span>
+              <span class="badge badge-right"
+                [ngClass]="{'negative-value' : loot < 0, 'zero-value' : loot == 0, 'positive-value' : loot > 0}">{{loot | ghsValueSign}}</span>
             </span>
             <span class="item">
               <ghs-pointer-input class="button" (singleClick)="changeLoot(1)" [repeat]="true">
@@ -149,17 +150,18 @@
             </span>
           </ng-container>
 
-          <!-- TODO: Add total on left hand badge and make right hand badge the red/green colored offset -->
-          <!-- TODO: Why are there two sets of character tokens? -->
           <span class="item">
-            <ghs-pointer-input class="button" [ngClass]="{'disabled' : characterToken == 0}"
+            <ghs-pointer-input class="button"
+              [ngClass]="{'disabled' : gameManager.toCharacter(data.entity).token + characterToken == 0}"
               (singleClick)="changeCharacterToken(-1)" [repeat]="true">
               <img class="ghs-svg" src="./assets/images/minus.svg">
             </ghs-pointer-input>
           </span>
           <span class="item character-token" [ghs-label]="'game.character.token'" [ghs-label-attribute]="'title'">
+            <span class="badge badge-left">{{gameManager.toCharacter(data.entity).token + characterToken}}</span>
             <span [ghs-label]="'%data.characterToken.' + gameManager.toCharacter(data.entity).name + '%'"></span>
-            <span class="badge">{{characterToken}}</span>
+            <span class="badge badge-right"
+              [ngClass]="{'negative-value' : characterToken < 0, 'zero-value' : characterToken == 0, 'positive-value' : characterToken > 0}">{{characterToken | ghsValueSign}}</span>
           </span>
           <span class="item">
             <ghs-pointer-input class="button" (singleClick)="changeCharacterToken(1)" [repeat]="true">
@@ -167,20 +169,21 @@
             </ghs-pointer-input>
           </span>
 
-          <!-- TODO: Add total on left hand badge and make right hand badge the red/green colored offset -->
-          <!-- TODO: Why are there two sets of character tokens? -->
           <ng-container *ngFor="let token of gameManager.toCharacter(data.entity).tokens; let i = index;">
             <span class="item">
-              <ghs-pointer-input class="button" [ngClass]="{'disabled' : characterTokenValues[i] == 0}"
+              <ghs-pointer-input class="button"
+                [ngClass]="{'disabled' : gameManager.toCharacter(data.entity).tokenValues[i] + characterTokenValues[i] == 0}"
                 (singleClick)="changeCharacterToken(-1, i)" [repeat]="true">
                 <img class="ghs-svg" src="./assets/images/minus.svg">
               </ghs-pointer-input>
             </span>
             <span class="item character-token" [ghs-label]="'data.character.token.' + token"
               [ghs-label-attribute]="'title'">
+              <span class="badge badge-left">{{gameManager.toCharacter(data.entity).tokenValues[i] + characterTokenValues[i]}}</span>
               <span
                 [ghs-label]="'%data.characterToken.' + gameManager.toCharacter(data.entity).name + '.' + token + '%'"></span>
-              <span class="badge">{{characterTokenValues[i]}}</span>
+              <span class="badge badge-right"
+                [ngClass]="{'negative-value' : characterTokenValues[i] < 0, 'zero-value' : characterTokenValues[i] == 0, 'positive-value' : characterTokenValues[i] > 0}">{{characterTokenValues[i] | ghsValueSign}}</span>
             </span>
             <span class="item">
               <ghs-pointer-input class="button" (singleClick)="changeCharacterToken(1, i)" [repeat]="true">
@@ -202,11 +205,13 @@
           </ghs-pointer-input>
         </span>
         <span class="item">
+          <span class="badge badge-left bless-count">{{countUpcomingAttackModifier(AttackModifierType.bless) + bless}}</span>
           <span class="condition" [ghsTooltip]="'game.condition.bless.hint'" [originX]="'center'" [overlayX]="'center'"
             [originY]="'top'" [overlayY]="'bottom'" [ngClass]="{'immunity disabled' : isImmune(ConditionName.bless)}">
             <img src="./assets/images/status/bless.svg" />
           </span>
-          <span class="badge bless-count">{{countUpcomingAttackModifier(AttackModifierType.bless) + bless}}</span>
+          <span class="badge badge-right"
+            [ngClass]="{'negative-value' : bless < 0, 'zero-value' : bless == 0, 'positive-value' : bless > 0}">{{bless | ghsValueSign}}</span>
           <span class="warning-badge" *ngIf="gameManager.attackModifierManager.countUpcomingBlesses() + bless > 10">
             <img src="./assets/images/warning.svg" />
           </span>
@@ -227,11 +232,13 @@
           </ghs-pointer-input>
         </span>
         <span class="item">
+          <span class="badge badge-left curse-count">{{countUpcomingAttackModifier(AttackModifierType.curse) + curse}}</span>
           <span class="condition" [ghsTooltip]="'game.condition.curse.hint'" [originX]="'center'" [overlayX]="'center'"
             [originY]="'top'" [overlayY]="'bottom'" [ngClass]="{'immunity disabled' : isImmune(ConditionName.curse)}">
             <img src="./assets/images/status/curse.svg" />
           </span>
-          <span class="badge curse-count">{{countUpcomingAttackModifier(AttackModifierType.curse) + curse}}</span>
+          <span class="badge badge-right"
+            [ngClass]="{'negative-value' : curse < 0, 'zero-value' : curse == 0, 'positive-value' : curse > 0}">{{curse | ghsValueSign}}</span>
           <span class="warning-badge"
             *ngIf="gameManager.attackModifierManager.countUpcomingCurses(gameManager.isMonster(data.figure) && !gameManager.toMonster(data.figure).isAlly && !gameManager.toMonster(data.figure).isAllied) + curse > 10">
             <img src="./assets/images/warning.svg" />
@@ -255,11 +262,12 @@
           </span>
           <span class="item" [ghsTooltip]="'game.condition.empower.hint'" [originX]="'center'" [overlayX]="'center'"
             [originY]="'top'" [overlayY]="'bottom'">
+            <span class="badge badge-left empower-count">{{countUpcomingAttackModifier(AttackModifierType.empower) + empower}}</span>
             <span class="condition">
               <img src="./assets/images/status/empower.svg" />
             </span>
-            <span class="badge empower-count">{{countUpcomingAttackModifier(AttackModifierType.empower) +
-              empower}}</span>
+            <span class="badge badge-right"
+              [ngClass]="{'negative-value' : empower < 0, 'zero-value' : empower == 0, 'positive-value' : empower > 0}">{{empower | ghsValueSign}}</span>
             <span class="warning-badge"
               *ngIf="countUpcomingAttackModifier(AttackModifierType.empower) + empower > countAdditional(AttackModifierType.empower)">
               <img src="./assets/images/warning.svg" />
@@ -284,11 +292,12 @@
           </span>
           <span class="item" [ghsTooltip]="'game.condition.enfeeble.hint'" [originX]="'center'" [overlayX]="'center'"
             [originY]="'top'" [overlayY]="'bottom'">
+            <span class="badge badge-left enfeeble-count">{{countUpcomingAttackModifier(AttackModifierType.enfeeble) + enfeeble}}</span>
             <span class="condition">
               <img src="./assets/images/status/enfeeble.svg" />
             </span>
-            <span class="badge enfeeble-count">{{countUpcomingAttackModifier(AttackModifierType.enfeeble) +
-              enfeeble}}</span>
+            <span class="badge badge-right"
+              [ngClass]="{'negative-value' : enfeeble < 0, 'zero-value' : enfeeble == 0, 'positive-value' : enfeeble > 0}">{{enfeeble | ghsValueSign}}</span>
             <span class="warning-badge"
               *ngIf="countUpcomingAttackModifier(AttackModifierType.enfeeble) + enfeeble > countAdditional(AttackModifierType.enfeeble)">
               <img src="./assets/images/warning.svg" />
@@ -491,7 +500,7 @@
             <img class="ghs-svg" src="./assets/images/minus.svg">
           </ghs-pointer-input>
           <img src="./assets/images/status/health.svg" [ghs-label]="'game.maxHealth'" [ghs-label-attribute]="'title'" />
-          <span class="badge max-health">{{(EntityValueFunction(data.entity.maxHealth) + maxHp <
+          <span class="badge badge-right max-health">{{(EntityValueFunction(data.entity.maxHealth) + maxHp <
               EntityValueFunction(data.entity.maxHealth) || data.entity.health==(+data.entity.maxHealth) ?
               EntityValueFunction(data.entity.maxHealth) + maxHp :
               data.entity.health)}}/{{EntityValueFunction(data.entity.maxHealth) + maxHp}}</span>
@@ -518,7 +527,7 @@
         </a>
         <span class="item">
           <img src="./assets/images/status/health.svg" />
-          <span class="badge max-health">{{(EntityValueFunction(data.entity.maxHealth) + maxHp <
+          <span class="badge badge-right max-health">{{(EntityValueFunction(data.entity.maxHealth) + maxHp <
               EntityValueFunction(data.entity.maxHealth) ||
               data.entity.health==EntityValueFunction(data.entity.maxHealth) ?
               EntityValueFunction(data.entity.maxHealth) + maxHp :
@@ -541,7 +550,7 @@
         </a>
         <span class="item">
           <img src="./assets/images/status/health.svg" />
-          <span class="badge max-health">{{(EntityValueFunction(gameManager.toObjectiveContainer(data.figure).health) + maxHp <
+          <span class="badge badge-right max-health">{{(EntityValueFunction(gameManager.toObjectiveContainer(data.figure).health) + maxHp <
             EntityValueFunction(gameManager.toObjectiveContainer(data.figure).health) ||
             data.entity.health==EntityValueFunction(gameManager.toObjectiveContainer(data.figure).health) ?
             EntityValueFunction(gameManager.toObjectiveContainer(data.figure).health) + maxHp :
@@ -582,7 +591,7 @@
         </a>
         <span class="item" [ghs-label]="'game.maxHealth'" [ghs-label-attribute]="'title'">
           <img src="./assets/images/status/health.svg" />
-          <span class="badge max-health">{{(EntityValueFunction(data.entity.maxHealth) + maxHp <
+          <span class="badge badge-right max-health">{{(EntityValueFunction(data.entity.maxHealth) + maxHp <
               EntityValueFunction(data.entity.maxHealth) ||
               data.entity.health==EntityValueFunction(data.entity.maxHealth) ?
               EntityValueFunction(data.entity.maxHealth) + maxHp :
@@ -602,7 +611,7 @@
         </a>
         <span class="item">
           <img src="./assets/images/status/health.svg" />
-          <span class="badge max-health">{{(EntityValueFunction(data.entity.maxHealth) + maxHp <
+          <span class="badge badge-right max-health">{{(EntityValueFunction(data.entity.maxHealth) + maxHp <
               EntityValueFunction(data.entity.maxHealth) ||
               data.entity.health==EntityValueFunction(data.entity.maxHealth) ?
               EntityValueFunction(data.entity.maxHealth) + maxHp :
@@ -618,7 +627,7 @@
         </a>
         <span class="item">
           <img class="ghs-svg" src="./assets/images/action/move.svg" />
-          <span class="badge" [value-calc]="gameManager.toSummon(data.entity).movement + movement"
+          <span class="badge badge-right" [value-calc]="gameManager.toSummon(data.entity).movement + movement"
             [empty]="true">></span>
         </span>
         <a class="button" (click)="changeMovement(1)">
@@ -631,9 +640,9 @@
         </a>
         <span class="item">
           <img class="ghs-svg" src="./assets/images/action/attack.svg" />
-          <span class="badge" *ngIf="gameManager.toSummon(data.entity).attack != 'X'"
+          <span class="badge badge-right" *ngIf="gameManager.toSummon(data.entity).attack != 'X'"
             [value-calc]="+gameManager.toSummon(data.entity).attack + attack" [empty]="true"></span>
-          <span class="badge" *ngIf="gameManager.toSummon(data.entity).attack == 'X'">X</span>
+          <span class="badge badge-right" *ngIf="gameManager.toSummon(data.entity).attack == 'X'">X</span>
         </span>
         <a class="button" (click)="changeAttack(1)"
           [ngClass]="{'disabled' : gameManager.toSummon(data.entity).attack == 'X'}">
@@ -646,7 +655,7 @@
         </a>
         <span class="item">
           <img class="ghs-svg" src="./assets/images/action/range.svg" />
-          <span class="badge" [value-calc]="gameManager.toSummon(data.entity).range + range" [empty]="true">></span>
+          <span class="badge badge-right" [value-calc]="gameManager.toSummon(data.entity).range + range" [empty]="true">></span>
         </span>
         <a class="button" (click)="changeRange(1)">
           <img class="ghs-svg" src="./assets/images/plus.svg">

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.html
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.html
@@ -90,11 +90,13 @@
       <ng-container
         *ngIf="data.entity && EntityValueFunction(data.entity.maxHealth) > 0 && (!gameManager.isMonster(data.figure) || !gameManager.toMonster(data.figure).immortal)">
         <span class="item">
-          <ghs-pointer-input class="button" (singleClick)="changeHealth(-1)" [repeat]="true">
+          <ghs-pointer-input class="button" [ngClass]="{'disabled' : data.entity.health + health == 0}"
+           (singleClick)="changeHealth(-1)" [repeat]="true">
             <img class="ghs-svg" src="./assets/images/minus.svg">
           </ghs-pointer-input>
         </span>
         <span class="item" [ghs-label]="'game.health'" [ghs-label-attribute]="'title'">
+          <span class="badge badge-left">{{data.entity.health + health}}</span>
           <img src="./assets/images/status/health.svg" />
           <span class="badge health-count"
             [ngClass]="{'negative-value' : health < 0, 'positive-value' : health > 0}">{{health | ghsValueSign}}</span>
@@ -116,8 +118,10 @@
             </ghs-pointer-input>
           </span>
           <span class="item" [ghs-label]="'game.experience'" [ghs-label-attribute]="'title'">
+            <span class="badge badge-left">{{gameManager.toCharacter(data.entity).experience + experience}}</span>
             <img src="./assets/images/status/experience.svg" />
-            <span class="badge">{{experience | ghsValueSign}}</span>
+            <span class="badge"
+                  [ngClass]="{'negative-value' : experience < 0, 'positive-value' : experience > 0}">{{experience | ghsValueSign}}</span>
           </span>
           <span class="item">
             <ghs-pointer-input class="button" (singleClick)="changeExperience(1)" [repeat]="true">
@@ -125,6 +129,7 @@
             </ghs-pointer-input>
           </span>
 
+          <!-- TODO: What is this used for? Not in character or monster dialog! If used, should augment this too? -->
           <ng-container *ngIf="!settingsManager.settings.alwaysLootDeck && !gameManager.fhRules()">
             <span class="item">
               <ghs-pointer-input class="button"
@@ -144,6 +149,8 @@
             </span>
           </ng-container>
 
+          <!-- TODO: Add total on left hand badge and make right hand badge the red/green colored offset -->
+          <!-- TODO: Why are there two sets of character tokens? -->
           <span class="item">
             <ghs-pointer-input class="button" [ngClass]="{'disabled' : characterToken == 0}"
               (singleClick)="changeCharacterToken(-1)" [repeat]="true">
@@ -160,6 +167,8 @@
             </ghs-pointer-input>
           </span>
 
+          <!-- TODO: Add total on left hand badge and make right hand badge the red/green colored offset -->
+          <!-- TODO: Why are there two sets of character tokens? -->
           <ng-container *ngFor="let token of gameManager.toCharacter(data.entity).tokens; let i = index;">
             <span class="item">
               <ghs-pointer-input class="button" [ngClass]="{'disabled' : characterTokenValues[i] == 0}"

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.scss
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.scss
@@ -201,17 +201,22 @@
 
   .badge {
     position: absolute;
-    right: 0;
     bottom: 0;
     color: var(--ghs-color-white);
     font-size: calc(var(--ghs-unit) * 2.5 * var(--ghs-dialog-factor));
     text-shadow: var(--ghs-outline);
     text-align: center;
 
-    // TODO make this nicer and/or fit more appropriately
     &.badge-left {
       left: 0;
-      right: auto;  // TODO horrible, horrible override of immediate parent style
+    }
+
+    &.badge-right {
+      right: 0;
+    }
+
+    &.zero-value {
+      visibility: hidden;
     }
   }
 

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.scss
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.scss
@@ -207,6 +207,12 @@
     font-size: calc(var(--ghs-unit) * 2.5 * var(--ghs-dialog-factor));
     text-shadow: var(--ghs-outline);
     text-align: center;
+
+    // TODO make this nicer and/or fit more appropriately
+    &.badge-left {
+      left: 0;
+      right: auto;  // TODO horrible, horrible override of immediate parent style
+    }
   }
 
   .warning-badge {

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
@@ -72,9 +72,8 @@ export class EntityMenuDialogComponent {
   constructor(@Inject(DIALOG_DATA) public data: { entity: Entity | undefined, figure: Figure, positionElement: ElementRef }, private changeDetectorRef: ChangeDetectorRef, private dialogRef: DialogRef, private dialog: Dialog, private overlay: Overlay) {
     if (data.entity instanceof Character) {
       this.conditionType = 'character';
-      this.characterToken = data.entity.token;
       for (let index = 0; index < data.entity.tokens.length; index++) {
-        this.characterTokenValues[index] = data.entity.tokenValues[index] || 0;
+        this.characterTokenValues[index] = 0;
       }
 
       if (data.entity.identities && data.entity.identities.length > 1 && settingsManager.settings.characterIdentities) {
@@ -666,23 +665,25 @@ export class EntityMenuDialogComponent {
         gameManager.stateManager.after();
       }
 
-      if (this.characterToken != this.data.entity.token) {
-        gameManager.stateManager.before("setCharacterToken", "data.character." + this.data.entity.name, '' + this.characterToken);
-        this.data.entity.token = this.characterToken;
-        if (this.data.entity.token < 0) {
-          this.data.entity.token = 0;
+      if (this.characterToken != 0) {
+        let token = this.data.entity.token + this.characterToken;
+        if (token < 0) {
+          token = 0;
         }
+        gameManager.stateManager.before("setCharacterToken", "data.character." + this.data.entity.name, '' + token);
+        this.data.entity.token = token;
         this.characterToken = 0;
         gameManager.stateManager.after();
       }
 
       for (let index = 0; index < this.data.entity.tokens.length; index++) {
-        if (this.characterTokenValues[index] != this.data.entity.tokenValues[index]) {
-          gameManager.stateManager.before("setCharacterTokenValue", "data.character." + this.data.entity.name, this.data.entity.tokens[index], '' + this.characterTokenValues[index]);
-          this.data.entity.tokenValues[index] = this.characterTokenValues[index];
-          if (this.data.entity.tokenValues[index] < 0) {
-            this.data.entity.tokenValues[index] = 0;
+        if (this.characterTokenValues[index] != 0) {
+          let tokenValue = this.data.entity.tokenValues[index] + this.characterTokenValues[index];
+          if (tokenValue < 0) {
+            tokenValue = 0;
           }
+          gameManager.stateManager.before("setCharacterTokenValue", "data.character." + this.data.entity.name, this.data.entity.tokens[index], '' + tokenValue);
+          this.data.entity.tokenValues[index] = tokenValue;
           this.characterTokenValues[index] = 0;
           gameManager.stateManager.after();
         }


### PR DESCRIPTION
**Problem statement**
The current entity menu dialog doesn't show your resulting totals, which can result in taking damage that exhausts you. To recover, you have to undo the damage via Undo or remember the HP you had before taking the damage.

**Proposed solution**
Based on the chosen offset that will be applied when the dialog closes, show the resulting total too. For HP, you should notice that you go down to zero before closing the dialog. For consistency, do the same for all counted items: health, XP, GH coins, class token, character resource tokens, bless, curse, empower and enfeeble.

**Concerns and Notes**
The totals and offsets are a bit too close to some icons, especially when the values are two digits. I wasn't sure how radical you wanted to change things, but I'm happy to add some extra horizontal spacing.

You seem to be pretty active, so I wanted to get this PR on your radar. But that meant I ran out of time before looking into how to test Empower and Enfeeble items. Also, I wanted going down to zero total HP to show the ZZZ icon for characters and the Skull icon for other figures.

Lastly, I tried to follow your established style, but please feel free to ask for any changes, no matter how trivial.

**Example UI**
<img src="https://github.com/Lurkars/gloomhavensecretariat/assets/7015158/73f2dcad-a305-401a-8b53-9e2b20bbcfce" width="400px">
