### PR TITLE
fix geminate solo item and add one part of special rules to gemiate solo scenario

### DIFF
--- a/data/solo/label-spoiler/en.json
+++ b/data/solo/label-spoiler/en.json
@@ -288,8 +288,8 @@
             "1": "On the next three deaths of any of your summons, %game.elementHalf:earth|dark% and perform:"
         },
         "solo-253": {
-            "1": "During your ranged attack ability while in %game.characterIconIdentity.geminate.0%, gain advantage for one attack, then flip this card over.",
-            "2": "When an enemy performs an attack targeting you while you are in %game.characterIconIdentity.geminate.1%, the attacker gains disadvantage, then flip this card over."
+            "1": "During your ranged attack ability while in %game.characterIconIdentity.geminate.1%, gain advantage for one attack, then flip this card over.",
+            "2": "When an enemy performs an attack targeting you while you are in %game.characterIconIdentity.geminate.0%, the attacker gains disadvantage, then flip this card over."
         },
         "solo-254": {
             "1": "During your turn, activate all your %data.action.custom.fh-infusion% as if you just performed a %data.action.custom.fh-infusion% action."

--- a/data/solo/scenarios/solo25_geminate.json
+++ b/data/solo/scenarios/solo25_geminate.json
@@ -21,6 +21,206 @@
   "lootDeckConfig": {
     "money": 15
   },
+  "rules": [
+    {
+      "round": "true",
+      "start": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "robotic-boltshooter|lightning-eel|lurker-wavethrower|flaming-bladespinner|lurker-soldier"
+          },
+          "type": "killed",
+          "value": "1"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "lurker-wavethrower",
+            "type": "normal"
+          },
+          "marker": "D"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "robotic-boltshooter|lightning-eel|lurker-wavethrower|flaming-bladespinner|lurker-soldier"
+          },
+          "type": "killed",
+          "value": "2"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "flaming-bladespinner",
+            "type": "normal"
+          },
+          "marker": "B"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "robotic-boltshooter|lightning-eel|lurker-wavethrower|flaming-bladespinner|lurker-soldier"
+          },
+          "type": "killed",
+          "value": "3"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "lurker-wavethrower",
+            "type": "normal"
+          },
+          "marker": "F"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "robotic-boltshooter|lightning-eel|lurker-wavethrower|flaming-bladespinner|lurker-soldier"
+          },
+          "type": "killed",
+          "value": "4"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "robotic-boltshooter",
+            "type": "normal"
+          },
+          "marker": "A"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "robotic-boltshooter|lightning-eel|lurker-wavethrower|flaming-bladespinner|lurker-soldier"
+          },
+          "type": "killed",
+          "value": "5"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "robotic-boltshooter",
+            "type": "normal"
+          },
+          "marker": "C"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "robotic-boltshooter|lightning-eel|lurker-wavethrower|flaming-bladespinner|lurker-soldier"
+          },
+          "type": "killed",
+          "value": "6"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "lurker-soldier",
+            "type": "normal"
+          },
+          "marker": "E"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "robotic-boltshooter|lightning-eel|lurker-wavethrower|flaming-bladespinner|lurker-soldier"
+          },
+          "type": "killed",
+          "value": "7"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "flaming-bladespinner",
+            "type": "normal"
+          },
+          "marker": "F"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "once": true,
+      "note": "special rules of the Ice Wraiths are not implemented",
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "robotic-boltshooter|lightning-eel|lurker-wavethrower|flaming-bladespinner|lurker-soldier"
+          },
+          "type": "killed",
+          "value": "8"
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "ice-wraith",
+            "type": "normal"
+          }
+        },
+        {
+          "monster": {
+            "name": "ice-wraith",
+            "type": "elite"
+          }
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,


### PR DESCRIPTION
# Description

Fixes #573 
Semi Fixes #574 (I only implement the spawning rules for the 9 monsters following monsters, but not the special rules for 2 Ice Wraith.)

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change that fixes an issue)
- [] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)