### PR TITLE
fix perk of mindthief 2nd edition

### DIFF
--- a/data/gh2e/character/mindthief.json
+++ b/data/gh2e/character/mindthief.json
@@ -164,7 +164,7 @@
         {
           "count": 2,
           "attackModifier": {
-            "type": "plus0",
+            "type": "plus1",
             "effects": [
               {
                 "type": "condition",


### PR DESCRIPTION
# Description

One perk of the mindthief was wrong, it's +1 immobilize you can add, not +0 immobilize.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)