### PR TITLE
Add Log Server Messages debug setting

### DIFF
--- a/src/app/game/businesslogic/SettingsManager.ts
+++ b/src/app/game/businesslogic/SettingsManager.ts
@@ -532,6 +532,11 @@ export class SettingsManager {
     this.storeSettings();
   }
 
+  setLogServerMessages(logServerMessages: boolean) {
+    this.settings.logServerMessages = logServerMessages;
+    this.storeSettings();
+  }
+
   setLootDeck(lootDeck: boolean) {
     this.settings.lootDeck = lootDeck;
     this.storeSettings();

--- a/src/app/game/model/Settings.ts
+++ b/src/app/game/model/Settings.ts
@@ -86,6 +86,7 @@ export class Settings {
   initiativeRequired: boolean = true;
   interactiveAbilities: boolean = true;
   locale: string = "en";
+  logServerMessages: boolean = false;
   lootDeck: boolean = true;
   maxUndo: number = 100;
   portraitMode: boolean = true;

--- a/src/app/ui/header/menu/debug/debug.html
+++ b/src/app/ui/header/menu/debug/debug.html
@@ -34,6 +34,13 @@
   <div class="line">
     <a (click)="settingsManager.validateEditionData()"><span [ghs-label]="'tools.validateEditionData'"></span></a>
   </div>
+  <div class="line">
+    <label>
+      <input type="checkbox" [checked]="settingsManager.settings.logServerMessages"
+             (change)="settingsManager.setLogServerMessages(!settingsManager.settings.logServerMessages)">
+      <span [ghs-label]="'settings.debug.logServerMessages'"></span>
+    </label>
+  </div>
   <div class="separator"></div>
   <div class="line">
     <a [routerLink]="'/'"><span [ghs-label]="'tools.backToGhs'"></span></a>

--- a/src/assets/locales/de.json
+++ b/src/assets/locales/de.json
@@ -1596,7 +1596,8 @@
     "debug": {
       ".": "Debug Einstellung/Werkzeuge",
       "hint": "",
-      "rightClick": "Rechtsklick immer erlauben"
+      "rightClick": "Rechtsklick immer erlauben",
+      "logServerMessages": "Servermeldungen protokollieren"
     },
     "disableAnimations": {
       ".": "Animationen deaktivieren",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1744,7 +1744,8 @@
     "conditions": "Conditions/Elements",
     "debug": {
       ".": "Debug Settings/Tools",
-      "rightClick": "Always enable Right-Click"
+      "rightClick": "Always enable Right-Click",
+      "logServerMessages": "Log Server Messages"
     },
     "disableAnimations": {
       ".": "Disable Animations",

--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -582,7 +582,8 @@
     "calculateStats": "Ajouter les valeurs des stats aux capacités",
     "debug": {
       ".": "Paramètres de debug/instruments",
-      "rightClick": "Toujour activer le clic droit"
+      "rightClick": "Toujour activer le clic droit",
+      "logServerMessages": "Messages du serveur de journalisation"
     },
     "disableAnimations": "Désactiver les animations",
     "disableColumns": "Désactiver affichage en colonnes",

--- a/src/assets/locales/ko.json
+++ b/src/assets/locales/ko.json
@@ -1508,7 +1508,8 @@
     "conditions": "상태/원소",
     "debug": {
       ".": "디버그 설정/도구",
-      "rightClick": "항상 오른쪽 클릭 활성화"
+      "rightClick": "항상 오른쪽 클릭 활성화",
+      "logServerMessages": "로그 서버 메시지"
     },
     "disableAnimations": {
       ".": "애니메이션 효과 비활성화",


### PR DESCRIPTION
When enabled, WebSocket activity and messages are logged to the console.

**Goal**: I want to debug two issues and this PR starts a dialogue on how you want to do this. The two issues are:

1. Actions of one client frequently overwrite the action of another client; e.g. if two clients set their initiative at the same time, it's not unusual for the second one to unset the first one.
2. The UI sometimes hard hangs for 15-45 or more seconds. It happens on desktops and mobiles and seems to be related to multiple clients in the same game at the same time. I haven't been able to reproduce it outside of our games, so we can't really debug it then.

**Proposed First Steps**: Add client logging to learn more (this PR). For goal 1, we'll learn what messages the clients are receiving and for goal 2 hopefully we'll see something that helps. Plus I think these are good debug logs to have regardless.

Note that to achieve goal 2, we might also need server side logging.

**Concerns**:

- For goal 2, we may need to capture the time it takes for the client to process each message and perhaps even the start time (to check for server/network lag). I left this out because I wanted to start the conversation before adding the bells and whistles, tho.
- I used Google Translate to get the DE/FR/KO locale strings. If you have a better method for translation, please let me know or just change them to the proper phrases.


Let me know how you want to proceed. I'm happy to make any changes to this PR, to let you import this code as a start and then extend it, or to put a hold on these changes as you already have some ideas in the works.

Thanks,
-Rick