### PR TITLE
Repair FH Stock on some mobile screens to be easier to manage

### DIFF
--- a/src/app/ui/figures/character/sheet/move-resources.scss
+++ b/src/app/ui/figures/character/sheet/move-resources.scss
@@ -1,4 +1,6 @@
 .move-resources-dialog {
+    max-height: calc(95vh - var(--ghs-unit) * 2);
+    overflow: auto;
     padding: 0.5em;
 
     .ghs-svg {
@@ -27,7 +29,6 @@
             font-size: calc(var(--ghs-unit) * 3 * var(--ghs-dialog-factor));
             color: var(--ghs-color-white);
             min-width: calc(var(--ghs-unit) * 44 * var(--ghs-dialog-factor));
-
 
             img.icon {
                 height: calc(var(--ghs-unit) * 4.5 * var(--ghs-dialog-factor));


### PR DESCRIPTION
# Description
There's a small but frustrating issue when my group tries to move resources using my smartphone: when there's a large amount, it gets stuck and we can't use "Move to Frosthaven Stocks" as intended.

Before:
![Before](https://github.com/user-attachments/assets/4a23dfde-a891-42e2-a9e9-040ff2dc5698)

After:
![After](https://github.com/user-attachments/assets/21020075-4de3-4efa-9cd6-080f01d0de54)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)