### PR TITLE
Implement automation for Astral class

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ A basic user guide is available [online](https://help.gloomhaven-secretariat.de)
       > Repair Drone Mode: Heal 2 self at start of turn
     </details>
     <details>
+      <summary>SPOILER WARNING: <img src="./src/assets/images/character/icons/fh-astral.svg" height="20px" style="filter:grayscale(1);"></summary>
+
+      > Imbue with Life: Whenever you do not have Disarm, gain Disarm
+
+      > Veil of Protection: Your current and maximum hitpoint values are increased by 3 (also applied to summons)
+    </details>
+    <details>
       <summary>SPOILER WARNING: <img src="./src/assets/images/character/icons/fh-shards.svg" height="20px" style="filter:grayscale(1);"></summary>
 
       > Resonance Tokens: At the end of each of your turns, you gain one Resonance Token

--- a/data/fh/character/astral.json
+++ b/data/fh/character/astral.json
@@ -12,6 +12,11 @@
   "spoiler": true,
   "specialActions": [
     {
+      "name": "imbue-with-life",
+      "expire": true,
+      "level": 1
+    },
+    {
       "name": "veil-of-protection",
       "expire": true,
       "level": 2

--- a/data/fh/character/astral.json
+++ b/data/fh/character/astral.json
@@ -10,6 +10,13 @@
   ],
   "color": "#6fb54e",
   "spoiler": true,
+  "specialActions": [
+    {
+      "name": "veil-of-protection",
+      "expire": true,
+      "level": 2
+    }
+  ],
   "stats": [
     {
       "level": 1,

--- a/data/fh/label/spoiler/en.json
+++ b/data/fh/label/spoiler/en.json
@@ -192,6 +192,10 @@
     "fh": {
       "astral": {
         "": "Infuser",
+        "imbue-with-life": {
+          "": "Imbue with Life",
+          "hint": "Whenever you do not have %game.condition.disarm%, gain %game.condition.disarm%."
+        },
         "veil-of-protection": {
           "": "Veil of Protection",
           "hint": "Your current and maximum hitpoint values are increased by 3."

--- a/data/fh/label/spoiler/en.json
+++ b/data/fh/label/spoiler/en.json
@@ -190,7 +190,13 @@
   },
   "character": {
     "fh": {
-      "astral": "Infuser",
+      "astral": {
+        "": "Infuser",
+        "veil-of-protection": {
+          "": "Veil of Protection",
+          "hint": "Your current and maximum hitpoint values are increased by 3."
+        }
+      },
       "coral": "Crashing Tide",
       "drill": {
         "": "Metal Mosaic",

--- a/src/app/game/businesslogic/CharacterManager.ts
+++ b/src/app/game/businesslogic/CharacterManager.ts
@@ -9,7 +9,7 @@ import { Summon, SummonColor, SummonState } from "../model/Summon";
 import { Action, ActionType } from "../model/data/Action";
 import { CharacterData } from "../model/data/CharacterData";
 import { CharacterStat } from "../model/data/CharacterStat";
-import { Condition, ConditionName } from "../model/data/Condition";
+import { Condition, ConditionName, EntityCondition, EntityConditionState } from "../model/data/Condition";
 import { Enhancement } from "../model/data/Enhancement";
 import { ItemData } from "../model/data/ItemData";
 import { PersonalQuest } from "../model/data/PersonalQuest";
@@ -231,10 +231,36 @@ export class CharacterManager {
         }
       }
     }
+
+    if (character.name == 'astral') {
+      if (summon.name == 'animated-claymore') {
+        let disarm = character.entityConditions.find((entityCondition) => entityCondition.name == ConditionName.disarm);
+        if (disarm) {
+          disarm.permanent = true;
+        } else {
+          disarm = new EntityCondition(ConditionName.disarm);
+          disarm.permanent = true;
+          character.entityConditions.push(disarm);
+        }
+      }
+
+      if (character.tags.indexOf('veil-of-protection') != -1) {
+        summon.health += 3;
+        summon.maxHealth += 3;
+      }
+    }
   }
 
   removeSummon(character: Character, summon: Summon) {
     character.summons.splice(character.summons.indexOf(summon), 1);
+
+    if (character.name == 'astral') {
+      let disarm = character.entityConditions.find((entityCondition) => entityCondition.name == ConditionName.disarm);
+      if (disarm) {
+        disarm.permanent = false;
+        disarm.state = EntityConditionState.expire;
+      }
+    }
   }
 
   addXP(character: Character, value: number, levelUp: boolean = true) {
@@ -275,6 +301,10 @@ export class CharacterManager {
 
     if (character.name == 'shackles' && character.edition == 'fh' && character.progress.perks[11] == 2) {
       character.maxHealth += 5;
+    }
+
+    if (character.name == 'astral' && character.tags.indexOf('veil-of-protection') != -1) {
+      character.maxHealth += 3;
     }
 
     if (character.progress.equippedItems.find((identifier) => identifier.edition == 'fh' && identifier.name == '3')) {

--- a/src/app/game/businesslogic/CharacterManager.ts
+++ b/src/app/game/businesslogic/CharacterManager.ts
@@ -233,7 +233,7 @@ export class CharacterManager {
     }
 
     if (character.name == 'astral') {
-      if (summon.name == 'animated-claymore') {
+      if (character.tags.indexOf('imbue-with-life') != -1 && summon.name == 'animated-claymore') {
         let disarm = character.entityConditions.find((entityCondition) => entityCondition.name == ConditionName.disarm);
         if (disarm) {
           disarm.permanent = true;
@@ -254,7 +254,7 @@ export class CharacterManager {
   removeSummon(character: Character, summon: Summon) {
     character.summons.splice(character.summons.indexOf(summon), 1);
 
-    if (character.name == 'astral') {
+    if (character.name == 'astral' && character.tags.indexOf('imbue-with-life') != -1 && summon.name == 'animated-claymore') {
       let disarm = character.entityConditions.find((entityCondition) => entityCondition.name == ConditionName.disarm);
       if (disarm) {
         disarm.permanent = false;

--- a/src/app/game/businesslogic/RoundManager.ts
+++ b/src/app/game/businesslogic/RoundManager.ts
@@ -630,6 +630,13 @@ export class RoundManager {
           }
         }
 
+        if (figure.name == 'astral' && figure.tags.find((tag) => tag === 'veil-of-protection')) {
+          const stat = figure.stats.find((stat) => stat.level == figure.level);
+          if (stat) {
+            figure.maxHealth = stat.health;
+          }
+        }
+
         figure.health = figure.maxHealth;
         figure.loot = 0;
         figure.lootCards = [];

--- a/src/app/ui/figures/character/character.ts
+++ b/src/app/ui/figures/character/character.ts
@@ -600,6 +600,18 @@ export class CharacterComponent implements OnInit, OnDestroy {
       }
     }
 
+    if (this.character.name == 'astral') {
+      if (specialAction == 'veil-of-protection') {
+        this.character.health -= 3;
+        this.character.maxHealth -= 3;
+        
+        this.character.summons.forEach((summon) => {
+          summon.health -= 3;
+          summon.maxHealth -= 3;
+        })
+      }
+    }
+
     gameManager.stateManager.after();
   }
 

--- a/src/app/ui/figures/character/character.ts
+++ b/src/app/ui/figures/character/character.ts
@@ -9,7 +9,7 @@ import { Character } from 'src/app/game/model/Character';
 import { Action, ActionType } from 'src/app/game/model/data/Action';
 import { AttackModifierType } from 'src/app/game/model/data/AttackModifier';
 import { CharacterSpecialAction } from 'src/app/game/model/data/CharacterStat';
-import { ConditionType, EntityCondition } from 'src/app/game/model/data/Condition';
+import { ConditionName, ConditionType, EntityCondition } from 'src/app/game/model/data/Condition';
 import { EntityValueFunction } from 'src/app/game/model/Entity';
 import { GameState } from 'src/app/game/model/Game';
 import { Summon, SummonState } from 'src/app/game/model/Summon';
@@ -609,6 +609,10 @@ export class CharacterComponent implements OnInit, OnDestroy {
           summon.health -= 3;
           summon.maxHealth -= 3;
         })
+      }
+
+      if (specialAction == 'imbue-with-life') {
+        this.character.entityConditions = this.character.entityConditions.filter((entityCondition) => entityCondition.name != ConditionName.disarm || !entityCondition.permanent)
       }
     }
 

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
@@ -1027,6 +1027,17 @@ export class EntityMenuDialogComponent {
           }
         }
 
+        if (this.data.entity.name == 'astral') {
+          if (specialTagsToTemove.indexOf('veil-of-protection') != -1) {
+            this.data.entity.health -= 3;
+            this.data.entity.maxHealth -= 3;
+            this.data.entity.summons.forEach((summon) => {
+              summon.health -= 3;
+              summon.maxHealth -= 3;
+            })
+          }
+        }
+
         gameManager.stateManager.after();
       }
 
@@ -1076,6 +1087,17 @@ export class EntityMenuDialogComponent {
                   summon.action = new Action(ActionType.pierce, 1);
                 }
               }
+            })
+          }
+        }
+
+        if (this.data.entity.name == 'astral') {
+          if (specialTagsToAdd.indexOf('veil-of-protection') != -1) {
+            this.data.entity.health += 3;
+            this.data.entity.maxHealth += 3;
+            this.data.entity.summons.forEach((summon) => {
+              summon.health += 3;
+              summon.maxHealth += 3;
             })
           }
         }

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
@@ -1036,6 +1036,10 @@ export class EntityMenuDialogComponent {
               summon.maxHealth -= 3;
             })
           }
+
+          if (specialTagsToTemove.indexOf('imbue-with-life') != -1) {
+            this.data.entity.entityConditions = this.data.entity.entityConditions.filter((entityCondition) => entityCondition.name != ConditionName.disarm || !entityCondition.permanent)
+          }
         }
 
         gameManager.stateManager.after();
@@ -1099,6 +1103,17 @@ export class EntityMenuDialogComponent {
               summon.health += 3;
               summon.maxHealth += 3;
             })
+          }
+
+          if (specialTagsToAdd.indexOf('imbue-with-life') != -1 && this.data.entity.summons.findIndex((summon) => summon.name == 'animated-claymore') != -1) {
+            let disarm = this.data.entity.entityConditions.find((entityCondition) => entityCondition.name == ConditionName.disarm);
+            if (disarm) {
+              disarm.permanent = true;
+            } else {
+              disarm = new EntityCondition(ConditionName.disarm);
+              disarm.permanent = true;
+              this.data.entity.entityConditions.push(disarm);
+            }
           }
         }
 


### PR DESCRIPTION
# Description

I implemented automation for two key Astral class cards that I was missing during my playthrough:

- Veil of Protection now adds 3 health to the current and maximum hitpoint values (both character and summons).
- The Imbue with Life summon now applies a permanent disarm until the summon is removed.

I only did some rough testing to verify the happy flow, but I'd be happy to fix any bugs that I encounter during my playthrough.

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change that adds functionality)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)