### PR TITLE
Fix Music Note perk notation

### DIFF
--- a/data/gh2e/character/music-note.json
+++ b/data/gh2e/character/music-note.json
@@ -77,8 +77,8 @@
                 "value": "bless",
                 "effects": [
                   {
-                    "type": "target",
-                    "value": 2
+                    "type": "specialTarget",
+                    "value": "%game.action.target%2"
                   }
                 ]
               }


### PR DESCRIPTION
# Description

Corrects this issue raised on the GH discord:
<img width="818" height="80" alt="image" src="https://github.com/user-attachments/assets/7f3369ff-4ee8-416e-a7c2-f01683ef5837" />
<img width="238" height="61" alt="image" src="https://github.com/user-attachments/assets/2553484d-6f34-4a8e-8cea-8a2d9dd9660f" />

## Type of change

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)