### PR TITLE
Fix missing morale cost for mining camp

### DIFF
--- a/data/fh/buildings.json
+++ b/data/fh/buildings.json
@@ -75,7 +75,8 @@
                 "prosperity": 1
             },
             {
-                "prosperity": 1
+                "prosperity": 1,
+                "loseMorale": 1
             }
         ],
         "prosperityUnlock": true,


### PR DESCRIPTION
# Description

Last level of mining camp should cost a morale like the hunting lodge and logging camp. [Card from any2cards for reference](https://github.com/any2cards/frosthaven/blob/09916553e161a8dd77f8fb0053e35fd7a392d85f/images/outpost-building-cards/frosthaven/fh-05-mining-camp-level-3.png).

Did a quick glance at other buildings and this seems to be the only one wrong.

Sorry for the unnecessary changed trailing newline. GitHub editor did that automatically and I'm not sure why.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)