### PR TITLE
Fixed an issue where the drag-hp event may get cancelled on iOS devices due to accidental scrolling

### DIFF
--- a/src/app/ui/figures/character/character.scss
+++ b/src/app/ui/figures/character/character.scss
@@ -397,6 +397,7 @@
       display: flex;
       align-items: center;
       z-index: 2;
+      touch-action: none;
     }
 
     .health {

--- a/src/app/ui/figures/character/summon/summon.scss
+++ b/src/app/ui/figures/character/summon/summon.scss
@@ -1,5 +1,6 @@
 .summon-border {
   position: relative;
+  touch-action: none;
   height: calc(var(--ghs-unit) * 7 * var(--ghs-text-factor));
 
   &::before {

--- a/src/app/ui/figures/standee/standee.scss
+++ b/src/app/ui/figures/standee/standee.scss
@@ -1,6 +1,6 @@
 .entity-border {
   position: relative;
-
+  touch-action: none;
   &:hover {
     z-index: 999;
   }


### PR DESCRIPTION
This is my attempt to finally fix #397. It seems to work on iOS based on my brief testing. I also tested that it did not seem to break anything on Safari or Chrome on a Mac. Further testing is recommended, especially on Android.

Some discussion on the solution: https://stackoverflow.com/a/43275544/3331890