### PR TITLE
Fix Actions for GH Scenario 72

### DIFF
--- a/data/gh/scenarios/72.json
+++ b/data/gh/scenarios/72.json
@@ -117,7 +117,8 @@
           "identifier": {
             "type": "objective",
             "edition": "objective",
-            "name": "Tree A"
+            "name": "Tree",
+            "marker": "a"
           },
           "type": "present"
         }
@@ -141,7 +142,8 @@
           "identifier": {
             "type": "objective",
             "edition": "objective",
-            "name": "Tree B"
+            "name": "Tree",
+            "marker": "b"
           },
           "type": "present"
         }
@@ -165,7 +167,8 @@
           "identifier": {
             "type": "objective",
             "edition": "objective",
-            "name": "Tree C"
+            "name": "Tree",
+            "marker": "c"
           },
           "type": "present"
         }


### PR DESCRIPTION
Currently, only the first 3 rounds are working, the next 3 never show the scenario action.
This fixes this issue and shows the action on all 6 rounds