### PR TITLE
Add missing experience reward for JotL: Scenario 10

### DIFF
--- a/data/jotl/scenarios/10.json
+++ b/data/jotl/scenarios/10.json
@@ -10,6 +10,9 @@
     "gridLocation": "E2"
   },
   "edition": "jotl",
+  "rewards": {
+    "experience": 15
+  },
   "unlocks": [
     "11",
     "12"


### PR DESCRIPTION
# Description
Scenario 10 of Jaws of the Lion is missing an experience reward

Please include a summary of the changes and the related issue. If you haven't already created an issue, please do so first.
Adds the data for the missing reward

Fixes #584 

## Type of change

Please delete options that are not relevant.
- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)