### PR TITLE
Fix Plague icons

### DIFF
--- a/data/gh2e/label/spoiler/en.json
+++ b/data/gh2e/label/spoiler/en.json
@@ -99,11 +99,11 @@
         "8": "In a single scneario, never attack an undamaged enemy while there are any damaged monsters alive, and perform at least 10 attacks"
       },
       "squidface": {
-        "1": "Give the target or one enemy within %game.action.range% 2 of the target %data.action.custom.gh2e-plaque%",
+        "1": "Give the target or one enemy within %game.action.range% 2 of the target %game.condition.plague%",
         "2": "Give the target or one enemy within %game.action.range% 2 of the target %game.condition.poison%",
         "3": "You have %game.action.fly%",
         "4": "Whenever you heal from a long rest, you may remove %game.condition.poison% from on ally to add +1 %game.action.heal%",
-        "5": "Once each scenario, when an enemy that has a %data.action.custom.gh2e-plaque% would die, you first control that enemy and have it perform the abilities on its ability card, adding %data.action.custom.gh2e-plaque% to all its attack, then it dies",
+        "5": "Once each scenario, when an enemy that has a %game.condition.plague% would die, you first control that enemy and have it perform the abilities on its ability card, adding %game.condition.plague% to all its attack, then it dies",
         "6": "In a single turn, kill 3 or more enemies without drawing an attack modifier card",
         "7": "In a single scenario, either apply or remove %game.condition.poison% from an ally or enemy each round"
       },

--- a/data/gh2e/label/spoiler/zh_Hans.json
+++ b/data/gh2e/label/spoiler/zh_Hans.json
@@ -94,11 +94,11 @@
         "8": "在单一剧本中，只要场上有受伤的怪物就不能攻击未受伤的敌人，并执行至少10次攻击"
       },
       "squidface": {
-        "1": "目标或目标%game.action.range% 2内的一个敌人获得%data.action.custom.gh2e-plaque%",
+        "1": "目标或目标%game.action.range% 2内的一个敌人获得%game.condition.plague%",
         "2": "目标或目标%game.action.range% 2内的一个敌人获得%game.condition.poison%",
         "3": "你获得%game.action.fly%",
         "4": "每当你获得充分休息的治疗时，你可以移除一个盟友的%game.condition.poison%来增加+1 %game.action.heal%",
-        "5": "每个剧本限一次，每当一个带有%data.action.custom.gh2e-plaque%的敌人将要死亡时，你先控制那个敌人执行其怪物能力卡牌上的行动，并为其所有攻击附加%data.action.custom.gh2e-plaque%，然后该敌人死亡",
+        "5": "每个剧本限一次，每当一个带有%game.condition.plague%的敌人将要死亡时，你先控制那个敌人执行其怪物能力卡牌上的行动，并为其所有攻击附加%game.condition.plague%，然后该敌人死亡",
         "6": "在单一轮次中，未抽取攻击修正卡牌的情况下消灭至少3个敌人",
         "7": "在单一剧本中，每轮都对一个敌人或盟友施加或移除%game.condition.poison%"
       },


### PR DESCRIPTION
# Description

Fixes missing Plague icons on Squidface's character sheets (and AMD cards, by extension).

Before:
<img width="260" height="130" alt="Image" src="https://github.com/user-attachments/assets/ef1c853b-d58e-4639-a3cd-d65a2be9fde9" />

After:
<img width="258" height="144" alt="firefox_ewgtFqqoWH" src="https://github.com/user-attachments/assets/7f43db8b-af19-47ab-b9a8-8c0f35525656" />
<img width="902" height="431" alt="firefox_OUHiJD6lON" src="https://github.com/user-attachments/assets/60b396f3-aff0-4e49-b6e5-868ac71552cb" />

Fixes #827 

## Type of change

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)