### PR TITLE
fix showing mix element consuming on items

### DIFF
--- a/data/fh/items.json
+++ b/data/fh/items.json
@@ -3681,7 +3681,7 @@
       },
       {
         "type": "elementHalf",
-        "value": "earth|dark",
+        "value": "earth:dark",
         "valueType": "minus",
         "subActions": [
           {
@@ -3808,7 +3808,7 @@
       },
       {
         "type": "elementHalf",
-        "value": "ice|air",
+        "value": "ice:air",
         "valueType": "minus",
         "subActions": [
           {
@@ -3914,7 +3914,7 @@
       },
       {
         "type": "elementHalf",
-        "value": "fire|light",
+        "value": "fire:light",
         "valueType": "minus",
         "subActions": [
           {


### PR DESCRIPTION
Hey Lukers,

with this fix the consuming of mix elements will now showing on this 3 items, in this way ...

![grafik](https://github.com/Lurkars/gloomhavensecretariat/assets/6031362/c08c5bf1-0e63-41b0-bbba-422491429f6f)

... but in my opinion it doesn't look good. Maybe later, you can also fix the UI in this case?
