### PR TITLE
Typo fixes

### DIFF
--- a/data/fh/label/en.json
+++ b/data/fh/label/en.json
@@ -1309,7 +1309,7 @@
         "1": "All allies within %game.range:2% add +1 %game.action.attack% to one of their attacks each turn.",
         "10": "Attack at least three enemies with each of three different area of effect attack abilities",
         "11": "Perform a Banner summon ability on your first turn, keep the banner alive and within %game.action.range:3% of you for the entire scenario",
-        "2": "At the start of their turns, grant allies withing %game.range:3%:",
+        "2": "At the start of their turns, grant allies within %game.range:3%:",
         "3": "All adjacent allies gain %game.shield% 1.",
         "4": "Negate the first source of %game.damage% to an adjacent ally each round",
         "5": "All enemies within %game.action.range%4 suffer %game.damage:1% at the start of their turns.",

--- a/data/fh/label/spoiler/en.json
+++ b/data/fh/label/spoiler/en.json
@@ -773,7 +773,7 @@
     },
     "fh-177": {
       "": "Boots of Transference",
-      "1": "When you spring a trap by entering its hex, you may apply its effects to a figure withing %game.action.range:3% instead of yourself."
+      "1": "When you spring a trap by entering its hex, you may apply its effects to a figure within %game.action.range:3% instead of yourself."
     },
     "fh-178": {
       "": "Tranquil Shoes",
@@ -833,7 +833,7 @@
     },
     "fh-190": {
       "": "White Card",
-      "1": "During your turn, place a character token on one normal or elite enemy withing %game.action.range:3%. This enemy adds -1 %game.action.attack% to all its attacks."
+      "1": "During your turn, place a character token on one normal or elite enemy within %game.action.range:3%. This enemy adds -1 %game.action.attack% to all its attacks."
     },
     "fh-191": {
       "": "Corrupted Scroll",
@@ -841,11 +841,11 @@
     },
     "fh-192": {
       "": "Enticing Bell",
-      "1": "At the end of your turn, designate one enemy withing %game.action.range:3%. You are its primary focus and it does not avoid negative hexes when determining movement this round. "
+      "1": "At the end of your turn, designate one enemy within %game.action.range:3%. You are its primary focus and it does not avoid negative hexes when determining movement this round. "
     },
     "fh-193": {
       "": "Mind Thieving Helmet",
-      "1": "During your turn, control one enemy withing %game.action.range:3%:"
+      "1": "During your turn, control one enemy within %game.action.range:3%:"
     },
     "fh-194": {
       "": "Temporal Amulet",
@@ -930,7 +930,7 @@
     },
     "fh-211": {
       "": "Boom Barrel",
-      "1": "During your turn, designate one adjacent hex. At the end of your turn, all figures withing %game.action.range:2% of the designated hex suffer %game.damage% 1."
+      "1": "During your turn, designate one adjacent hex. At the end of your turn, all figures within %game.action.range:2% of the designated hex suffer %game.damage% 1."
     },
     "fh-212": {
       "": "Elemental Stone",
@@ -1007,11 +1007,11 @@
     },
     "fh-228": {
       "": "Extendable Pole",
-      "1": "During your turn, open one unlocked door while withing %game.action.range:2%."
+      "1": "During your turn, open one unlocked door while within %game.action.range:2%."
     },
     "fh-229": {
       "": "Exquisite Map",
-      "1": "During your turn grant one ally withing %game.action.range:3%:"
+      "1": "During your turn grant one ally within %game.action.range:3%:"
     },
     "fh-23": {
       "": "Sturdy Greaves",
@@ -1047,7 +1047,7 @@
     },
     "fh-237": {
       "": "Mesmerizing Seashell",
-      "1": "During your turn, choose one of six directions. You and all figures withing %game.action.range:2% are forced to simultaneously move 2 hexes in the chosen direction."
+      "1": "During your turn, choose one of six directions. You and all figures within %game.action.range:2% are forced to simultaneously move 2 hexes in the chosen direction."
     },
     "fh-238": {
       "": "Cracked Idol",
@@ -1325,7 +1325,7 @@
     },
     "fh-77": {
       "": "Chaos Cannon",
-      "1": "During you turn, replace one 1-hex obstacle, hazardous terrain, difficult terrain, or icy terrain tile in an unoccupied hex withing %game.action.range:2% with a different type of tile listed above."
+      "1": "During you turn, replace one 1-hex obstacle, hazardous terrain, difficult terrain, or icy terrain tile in an unoccupied hex within %game.action.range:2% with a different type of tile listed above."
     },
     "fh-78": {
       "": "Balanced Scales",
@@ -1414,7 +1414,7 @@
     },
     "fh-97": {
       "": "Explosive Vial",
-      "1": "During your turn, one enemy withing %game.action.range:2% suffers %game.damage% 2."
+      "1": "During your turn, one enemy within %game.action.range:2% suffers %game.damage% 2."
     },
     "fh-98": {
       "": "Unhealthy Mixture",

--- a/data/gh2e/label/en.json
+++ b/data/gh2e/label/en.json
@@ -273,7 +273,7 @@
       },
       "cragheart": {
         "1": "Create one 1-hex obstacle tile in an empty hex adjacent to the target",
-        "2": "Once each scenario, during your turn, you may destroy one 1-hex obstacle withing %game.action.range:5% to %game.action.teleport% to the hex it occupied",
+        "2": "Once each scenario, during your turn, you may destroy one 1-hex obstacle within %game.action.range:5% to %game.action.teleport% to the hex it occupied",
         "3": "At the end of each of your rests, you may destroy one 1-hex obstacle within %game.action.range:5% to %game.element.earth%",
         "4": "Whenever a new room is revealed, control all enemies in the newly revealed room: %game.action.move% 1, this movement must end in an empty hex",
         "5": "For an entire scenario, create, destroy, or move at least one obstacle tile each round",
@@ -334,7 +334,7 @@
         "4": "Add +1 %game.action.attack% for each negative condition the target has",
         "5": "Whenever you control the attack of an enemy, you may have the enemy use your attack modifier deck",
         "6": "You are considered to be last in initiative order when determining monster focus",
-        "7": "At the end of each of your rests, you may %game.elementHalf.consume:ice|dark% to control one enemy withing %game.action.range:5%: %game.action.attack% 1",
+        "7": "At the end of each of your rests, you may %game.elementHalf.consume:ice|dark% to control one enemy within %game.action.range:5%: %game.action.attack% 1",
         "8": "In a single scenario, kill 5 or more enemies with control abilities",
         "9": "In a single scenario, trigger the on-attack effect from four different Augments at least 3 times each"
       },
