### PR TITLE
Align character icon in container

### DIFF
--- a/src/app/ui/figures/character/character.scss
+++ b/src/app/ui/figures/character/character.scss
@@ -717,7 +717,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-right: calc(var(--ghs-unit) * 4);
+    margin-right: calc(var(--ghs-unit) * 5);
     margin-left: calc(var(--ghs-unit) * 2);
 
     &.hand-size-margin {


### PR DESCRIPTION
# Description

Adjusts the padding on the class icon in the character container so that it lines up better in the Modern theme. Yes this is solely because it bugs me endlessly when I look at it.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/876ffa04-3f1a-4a39-b351-3a9762a4ce7f" />

Still looks fine in other themes:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d6608fb3-d266-4eff-a405-7260d1c8fe02" />

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)