### PR TITLE
fix prosperity value when selecting FH

### DIFF
--- a/src/app/ui/figures/party/party-sheet-dialog.ts
+++ b/src/app/ui/figures/party/party-sheet-dialog.ts
@@ -704,7 +704,7 @@ export class PartySheetDialogComponent implements OnInit, OnDestroy {
 
     if (this.fhSheet) {
       this.prosperitySteps = FH_PROSPERITY_STEPS;
-    } if (this.gh2eSheet) {
+    } else if (this.gh2eSheet) {
       this.prosperitySteps = GH2E_PROSPERITY_STEPS;
     } else {
       this.prosperitySteps = GH_PROSPERITY_STEPS;


### PR DESCRIPTION
# Description

Fix an issue where prosperity level was using GH1ed where it should be using FH

Fixes #771 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)