### PR TITLE
Fixed HP dragging on iOS also for objectives

### DIFF
--- a/src/app/ui/figures/objective-container/objective-container.scss
+++ b/src/app/ui/figures/objective-container/objective-container.scss
@@ -126,6 +126,7 @@
       display: flex;
       align-items: center;
       z-index: 2;
+      touch-action: none;
     }
 
     .health {


### PR DESCRIPTION
The previous fix did not include objectives. Fixes the issue where the drag-hp event may get cancelled on iOS devices due to accidental scrolling. See #397 for details.