### PR TITLE
Add move + 0 to Fish King Special 2

### DIFF
--- a/data/fh/monster/fish-king.json
+++ b/data/fh/monster/fish-king.json
@@ -57,6 +57,11 @@
       ],
       [
         {
+          "type": "move",
+          "value": 0,
+          "valueType": "plus"
+        },
+        {
           "type": "specialTarget",
           "value": "focusEnemyFarthest",
           "small": true,


### PR DESCRIPTION
The Fish King's Special 2 attack is missing a move + 0