### PR TITLE
fix wrong automatism for shards 10th perk

### DIFF
--- a/src/app/game/businesslogic/RoundManager.ts
+++ b/src/app/game/businesslogic/RoundManager.ts
@@ -594,7 +594,7 @@ export class RoundManager {
         }
 
         if (figure.tags.find((tag) => tag === 'resonance_tokens') && figure.primaryToken == 0) {
-          figure.tokenValues[0] = figure.progress.perks[10] == 1 ? 3 : 1;
+          figure.tokenValues[0] = 1;
         }
 
         figure.availableSummons.filter((summonData) => summonData.special).forEach((summonData) => gameManager.characterManager.createSpecialSummon(figure, summonData));


### PR DESCRIPTION
# Description

Remove the automatism to add 2 more resonance tokens at the start of a senario, because it's optional to take brittle to get 2 more resonance tokens.

Fixes #641

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)