@@ -376,7 +376,7 @@
         "1": "Once each scenario, one adjacent ally may use one of your <i>potion</i> %game.itemSlot:small% items during their turn without it becoming %game.card.lost%",
         "2": "Whenever you perform an action with %game.card.lost%, you may %game.element.wild%",
         "3": "Whenever you long rest, you may perform: %game.action.heal% 2, %game.action.range:3%",
-        "4": "For an entire scenario, during each of your turns, give an enemy a negative condition, give an ally a positive condition, heal an ally or grant an ally shield",
+        "4": "For an entire scenario, during each of your turns, give an enemy a negative condition, give an ally a positive condition, heal an ally, or grant an ally shield",
         "5": "Perform 11 different %game.card.lost% actions"
       }
     }

--- a/data/gh2e/label/spoiler/en.json
+++ b/data/gh2e/label/spoiler/en.json
@@ -103,9 +103,9 @@
         "2": "Give the target or one enemy within %game.action.range% 2 of the target %game.condition.poison%",
         "3": "You have %game.action.fly%",
         "4": "Whenever you heal from a long rest, you may remove %game.condition.poison% from on ally to add +1 %game.action.heal%",
-        "5": "Once each scenario, when an anemy that has a %data.action.custom.gh2e-plaque% would die, you first control that enemy and have it perform the abilities on its ability card, adding %data.action.custom.gh2e-plaque% to all its attack, then it dies",
+        "5": "Once each scenario, when an enemy that has a %data.action.custom.gh2e-plaque% would die, you first control that enemy and have it perform the abilities on its ability card, adding %data.action.custom.gh2e-plaque% to all its attack, then it dies",
         "6": "In a single turn, kill 3 or more enemies without drawing an attack modifier card",
-        "7": "In a single scenario, either apply or remove %game.condition.poison% form an ally or enemy each round"
+        "7": "In a single scenario, either apply or remove %game.condition.poison% from an ally or enemy each round"
       },
       "sun": {
         "1": "You or an adjacent ally may %game.card.recover% on level 1 card from the discard pile",
@@ -137,7 +137,7 @@
         "2": "Whenever %data.action.custom.gh2e-bear-summon% is attacked, treat and %game.attackmodifier.double% attack modifier card the enemy draws as %game.attackmodifier.plus0% instead",
         "3": "Once each scenario, during your turn, %data.action.custom.gh2e-command%: %game.action.move% 4.<br>If %data.action.custom.gh2e-bear-summon% exits a hex adjacent to you during this movement, you may %game.action.teleport% to an empty hex adjacent to %data.action.custom.gh2e-bear-summon% at the end of the movement",
         "4": "At the start or end of each of your long rests, you may %game.elementHalf:air|earth% and reduce your current hit point value by X (X must be at least 1) to %data.action.custom.gh2e-command%: %game.action.heal% X, self",
-        "5": "In a single scenario, infuse or consuem %game.element.air% or %game.element.earth% during each of your turns",
+        "5": "In a single scenario, infuse or consume %game.element.air% or %game.element.earth% during each of your turns",
         "6": "In a single scenario, kill 4 or more enemies with %data.action.custom.gh2e-command% attacks of 7 or greater (after all bonuses, before attack modifiers)"
       }
     }


### PR DESCRIPTION
# Description

This corrects and updates a few pieces of data.
Namely:
- Corrects many cases of "within" being spelled "withing"
- Fixes a punctuation difference for one of Tinkerer's masteries
- Fixes typos for a Squidface perk and mastery
- Fixes a typo in a Two Minis mastery

Fixes #242 

## Type of change

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)