### PR TITLE
Bug: Scenario 40 loot deck config

### DIFF
--- a/data/fh/scenarios/040.json
+++ b/data/fh/scenarios/040.json
@@ -24,7 +24,7 @@
     "lumber": 3,
     "metal": 4,
     "hide": 2,
-    "rockroot": 1,
+    "flamefruit": 1,
     "arrowvine": 2
   },
   "rooms": [


### PR DESCRIPTION
Fix loot deck for Scenario 40.

Incorrectly mentioned as rockroot when scenario book lists it as flamefruit