### PR TITLE
Fix GH2E prosperity levelling

### DIFF
--- a/src/app/ui/header/menu/character/character.ts
+++ b/src/app/ui/header/menu/character/character.ts
@@ -27,7 +27,7 @@ export class CharacterMenuComponent implements OnInit {
   characterData: Record<string, CharacterData[]> = {};
 
   ngOnInit(): void {
-    this.characterLevel = gameManager.fhRules() ? Math.ceil(gameManager.prosperityLevel() / 2) : gameManager.prosperityLevel();
+    this.characterLevel = gameManager.fhRules(true) ? Math.ceil(gameManager.prosperityLevel() / 2) : gameManager.prosperityLevel();
     this.update();
   }
 


### PR DESCRIPTION
# Description

Fixes prosperity leveling in GH2E so that it follows the new rules, rather than 1E rules.

Fixes #844

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)