### PR TITLE
Shackles delayed malady

### DIFF
--- a/data/fh/character/shackles.json
+++ b/data/fh/character/shackles.json
@@ -10,6 +10,11 @@
   ],
   "color": "#7476a7",
   "spoiler": true,
+  "specialActions": [
+    {
+      "name": "delayed_malady"
+    }
+  ],
   "stats": [
     {
       "level": 1,

--- a/data/fh/character/shackles.json
+++ b/data/fh/character/shackles.json
@@ -13,6 +13,7 @@
   "specialActions": [
     {
       "name": "delayed_malady",
+      "expire": true,
       "counter": {
         "initial": 5,
         "min": 1,

--- a/data/fh/character/shackles.json
+++ b/data/fh/character/shackles.json
@@ -12,7 +12,13 @@
   "spoiler": true,
   "specialActions": [
     {
-      "name": "delayed_malady"
+      "name": "delayed_malady",
+      "counter": {
+        "initial": 5,
+        "min": 1,
+        "decrementOnRound": true,
+        "removeOnZero": true
+      }
     }
   ],
   "stats": [

--- a/data/fh/label/spoiler/en.json
+++ b/data/fh/label/spoiler/en.json
@@ -253,7 +253,13 @@
           "mode": "Mode Token"
         }
       },
-      "shackles": "Pain Conduit",
+      "shackles": {
+        "": "Pain Conduit",
+        "delayed_malady": {
+          "": "Delayed Malady",
+          "hint": "During this and the next four rounds, you are unaffected by Negative conditions you have and they cannot be removed"
+        }
+      },
       "shards": {
         "": "Shattersong",
         "extra_resonance_tokens": {

--- a/src/app/game/businesslogic/EntityManager.ts
+++ b/src/app/game/businesslogic/EntityManager.ts
@@ -1,6 +1,7 @@
 import { Character } from "../model/Character";
 import { ActionType } from "../model/data/Action";
 import { Condition, ConditionName, ConditionType, EntityCondition, EntityConditionState } from "../model/data/Condition";
+import { SpecialActionHelper } from "../model/data/SpecialActionHelper";
 import { Entity, EntityValueFunction } from "../model/Entity";
 import { Figure } from "../model/Figure";
 import { Game, GameState } from "../model/Game";
@@ -181,7 +182,7 @@ export class EntityManager {
       }
 
       if (entity.health + value > entity.health) {
-        const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+        const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
         const clearHeal = entity.entityConditions.find((condition) => {
           const isNegative = condition.types.indexOf(ConditionType.negative) !== -1;
           const isBlockedByDelayedMalady = hasDelayedMalady && isNegative;
@@ -207,7 +208,7 @@ export class EntityManager {
 
   sufferDamageHighlightConditions(entity: Entity, figure: Figure, value: number, damageOnly: boolean = false) {
     if (settingsManager.settings.applyConditions) {
-      const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+      const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
 
       if (value < 0 && !damageOnly) {
         let shieldValue = 0;
@@ -436,7 +437,7 @@ export class EntityManager {
   }
 
   removeCondition(entity: Entity, figure: Figure, condition: Condition, permanent: boolean = false) {
-    const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+    const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
     const isNegativeCondition = condition.types.indexOf(ConditionType.negative) !== -1;
 
     if (hasDelayedMalady && isNegativeCondition) {
@@ -455,7 +456,7 @@ export class EntityManager {
     const condition = entity.entityConditions.find((entityCondition) => entityCondition.name == name && !entityCondition.expired && (entityCondition.types.indexOf(ConditionType.apply) != -1 || entityCondition.types.indexOf(ConditionType.highlightOnly) != -1));
 
     if (condition) {
-      const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+      const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
       const isNegativeCondition = condition.types.indexOf(ConditionType.negative) !== -1;
 
       if (hasDelayedMalady && isNegativeCondition) {
@@ -541,7 +542,7 @@ export class EntityManager {
           entity.health -= condition.value;
         }
 
-        const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+        const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
 
         if (!hasDelayedMalady) {
           let clearHeal = entity.entityConditions.find((condition) => condition.types.indexOf(ConditionType.clearHeal) != -1 && !condition.permanent && !condition.expired);
@@ -614,7 +615,7 @@ export class EntityManager {
   }
 
   expireConditions(entity: Entity, figure: Figure) {
-    const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+    const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
     let negativeCondition = false;
 
     entity.entityConditions.forEach((entityCondition) => {
@@ -655,7 +656,7 @@ export class EntityManager {
 
     if (regenerateCondition) {
       const maxHealth = EntityValueFunction(entity.maxHealth);
-      const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+      const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
 
       const heal = entity.entityConditions.every((entityCondition) => {
         const isPreventHeal = entityCondition.types.indexOf(ConditionType.preventHeal) != -1;
@@ -703,7 +704,7 @@ export class EntityManager {
 
     entity.entityConditions.filter((entityCondition) => !entityCondition.expired && entityCondition.state == EntityConditionState.normal && entityCondition.types.indexOf(ConditionType.turn) != -1).forEach((entityCondition) => {
       if (!this.isImmune(entity, figure, entityCondition.name) && settingsManager.settings.applyConditionsExcludes.indexOf(entityCondition.name) == -1) {
-        const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+        const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
         const skipNegativeEffect = hasDelayedMalady && entityCondition.types.indexOf(ConditionType.negative) !== -1;
 
         entityCondition.lastState = entityCondition.state;
@@ -749,7 +750,7 @@ export class EntityManager {
   }
 
   unapplyConditionsTurn(entity: Entity, figure: Figure) {
-    const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+    const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
 
     entity.entityConditions.filter((entityCondition) => entityCondition.state == EntityConditionState.turn && entityCondition.types.indexOf(ConditionType.turn) != -1 && settingsManager.settings.applyConditionsExcludes.indexOf(entityCondition.name) == -1).forEach((entityCondition) => {
       if (entityCondition.expired) {
@@ -792,7 +793,7 @@ export class EntityManager {
   applyConditionsAfter(entity: Entity, figure: Figure) {
     entity.entityConditions.filter((entityCondition) => !entityCondition.expired && entityCondition.types.indexOf(ConditionType.afterTurn) != -1).forEach((entityCondition) => {
       if (!this.isImmune(entity, figure, entityCondition.name) && settingsManager.settings.applyConditionsExcludes.indexOf(entityCondition.name) == -1) {
-        const hasDelayedMalady = entity instanceof Character && entity.tags.some(tag => tag.startsWith('delayed_malady:'));
+        const hasDelayedMalady = SpecialActionHelper.hasActionProtection(entity, 'delayed_malady');
         const skipNegativeEffect = hasDelayedMalady && entityCondition.types.indexOf(ConditionType.negative) !== -1;
 
         if (entityCondition.state == EntityConditionState.turn) {

--- a/src/app/game/businesslogic/GameManager.ts
+++ b/src/app/game/businesslogic/GameManager.ts
@@ -786,19 +786,7 @@ export class GameManager {
 
   additionalIdentifier(figure: Figure, entity: Entity | undefined = undefined): AdditionalIdentifier {
     if (figure instanceof Character) {
-      // Exclude transient special action tags (with counters) and round action markers from entity counting
-      const persistentTags = figure.tags.filter(tag => {
-        // Exclude roundAction- markers
-        if (tag.startsWith('roundAction-')) {
-          return false;
-        }
-        // Exclude special action tags with counter values (e.g., "delayed_malady:4")
-        if (figure.specialActions.some(action => tag.startsWith(`${action.name}:`))) {
-          return false;
-        }
-        return true;
-      });
-      return new AdditionalIdentifier(figure.name, figure.edition, "character", undefined, persistentTags);
+      return new AdditionalIdentifier(figure.name, figure.edition, "character", undefined, figure.tags);
     } else if (figure instanceof Monster) {
       if (entity instanceof MonsterEntity) {
         return new AdditionalIdentifier(figure.name, figure.edition, "monster", entity.marker, entity.tags);
@@ -847,21 +835,6 @@ export class GameManager {
   }
 
   checkEntitiesKilled() {
-    // Clean up old character counters that have tags (from before the fix)
-    // Keep only counters with empty/no tags for characters
-    const oldCountersRemoved = this.game.entitiesCounter.filter(c =>
-      c.identifier.type === 'character' && c.identifier.tags && c.identifier.tags.length > 0
-    );
-
-    if (oldCountersRemoved.length > 0) {
-      console.log(`Removing ${oldCountersRemoved.length} old character counters with tags:`,
-        oldCountersRemoved.map(c => ({name: c.identifier.name, tags: c.identifier.tags})));
-
-      this.game.entitiesCounter = this.game.entitiesCounter.filter(c =>
-        c.identifier.type !== 'character' || !c.identifier.tags || c.identifier.tags.length === 0
-      );
-    }
-
     this.game.figures.forEach((figure) => {
       if (figure instanceof Character) {
         if (!this.entityCounter(this.additionalIdentifier(figure))) {

--- a/src/app/game/businesslogic/GameManager.ts
+++ b/src/app/game/businesslogic/GameManager.ts
@@ -786,7 +786,19 @@ export class GameManager {
 
   additionalIdentifier(figure: Figure, entity: Entity | undefined = undefined): AdditionalIdentifier {
     if (figure instanceof Character) {
-      return new AdditionalIdentifier(figure.name, figure.edition, "character", undefined, figure.tags);
+      // Exclude transient special action tags (with counters) and round action markers from entity counting
+      const persistentTags = figure.tags.filter(tag => {
+        // Exclude roundAction- markers
+        if (tag.startsWith('roundAction-')) {
+          return false;
+        }
+        // Exclude special action tags with counter values (e.g., "delayed_malady:4")
+        if (figure.specialActions.some(action => tag.startsWith(`${action.name}:`))) {
+          return false;
+        }
+        return true;
+      });
+      return new AdditionalIdentifier(figure.name, figure.edition, "character", undefined, persistentTags);
     } else if (figure instanceof Monster) {
       if (entity instanceof MonsterEntity) {
         return new AdditionalIdentifier(figure.name, figure.edition, "monster", entity.marker, entity.tags);
@@ -835,6 +847,21 @@ export class GameManager {
   }
 
   checkEntitiesKilled() {
+    // Clean up old character counters that have tags (from before the fix)
+    // Keep only counters with empty/no tags for characters
+    const oldCountersRemoved = this.game.entitiesCounter.filter(c =>
+      c.identifier.type === 'character' && c.identifier.tags && c.identifier.tags.length > 0
+    );
+
+    if (oldCountersRemoved.length > 0) {
+      console.log(`Removing ${oldCountersRemoved.length} old character counters with tags:`,
+        oldCountersRemoved.map(c => ({name: c.identifier.name, tags: c.identifier.tags})));
+
+      this.game.entitiesCounter = this.game.entitiesCounter.filter(c =>
+        c.identifier.type !== 'character' || !c.identifier.tags || c.identifier.tags.length === 0
+      );
+    }
+
     this.game.figures.forEach((figure) => {
       if (figure instanceof Character) {
         if (!this.entityCounter(this.additionalIdentifier(figure))) {

--- a/src/app/game/businesslogic/RoundManager.ts
+++ b/src/app/game/businesslogic/RoundManager.ts
@@ -106,6 +106,14 @@ export class RoundManager {
       }
       this.game.state = GameState.next;
       this.game.round++;
+
+      // Clear roundAction tags at the start of each new round
+      this.game.figures.forEach((figure) => {
+        if (figure instanceof Character || figure instanceof Monster) {
+          figure.tags = figure.tags.filter((tag) => !tag.startsWith('roundAction-'));
+        }
+      });
+
       gameManager.characterManager.draw();
       gameManager.monsterManager.draw();
       gameManager.objectiveManager.draw();
@@ -526,6 +534,24 @@ export class RoundManager {
 
       if (figure instanceof Character && figure.name == 'shards' && figure.tags.indexOf('resonance_tokens') != -1 && figure.tokenValues[0] < 5) {
         figure.tokenValues[0] += 1;
+      }
+
+      if (figure instanceof Character) {
+        const delayedMaladyTag = figure.tags.find(tag => tag.startsWith('delayed_malady:'));
+        const alreadyProcessed = figure.tags.indexOf('roundAction-delayed_malady') !== -1;
+
+        if (delayedMaladyTag && !alreadyProcessed) {
+          const rounds = parseInt(delayedMaladyTag.split(':')[1], 10);
+
+          if (rounds <= 1) {
+            figure.tags = figure.tags.filter(tag => !tag.startsWith('delayed_malady'));
+          } else {
+            const tagIndex = figure.tags.indexOf(delayedMaladyTag);
+            figure.tags[tagIndex] = `delayed_malady:${rounds - 1}`;
+          }
+
+          figure.tags.push('roundAction-delayed_malady');
+        }
       }
 
       if (figure instanceof Character) {

--- a/src/app/game/businesslogic/RoundManager.ts
+++ b/src/app/game/businesslogic/RoundManager.ts
@@ -688,7 +688,17 @@ export class RoundManager {
           figure.progress.gold = 0;
         }
 
-        figure.tags = figure.tags.filter((tag) => tag != 'new-character' && !figure.specialActions.find((specialAction) => specialAction.name == tag && specialAction.expire));
+        figure.tags = figure.tags.filter((tag) => {
+          if (tag === 'new-character') return false;
+
+          if (tag.startsWith('roundAction-')) return false;
+
+          const matchingAction = figure.specialActions.find((specialAction) => {
+            return (specialAction.name === tag || tag.startsWith(`${specialAction.name}:`)) && specialAction.expire;
+          });
+
+          return !matchingAction;
+        });
 
         if (figure.defaultIdentity != undefined) {
           figure.identity = figure.defaultIdentity;

--- a/src/app/game/businesslogic/RoundManager.ts
+++ b/src/app/game/businesslogic/RoundManager.ts
@@ -107,7 +107,6 @@ export class RoundManager {
       this.game.state = GameState.next;
       this.game.round++;
 
-      // Clear roundAction tags at the start of each new round
       this.game.figures.forEach((figure) => {
         if (figure instanceof Character || figure instanceof Monster) {
           figure.tags = figure.tags.filter((tag) => !tag.startsWith('roundAction-'));

--- a/src/app/game/model/data/CharacterStat.ts
+++ b/src/app/game/model/data/CharacterStat.ts
@@ -8,6 +8,14 @@ export class CharacterStat {
   }
 }
 
+export interface SpecialActionCounter {
+  initial: number;
+  min?: number;
+  max?: number;
+  decrementOnRound?: boolean;
+  removeOnZero?: boolean;
+}
+
 export class CharacterSpecialAction {
   name: string;
   level: number;
@@ -16,13 +24,15 @@ export class CharacterSpecialAction {
   round: boolean;
   summon: boolean;
   perk: number | undefined;
+  counter?: SpecialActionCounter;
 
-  constructor(name: string, level: number = 0, noTag: boolean = false, expire: boolean = false, round: boolean = false, summon: boolean = false) {
+  constructor(name: string, level: number = 0, noTag: boolean = false, expire: boolean = false, round: boolean = false, summon: boolean = false, counter?: SpecialActionCounter) {
     this.name = name;
     this.level = level;
     this.noTag = noTag;
     this.expire = expire;
     this.round = round;
     this.summon = summon;
+    this.counter = counter;
   }
 }

--- a/src/app/game/model/data/SpecialActionHelper.ts
+++ b/src/app/game/model/data/SpecialActionHelper.ts
@@ -1,0 +1,125 @@
+import { CharacterSpecialAction, SpecialActionCounter } from "./CharacterStat";
+import { Character } from "../Character";
+import { Entity } from "../Entity";
+
+export class SpecialActionHelper {
+  static getCounterValue(tags: string[], actionName: string): number | null {
+    const tag = tags.find(t => t.startsWith(`${actionName}:`));
+    if (!tag) {
+      return null;
+    }
+
+    const parts = tag.split(':');
+    if (parts.length < 2) {
+      return null;
+    }
+
+    const value = parseInt(parts[1], 10);
+    return isNaN(value) ? null : value;
+  }
+
+  static setCounterValue(tags: string[], actionName: string, value: number): void {
+    const existingIndex = tags.findIndex(t => t.startsWith(`${actionName}:`));
+    const newTag = `${actionName}:${value}`;
+
+    if (existingIndex !== -1) {
+      tags[existingIndex] = newTag;
+    } else {
+      tags.push(newTag);
+    }
+  }
+
+  static hasCounter(action: CharacterSpecialAction): boolean {
+    return action.counter !== undefined && action.counter !== null;
+  }
+
+  static getCounterConfig(action: CharacterSpecialAction): Required<SpecialActionCounter> {
+    const counter = action.counter || { initial: 0 };
+
+    return {
+      initial: counter.initial,
+      min: counter.min !== undefined ? counter.min : 0,
+      max: counter.max !== undefined ? counter.max : Number.MAX_SAFE_INTEGER,
+      decrementOnRound: counter.decrementOnRound !== undefined ? counter.decrementOnRound : false,
+      removeOnZero: counter.removeOnZero !== undefined ? counter.removeOnZero : true
+    };
+  }
+
+  static createCounterTag(action: CharacterSpecialAction): string {
+    if (!this.hasCounter(action)) {
+      throw new Error(`Special action '${action.name}' does not have counter configuration`);
+    }
+
+    const config = this.getCounterConfig(action);
+    return `${action.name}:${config.initial}`;
+  }
+
+  static hasActionProtection(entity: Entity, actionName: string): boolean {
+    if (!(entity instanceof Character)) {
+      return false;
+    }
+
+    return entity.tags.some((tag: string) => tag === actionName || tag.startsWith(`${actionName}:`));
+  }
+
+  static decrementCounter(tags: string[], action: CharacterSpecialAction): boolean {
+    const currentValue = this.getCounterValue(tags, action.name);
+    if (currentValue === null) {
+      return false;
+    }
+
+    const config = this.getCounterConfig(action);
+    const newValue = currentValue - 1;
+
+    if (newValue < config.min || (newValue === 0 && config.removeOnZero)) {
+      const index = tags.findIndex(t => t.startsWith(`${action.name}:`));
+      if (index !== -1) {
+        tags.splice(index, 1);
+      }
+      return false;
+    } else {
+      this.setCounterValue(tags, action.name, newValue);
+      return true;
+    }
+  }
+
+  static incrementCounter(tags: string[], action: CharacterSpecialAction): boolean {
+    const currentValue = this.getCounterValue(tags, action.name);
+    if (currentValue === null) {
+      return false;
+    }
+
+    const config = this.getCounterConfig(action);
+    const newValue = currentValue + 1;
+
+    if (newValue > config.max) {
+      return false;
+    }
+
+    this.setCounterValue(tags, action.name, newValue);
+    return true;
+  }
+
+  static changeCounter(tags: string[], action: CharacterSpecialAction, delta: number): number | null {
+    const currentValue = this.getCounterValue(tags, action.name);
+    if (currentValue === null) {
+      return null;
+    }
+
+    const config = this.getCounterConfig(action);
+    let newValue = currentValue + delta;
+
+    newValue = Math.max(config.min, Math.min(config.max, newValue));
+
+    if (newValue === 0 && config.removeOnZero || newValue < config.min) {
+      const index = tags.findIndex(t => t.startsWith(`${action.name}:`));
+      if (index !== -1) {
+        tags.splice(index, 1);
+      }
+      return null;
+    }
+
+    this.setCounterValue(tags, action.name, newValue);
+    return newValue;
+  }
+}

--- a/src/app/game/model/data/SpecialActionHelper.ts
+++ b/src/app/game/model/data/SpecialActionHelper.ts
@@ -54,12 +54,12 @@ export class SpecialActionHelper {
     return `${action.name}:${config.initial}`;
   }
 
-  static hasActionProtection(entity: Entity, actionName: string): boolean {
+  static hasActiveSpecialAction(entity: Entity, actionName: string): boolean {
     if (!(entity instanceof Character)) {
       return false;
     }
 
-    return entity.tags.some((tag: string) => tag === actionName || tag.startsWith(`${actionName}:`));
+    return entity.tags.some(tag => tag === actionName || tag.startsWith(`${actionName}:`));
   }
 
   static decrementCounter(tags: string[], action: CharacterSpecialAction): boolean {
@@ -111,7 +111,7 @@ export class SpecialActionHelper {
 
     newValue = Math.max(config.min, Math.min(config.max, newValue));
 
-    if (newValue === 0 && config.removeOnZero || newValue < config.min) {
+    if (newValue === 0 && config.removeOnZero) {
       const index = tags.findIndex(t => t.startsWith(`${action.name}:`));
       if (index !== -1) {
         tags.splice(index, 1);

--- a/src/app/ui/figures/character/character.html
+++ b/src/app/ui/figures/character/character.html
@@ -389,18 +389,14 @@
         ghs-pointer-input (singleClick)="openEntityMenu()" (doubleClick)="removeSpecialAction(specialAction.name)"
         [ghs-tooltip]="'data.character.' + character.edition + '.' + character.name + '.' + specialAction.name + '.hint'"
         [originY]="'top'" [overlayY]="'bottom'" [originX]="'center'" [overlayX]="'center'">
-        @if (specialAction.name == 'delayed_malady') {
-          @for (tag of character.tags; track tag) {
-            @if (tag.startsWith('delayed_malady:')) {
-              <span class="delayed-malady-counter">
-                &nbsp;(
-                <span class="counter-button" (click)="changeDelayedMaladyCounter(-1, $event)">-</span>
-                {{ tag.split(':')[1] }}
-                <span class="counter-button" (click)="changeDelayedMaladyCounter(1, $event)">+</span>
-                )
-              </span>
-            }
-          }
+        @if (specialAction.counter) {
+          <span class="special-action-counter">
+            &nbsp;(
+            <span class="counter-button" (click)="changeSpecialActionCounter(specialAction, -1, $event)">-</span>
+            {{ getSpecialActionCounterValue(specialAction) }}
+            <span class="counter-button" (click)="changeSpecialActionCounter(specialAction, 1, $event)">+</span>
+            )
+          </span>
         }
       </span>
       @if (i < specialActions.length - 1 && specialActions.length> 1) {

--- a/src/app/ui/figures/character/character.html
+++ b/src/app/ui/figures/character/character.html
@@ -388,7 +388,21 @@
         [ghs-label]="'data.character.' + character.edition + '.' + character.name + '.' + specialAction.name"
         ghs-pointer-input (singleClick)="openEntityMenu()" (doubleClick)="removeSpecialAction(specialAction.name)"
         [ghs-tooltip]="'data.character.' + character.edition + '.' + character.name + '.' + specialAction.name + '.hint'"
-        [originY]="'top'" [overlayY]="'bottom'" [originX]="'center'" [overlayX]="'center'"></span>
+        [originY]="'top'" [overlayY]="'bottom'" [originX]="'center'" [overlayX]="'center'">
+        @if (specialAction.name == 'delayed_malady') {
+          @for (tag of character.tags; track tag) {
+            @if (tag.startsWith('delayed_malady:')) {
+              <span class="delayed-malady-counter">
+                &nbsp;(
+                <span class="counter-button" (click)="changeDelayedMaladyCounter(-1, $event)">-</span>
+                {{ tag.split(':')[1] }}
+                <span class="counter-button" (click)="changeDelayedMaladyCounter(1, $event)">+</span>
+                )
+              </span>
+            }
+          }
+        }
+      </span>
       @if (i < specialActions.length - 1 && specialActions.length> 1) {
         <span class="separator">|</span>
         }

--- a/src/app/ui/figures/character/character.scss
+++ b/src/app/ui/figures/character/character.scss
@@ -908,6 +908,31 @@
     .separator {
       margin: 0 calc(var(--ghs-unit) * 0.2 * var(--ghs-text-factor));
     }
+
+    .delayed-malady-counter {
+      display: inline-flex;
+      align-items: center;
+      gap: calc(var(--ghs-unit) * 0.5);
+
+      .counter-button {
+        cursor: pointer;
+        padding: calc(var(--ghs-unit) * 0.5) calc(var(--ghs-unit) * 1);
+        font-weight: bold;
+        user-select: none;
+        min-width: calc(var(--ghs-unit) * 3);
+        text-align: center;
+        background-color: rgba(255, 255, 255, 0.2);
+        border-radius: calc(var(--ghs-unit) * 0.5);
+
+        &:hover {
+          background-color: rgba(255, 255, 255, 0.3);
+        }
+
+        &:active {
+          background-color: rgba(255, 255, 255, 0.4);
+        }
+      }
+    }
   }
 
   .title,

--- a/src/app/ui/figures/character/character.scss
+++ b/src/app/ui/figures/character/character.scss
@@ -909,27 +909,38 @@
       margin: 0 calc(var(--ghs-unit) * 0.2 * var(--ghs-text-factor));
     }
 
-    .delayed-malady-counter {
+    .special-action-counter {
       display: inline-flex;
       align-items: center;
-      gap: calc(var(--ghs-unit) * 0.5);
+      gap: calc(var(--ghs-unit) * 0.6);
+      margin-left: calc(var(--ghs-unit) * 0.3);
 
       .counter-button {
         cursor: pointer;
-        padding: calc(var(--ghs-unit) * 0.5) calc(var(--ghs-unit) * 1);
+        padding: calc(var(--ghs-unit) * 0.6) calc(var(--ghs-unit) * 1.2);
         font-weight: bold;
+        font-size: calc(var(--ghs-unit) * 2);
+        line-height: 1;
         user-select: none;
-        min-width: calc(var(--ghs-unit) * 3);
+        min-width: calc(var(--ghs-unit) * 3.2);
+        min-height: calc(var(--ghs-unit) * 3.2);
         text-align: center;
-        background-color: rgba(255, 255, 255, 0.2);
-        border-radius: calc(var(--ghs-unit) * 0.5);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background-color: rgba(255, 255, 255, 0.25);
+        border-radius: calc(var(--ghs-unit) * 0.6);
+        transition: all calc(var(--ghs-animation-speed) * 80ms) ease-in-out;
+        border: 1px solid rgba(255, 255, 255, 0.3);
 
         &:hover {
-          background-color: rgba(255, 255, 255, 0.3);
+          background-color: rgba(255, 255, 255, 0.35);
+          transform: scale(1.05);
         }
 
         &:active {
-          background-color: rgba(255, 255, 255, 0.4);
+          background-color: rgba(255, 255, 255, 0.5);
+          transform: scale(0.95);
         }
       }
     }

--- a/src/app/ui/figures/character/character.ts
+++ b/src/app/ui/figures/character/character.ts
@@ -111,10 +111,7 @@ export class CharacterComponent implements OnInit, OnDestroy {
     this.shortMenu = false;
     this.bb = gameManager.bbRules() || this.character.bb;
     this.specialActions = this.character.specialActions.filter((specialAction) => {
-      if (specialAction.name === 'delayed_malady') {
-        return this.character.tags.some(tag => tag.startsWith('delayed_malady:'));
-      }
-      return this.character.tags.indexOf(specialAction.name) !== -1;
+      return SpecialActionHelper.hasActiveSpecialAction(this.character, specialAction.name);
     });
   }
 
@@ -591,12 +588,8 @@ export class CharacterComponent implements OnInit, OnDestroy {
     }
 
     gameManager.stateManager.before("updateSpecialTags", gameManager.characterManager.characterName(this.character), '%data.character.' + this.character.edition + '.' + this.character.name + '.' + specialAction.name + '%');
-    const newValue = SpecialActionHelper.changeCounter(this.character.tags, specialAction, delta);
-    if (newValue !== null) {
-      gameManager.stateManager.after();
-    } else {
-      gameManager.stateManager.after();
-    }
+    SpecialActionHelper.changeCounter(this.character.tags, specialAction, delta);
+    gameManager.stateManager.after();
   }
 
   getSpecialActionCounterValue(specialAction: CharacterSpecialAction): number | null {
@@ -605,8 +598,10 @@ export class CharacterComponent implements OnInit, OnDestroy {
 
   removeSpecialAction(specialAction: string) {
     gameManager.stateManager.before("removeSpecialTags", gameManager.characterManager.characterName(this.character), '%data.character.' + this.character.edition + '.' + this.character.name + '.' + specialAction + '%');
-    if (specialAction === 'delayed_malady') {
-      this.character.tags = this.character.tags.filter((specialTag) => !specialTag.startsWith('delayed_malady'));
+
+    const action = this.character.specialActions.find(a => a.name === specialAction);
+    if (action && SpecialActionHelper.hasCounter(action)) {
+      this.character.tags = this.character.tags.filter((specialTag) => !specialTag.startsWith(`${specialAction}:`));
     } else {
       this.character.tags = this.character.tags.filter((specialTag) => specialTag !== specialAction);
     }

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.html
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.html
@@ -676,10 +676,23 @@
       specialAction.summon)) { <div class="hint-container">
       <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg">
       <span class="hint-trigger special-action text-white"
-        [ngClass]="{'active-tag' : specialTags.indexOf(specialAction.name) != -1}" tabclick
+        [ngClass]="{'active-tag' : isSpecialActionActive(specialAction.name)}" tabclick
         (click)="applySpecialAction(specialAction)">
         <span
           [ghs-label]="'data.character.' + data.figure.edition + '.' + data.figure.name + '.' + specialAction.name"></span>
+        @if (specialAction.name == 'delayed_malady' && isSpecialActionActive(specialAction.name)) {
+          @for (tag of specialTags; track tag) {
+            @if (tag.startsWith('delayed_malady:')) {
+              <span class="delayed-malady-counter">
+                &nbsp;(
+                <span class="counter-button" (click)="changeDelayedMaladyCounter(-1, $event)">-</span>
+                {{ tag.split(':')[1] }}
+                <span class="counter-button" (click)="changeDelayedMaladyCounter(1, $event)">+</span>
+                )
+              </span>
+            }
+          }
+        }
       </span>
       <span class="hint above center">
         <div class="text">

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.html
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.html
@@ -676,22 +676,18 @@
       specialAction.summon)) { <div class="hint-container">
       <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg">
       <span class="hint-trigger special-action text-white"
-        [ngClass]="{'active-tag' : isSpecialActionActive(specialAction.name)}" tabclick
+        [ngClass]="{'active-tag' : isSpecialActionActive(specialAction)}" tabclick
         (click)="applySpecialAction(specialAction)">
         <span
           [ghs-label]="'data.character.' + data.figure.edition + '.' + data.figure.name + '.' + specialAction.name"></span>
-        @if (specialAction.name == 'delayed_malady' && isSpecialActionActive(specialAction.name)) {
-          @for (tag of specialTags; track tag) {
-            @if (tag.startsWith('delayed_malady:')) {
-              <span class="delayed-malady-counter">
-                &nbsp;(
-                <span class="counter-button" (click)="changeDelayedMaladyCounter(-1, $event)">-</span>
-                {{ tag.split(':')[1] }}
-                <span class="counter-button" (click)="changeDelayedMaladyCounter(1, $event)">+</span>
-                )
-              </span>
-            }
-          }
+        @if (specialAction.counter && isSpecialActionActive(specialAction)) {
+          <span class="special-action-counter">
+            &nbsp;(
+            <span class="counter-button" (click)="changeSpecialActionCounter(specialAction, -1, $event)">-</span>
+            {{ getSpecialActionCounterValue(specialAction) }}
+            <span class="counter-button" (click)="changeSpecialActionCounter(specialAction, 1, $event)">+</span>
+            )
+          </span>
         }
       </span>
       <span class="hint above center">

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.scss
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.scss
@@ -651,6 +651,31 @@
           transform: scale(1);
         }
       }
+
+      .delayed-malady-counter {
+        display: inline-flex;
+        align-items: center;
+        gap: calc(var(--ghs-unit) * 0.5 * var(--ghs-dialog-factor));
+
+        .counter-button {
+          cursor: pointer;
+          padding: calc(var(--ghs-unit) * 0.5 * var(--ghs-dialog-factor)) calc(var(--ghs-unit) * 1 * var(--ghs-dialog-factor));
+          font-weight: bold;
+          user-select: none;
+          min-width: calc(var(--ghs-unit) * 3 * var(--ghs-dialog-factor));
+          text-align: center;
+          background-color: rgba(255, 255, 255, 0.2);
+          border-radius: calc(var(--ghs-unit) * 0.5 * var(--ghs-dialog-factor));
+
+          &:hover {
+            background-color: rgba(255, 255, 255, 0.3);
+          }
+
+          &:active {
+            background-color: rgba(255, 255, 255, 0.4);
+          }
+        }
+      }
     }
   }
 

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.scss
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.scss
@@ -652,27 +652,38 @@
         }
       }
 
-      .delayed-malady-counter {
+      .special-action-counter {
         display: inline-flex;
         align-items: center;
-        gap: calc(var(--ghs-unit) * 0.5 * var(--ghs-dialog-factor));
+        gap: calc(var(--ghs-unit) * 0.6 * var(--ghs-dialog-factor));
+        margin-left: calc(var(--ghs-unit) * 0.3 * var(--ghs-dialog-factor));
 
         .counter-button {
           cursor: pointer;
-          padding: calc(var(--ghs-unit) * 0.5 * var(--ghs-dialog-factor)) calc(var(--ghs-unit) * 1 * var(--ghs-dialog-factor));
+          padding: calc(var(--ghs-unit) * 0.6 * var(--ghs-dialog-factor)) calc(var(--ghs-unit) * 1.2 * var(--ghs-dialog-factor));
           font-weight: bold;
+          font-size: calc(var(--ghs-unit) * 2 * var(--ghs-dialog-factor));
+          line-height: 1;
           user-select: none;
-          min-width: calc(var(--ghs-unit) * 3 * var(--ghs-dialog-factor));
+          min-width: calc(var(--ghs-unit) * 3.2 * var(--ghs-dialog-factor));
+          min-height: calc(var(--ghs-unit) * 3.2 * var(--ghs-dialog-factor));
           text-align: center;
-          background-color: rgba(255, 255, 255, 0.2);
-          border-radius: calc(var(--ghs-unit) * 0.5 * var(--ghs-dialog-factor));
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          background-color: rgba(255, 255, 255, 0.25);
+          border-radius: calc(var(--ghs-unit) * 0.6 * var(--ghs-dialog-factor));
+          transition: all calc(var(--ghs-animation-speed) * 80ms) ease-in-out;
+          border: 1px solid rgba(255, 255, 255, 0.3);
 
           &:hover {
-            background-color: rgba(255, 255, 255, 0.3);
+            background-color: rgba(255, 255, 255, 0.35);
+            transform: scale(1.05);
           }
 
           &:active {
-            background-color: rgba(255, 255, 255, 0.4);
+            background-color: rgba(255, 255, 255, 0.5);
+            transform: scale(0.95);
           }
         }
       }

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
@@ -139,7 +139,6 @@ export class EntityMenuDialogComponent {
     if (this.data.figure instanceof Character && this.data.figure.specialActions && this.data.entity) {
       const entity = this.data.entity;
       this.data.figure.specialActions.forEach((specialAction) => {
-        // Special handling for delayed_malady which stores rounds as suffix
         const hasTag = specialAction.name == 'delayed_malady'
           ? entity.tags.find(tag => tag.startsWith('delayed_malady'))
           : entity.tags.indexOf(specialAction.name) != -1;
@@ -1041,7 +1040,6 @@ export class EntityMenuDialogComponent {
       const specialTagsToTemove = this.data.entity.tags.filter((specialTag) => {
         if (this.data.figure instanceof Character && this.data.figure.specialActions) {
           const matchingAction = this.data.figure.specialActions.find((specialAction) => {
-            // Handle delayed_malady with round suffix
             if (specialAction.name == 'delayed_malady' && specialTag.startsWith('delayed_malady')) {
               return true;
             }
@@ -1307,7 +1305,6 @@ export class EntityMenuDialogComponent {
         const specialTagsToTemove = this.data.entity.tags.filter((specialTag) => {
         if (this.data.figure instanceof Character && this.data.figure.specialActions) {
           const matchingAction = this.data.figure.specialActions.find((specialAction) => {
-            // Handle delayed_malady with round suffix
             if (specialAction.name == 'delayed_malady' && specialTag.startsWith('delayed_malady')) {
               return true;
             }

--- a/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
+++ b/src/app/ui/figures/entity-menu/entity-menu-dialog.ts
@@ -140,15 +140,15 @@ export class EntityMenuDialogComponent {
     if (this.data.figure instanceof Character && this.data.figure.specialActions && this.data.entity) {
       const entity = this.data.entity;
       this.data.figure.specialActions.forEach((specialAction) => {
-        const hasTag = specialAction.name == 'delayed_malady'
-          ? entity.tags.find(tag => tag.startsWith('delayed_malady'))
+        const hasTag = SpecialActionHelper.hasCounter(specialAction)
+          ? entity.tags.some(tag => tag.startsWith(`${specialAction.name}:`))
           : entity.tags.indexOf(specialAction.name) != -1;
 
         if (entity instanceof Character && !specialAction.summon && hasTag) {
-          if (specialAction.name == 'delayed_malady') {
-            const tagWithRounds = entity.tags.find(tag => tag.startsWith('delayed_malady'));
-            if (tagWithRounds) {
-              this.specialTags.push(tagWithRounds);
+          if (SpecialActionHelper.hasCounter(specialAction)) {
+            const tagWithValue = entity.tags.find(tag => tag.startsWith(`${specialAction.name}:`));
+            if (tagWithValue) {
+              this.specialTags.push(tagWithValue);
             }
           } else {
             this.specialTags.push(specialAction.name);
@@ -1037,7 +1037,7 @@ export class EntityMenuDialogComponent {
       const specialTagsToTemove = this.data.entity.tags.filter((specialTag) => {
         if (this.data.figure instanceof Character && this.data.figure.specialActions) {
           const matchingAction = this.data.figure.specialActions.find((specialAction) => {
-            if (specialAction.name == 'delayed_malady' && specialTag.startsWith('delayed_malady')) {
+            if (SpecialActionHelper.hasCounter(specialAction) && specialTag.startsWith(`${specialAction.name}:`)) {
               return true;
             }
             return specialAction.name == specialTag;
@@ -1300,17 +1300,17 @@ export class EntityMenuDialogComponent {
         }
 
         const specialTagsToTemove = this.data.entity.tags.filter((specialTag) => {
-        if (this.data.figure instanceof Character && this.data.figure.specialActions) {
-          const matchingAction = this.data.figure.specialActions.find((specialAction) => {
-            if (specialAction.name == 'delayed_malady' && specialTag.startsWith('delayed_malady')) {
-              return true;
-            }
-            return specialAction.name == specialTag;
-          });
-          return matchingAction != undefined && this.specialTags.indexOf(specialTag) == -1;
-        }
-        return false;
-      });
+          if (this.data.figure instanceof Character && this.data.figure.specialActions) {
+            const matchingAction = this.data.figure.specialActions.find((specialAction) => {
+              if (SpecialActionHelper.hasCounter(specialAction) && specialTag.startsWith(`${specialAction.name}:`)) {
+                return true;
+              }
+              return specialAction.name == specialTag;
+            });
+            return matchingAction != undefined && this.specialTags.indexOf(specialTag) == -1;
+          }
+          return false;
+        });
 
         if (specialTagsToTemove.length) {
           gameManager.stateManager.before("removeSpecialTagsSummon", gameManager.characterManager.characterName(this.data.figure), specialTagsToTemove.map((specialTag) => '%data.character.' + this.data.figure.edition + '.' + this.data.figure.name + '.' + specialTag + '%').join(','), this.data.entity.title ? this.data.entity.title : "data.summon." + this.data.entity.name);


### PR DESCRIPTION
# Description

This PR implements the **Delayed Malady** ability for the Shackles character (Frosthaven). 

Delayed Malady is a special ability that prevents negative conditions (poison, wound, etc.) from taking effect for 5 rounds.

## Features

- Toggle Delayed Malady on/off from the entity menu
- Configure number of rounds (default: 5) when activating
- Increment/decrement round counter with +/- buttons
- Automatic round counter decrement at end of each round
- Prevents negative conditions from applying during character's turn while active
- Prevents negative conditions from being removed
- Visual indicator showing remaining rounds in the entity menu

## Implementation
- Extended character tag system to support `delayed_malady:N` format for round tracking
- Added special action UI in the entity menu
- Modified condition application logic in EntityManager to skip negative conditions when Delayed Malady is active
- Added round counter decrement logic in RoundManager with duplicate-prevention using `roundAction-` tags

Fixes #869 

## Type of change

- [x] New feature (non-breaking change that adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)