### PR TITLE
Retaliate typo fixes

### DIFF
--- a/data/fh/label/spoiler/de.json
+++ b/data/fh/label/spoiler/de.json
@@ -566,7 +566,7 @@
     },
     "fh-53": {
       "": "Nagelstiefel",
-      "1": "Erhalte, nachdem du dich während deines Zugs mindestens 4 Felder weit bewegt hast, %game.action,retaliate% 1 für die Runde."
+      "1": "Erhalte, nachdem du dich während deines Zugs mindestens 4 Felder weit bewegt hast, %game.action.retaliate% 1 für die Runde."
     },
     "fh-54": {
       "": "Wohlfühlschuhe",
@@ -574,7 +574,7 @@
     },
     "fh-55": {
       "": "Stachelstulpe",
-      "1": "Wenn du von einem angrenzenden Gegner angegriffen wirst, erhältst du für den Angriff %game.action,retaliate% 2."
+      "1": "Wenn du von einem angrenzenden Gegner angegriffen wirst, erhältst du für den Angriff %game.action.retaliate% 2."
     },
     "fh-56": {
       "": "Magnetsammler",
@@ -720,7 +720,7 @@
     },
     "fh-88": {
       "": "Feuerschildtrank",
-      "1": "Führe während deines Zugs aus: %game.action,retaliate% 1 %game.action.range:3% "
+      "1": "Führe während deines Zugs aus: %game.action.retaliate% 1 %game.action.range:3% "
     },
     "fh-89": {
       "": "Steinhauttrank",

--- a/data/fh/label/spoiler/en.json
+++ b/data/fh/label/spoiler/en.json
@@ -1191,7 +1191,7 @@
     },
     "fh-53": {
       "": "Hobnail Boots",
-      "1": "After you move 4 or more hexes during your turn, gain %game.action,retaliate% 1 for the round."
+      "1": "After you move 4 or more hexes during your turn, gain %game.action.retaliate% 1 for the round."
     },
     "fh-54": {
       "": "Restful Slippers",
@@ -1199,7 +1199,7 @@
     },
     "fh-55": {
       "": "Biting Gauntlet",
-      "1": "When you are attacked by an adjacent enemy, gain %game.action,retaliate% 2 for the attack."
+      "1": "When you are attacked by an adjacent enemy, gain %game.action.retaliate% 2 for the attack."
     },
     "fh-56": {
       "": "Scavenger's Magnet",
@@ -1345,7 +1345,7 @@
     },
     "fh-88": {
       "": "Fireshield Potion",
-      "1": "During your turn perform %game.action,retaliate% 1 %game.action.range:3% "
+      "1": "During your turn perform %game.action.retaliate% 1 %game.action.range:3% "
     },
     "fh-89": {
       "": "Stoneskin Potion",

--- a/data/fh/label/spoiler/es.json
+++ b/data/fh/label/spoiler/es.json
@@ -381,7 +381,7 @@
     },
     "fh-53": {
       "": "Botas de clavos",
-      "1": "Después de moverte 4 o más hexágonos durante tu turno, obtén %game.action,retaliate% 1 durante esta ronda."
+      "1": "Después de moverte 4 o más hexágonos durante tu turno, obtén %game.action.retaliate% 1 durante esta ronda."
     },
     "fh-54": {
       "": "Zapatillas de descanso",
@@ -389,7 +389,7 @@
     },
     "fh-55": {
       "": "Guantelete mordedor",
-      "1": "Cuando te ataque un enemigo adyacente, obtén %game.action,retaliate% 2 para dicho ataque."
+      "1": "Cuando te ataque un enemigo adyacente, obtén %game.action.retaliate% 2 para dicho ataque."
     },
     "fh-56": {
       "": "Imán de rapiñador",
@@ -465,7 +465,7 @@
     },
     "fh-88": {
       "": "Poción de piroescudo",
-      "1": "Durante tu turno, realiza: %game.action,retaliate% 1 %game.action.range:3% "
+      "1": "Durante tu turno, realiza: %game.action.retaliate% 1 %game.action.range:3% "
     },
     "fh-89": {
       "": "Poción de piel pétrea",

--- a/data/fh/label/spoiler/fr.json
+++ b/data/fh/label/spoiler/fr.json
@@ -1015,7 +1015,7 @@
     },
     "fh-53": {
       "": "Bottes Ferrées",
-      "1": "Après un déplacement d'au moins 4 hexagones pendant votre tour, gagnez %game.action,retaliate% 1 pour le round."
+      "1": "Après un déplacement d'au moins 4 hexagones pendant votre tour, gagnez %game.action.retaliate% 1 pour le round."
     },
     "fh-54": {
       "": "Pantoufles Reposantes",
@@ -1023,7 +1023,7 @@
     },
     "fh-55": {
       "": "Gantelet Acéré",
-      "1": "Lorsque vous êtes attaqué par un adversaire adjacent, gagnez %game.action,retaliate% 2 pour l'attaque."
+      "1": "Lorsque vous êtes attaqué par un adversaire adjacent, gagnez %game.action.retaliate% 2 pour l'attaque."
     },
     "fh-56": {
       "": "Aimant du Récupérateur",
@@ -1169,7 +1169,7 @@
     },
     "fh-88": {
       "": "Potion Bouclier-de-feu",
-      "1": "Pendant votre tour, effectuez : %game.action,retaliate% 1 %game.action.range:3% "
+      "1": "Pendant votre tour, effectuez : %game.action.retaliate% 1 %game.action.range:3% "
     },
     "fh-89": {
       "": "Potion Peau-de-pierre",


### PR DESCRIPTION
# Description
Items 53, 55 and 88 have a typo that prevents their Retaliate symbols from showing up correctly; they say "action,retaliate" instead of displaying the inline fist symbol. This PR corrects instances of this issue across english, spanish, german, and french language files.

Fixes #242 

## Type of change

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)