### PR TITLE
fix standard spawn avalability count

### DIFF
--- a/data/fh/deck/ooze.json
+++ b/data/fh/deck/ooze.json
@@ -189,6 +189,7 @@
       ]
     },
     {
+      "name": "Split",
       "cardId": 872,
       "initiative": 94,
       "shuffle": true,

--- a/src/app/game/businesslogic/ActionsManager.ts
+++ b/src/app/game/businesslogic/ActionsManager.ts
@@ -419,6 +419,7 @@ export class ActionsManager {
                 let monsterStandee = new MonsterStandeeData(summonValue[0]);
                 monsterStandee.type = MonsterType.normal;
                 let monsterSpawn = new MonsterSpawnData(undefined, monsterStandee);
+                monsterSpawn.count = 1;
 
                 if (summonValue.length > 1) {
                     if (!isNaN(+summonValue[1])) {


### PR DESCRIPTION
# Description

Thex standard spawn value like "piranha-pig:normal" has spawn no monster and I add a standard spawn count of 1.

I have also fix the name of the 2nd spawn card of Oozes.

Fixes #540 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)