### PR TITLE
fixed german translation issue in JOTL demolitionist perk

### DIFF
--- a/data/jotl/label/de.json
+++ b/data/jotl/label/de.json
@@ -320,6 +320,9 @@
         "2": "Werden sich bewegen um zu vermeiden an ihren Fokus anzugrenzen.",
         "3": "Bewegen sich diese Runde nicht.",
         "4": "Dies ist dasselbe Verhalten wie im vorherigen Szenario."
+      },
+      "demolitionist": {
+        "1": "Alle angrenzenden Gegner erleiden %game.damage:1%"
       }
     },
     "perks": {


### PR DESCRIPTION
# Description

fixed a minor german translation issue in the JOTL demolitionist perks screen:

![image](https://github.com/Lurkars/gloomhavensecretariat/assets/4655589/631c7683-88ab-4eb5-881b-76eb3b17d120)

## Type of change

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)