### PR TITLE
fix gh2e #61, #62 and retirement of mindthief

### DIFF
--- a/data/gh2e/character/mindthief.json
+++ b/data/gh2e/character/mindthief.json
@@ -5,7 +5,7 @@
   "icon": "gh-mindthief",
   "edition": "gh2e",
   "handSize": 10,
-  "retireEvent": "city:86|road:61",
+  "retireEvent": "city:86|city:87|road:61",
   "traits": [
     "nimble",
     "outcast",

--- a/data/gh2e/scenarios/61.json
+++ b/data/gh2e/scenarios/61.json
@@ -6,9 +6,6 @@
   "unlocks": [
     "62"
   ],
-  "rewards": {
-    "prosperity": 1
-  },
   "monsters": [
     "cave-bear",
     "forest-imp",

--- a/data/gh2e/scenarios/62.json
+++ b/data/gh2e/scenarios/62.json
@@ -3,6 +3,9 @@
   "name": "Alchemy Lab",
   "flowChartGroup": "personal-quests",
   "edition": "gh2e",
+  "rewards": {
+    "prosperity": 1
+  },
   "monsters": [],
   "objectives": [
     {

--- a/data/gh2e/sections/121-4.json
+++ b/data/gh2e/sections/121-4.json
@@ -36,20 +36,22 @@
         },
         {
           "name": "forest-imp",
-          "type": "elite"
-        },
-        {
-          "name": "forest-imp",
+          "player2": "elite",
           "player3": "normal",
-          "player4": "normal"
-        },
-        {
-          "name": "forest-imp",
-          "player4": "normal"
-        },
-        {
-          "name": "forest-imp",
           "player4": "elite"
+        },
+        {
+          "name": "forest-imp",
+          "player3": "elite",
+          "player4": "elite"
+        },
+        {
+          "name": "forest-imp",
+          "player4": "normal"
+        },
+        {
+          "name": "forest-imp",
+          "player4": "normal"
         },
         {
           "name": "hound",

--- a/data/gh2e/sections/136-5.json
+++ b/data/gh2e/sections/136-5.json
@@ -22,7 +22,7 @@
         {
           "name": "giant-viper",
           "player2": "normal",
-          "player3": "normal",
+          "player3": "elite",
           "player4": "elite"
         },
         {
@@ -33,6 +33,7 @@
         },
         {
           "name": "giant-viper",
+          "player3": "normal",
           "player4": "elite"
         },
         {

--- a/data/gh2e/sections/78-2.json
+++ b/data/gh2e/sections/78-2.json
@@ -50,20 +50,24 @@
         },
         {
           "name": "hound",
-          "type": "normal"
-        },
-        {
-          "name": "hound",
-          "type": "normal"
-        },
-        {
-          "name": "hound",
+          "player2": "normal",
           "player3": "normal",
           "player4": "elite"
         },
         {
           "name": "hound",
+          "player2": "normal",
           "player3": "elite",
+          "player4": "normal"
+        },
+        {
+          "name": "hound",
+          "player3": "normal",
+          "player4": "normal"
+        },
+        {
+          "name": "hound",
+          "player3": "normal",
           "player4": "elite"
         }
       ]


### PR DESCRIPTION
# Description

Fixes some data error on GH2e:
- The retirement of Mindthief adds one more city event. 
- rewards of scenario 61 and 62
- monster data of scenario 61 and 62

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)