### PR TITLE
fix summary of solo scenarios

### DIFF
--- a/src/app/ui/footer/scenario/summary/scenario-summary.ts
+++ b/src/app/ui/footer/scenario/summary/scenario-summary.ts
@@ -246,6 +246,9 @@ export class ScenarioSummaryComponent {
                             if (this.characters.filter((char) => !char.absent).length == 1) {
                                 const char = this.characters.find((char) => !char.absent);
                                 if (char) {
+                                    if (this.items[this.characters.indexOf(char)] === undefined) {
+                                      this.items[this.characters.indexOf(char)] = [];
+                                    }
                                     this.items[this.characters.indexOf(char)].push(index);
                                 }
                             }


### PR DESCRIPTION
Hi Lukars,

yesterday I played the trapper solo scenario and the summary doesn't show up and there was an error in the browser console. It seems the error appears in all solo scenarios. I tried to fixed it in this way.

Best regards,,
Christian