### PR TITLE
add abilities for GH2e mindthief and spellweaver

### DIFF
--- a/data/gh2e/character/deck/mindthief.json
+++ b/data/gh2e/character/deck/mindthief.json
@@ -1,0 +1,1801 @@
+{
+  "name": "mindthief",
+  "edition": "gh2e",
+  "character": true,
+  "abilities": [
+    {
+      "name": "Submissive Affliction",
+      "cardId": 146,
+      "level": 1,
+      "initiative": 48,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.146.1%",
+              "small": true
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.146.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "value": "ice",
+          "valueType": "minus",
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.146.3%",
+              "small": true
+            },
+            {
+              "type": "card",
+              "value": "experience:1",
+              "small": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Hidden in the Shadows",
+      "cardId": 147,
+      "level": 1,
+      "initiative": 14,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "advantage",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.147.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "invisible",
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "specialTarget",
+                  "value": "self",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.147.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "invisible",
+              "subActions": [
+                {
+                  "type": "specialTarget",
+                  "value": "self",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.147.3%"
+            }
+          ]
+        }
+      ],
+      "bottomPersistent": true
+    },
+    {
+      "name": "Scurry",
+      "cardId": 148,
+      "level": 1,
+      "initiative": 20,
+      "actions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "diamond"
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "loot",
+          "value": 2
+        }
+      ],
+      "bottomXp": 1
+    },
+    {
+      "name": "Withering Claw",
+      "cardId": 149,
+      "level": 1,
+      "initiative": 18,
+      "actions": [
+        {
+          "type": "box",
+          "value": "%data.custom.gh2e.mindthief.augment%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.149.1%"
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "immobilize",
+              "small": true
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.149.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 2,
+              "enhancementTypes": [
+                "diamond"
+              ]
+            }
+          ]
+        }
+      ],
+      "xp": 1,
+      "persistent": true
+    },
+    {
+      "name": "Frigid Apparition",
+      "cardId": 150,
+      "level": 1,
+      "initiative": 10,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "stun"
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomXp": 2
+    },
+    {
+      "name": "The Mind's Weakness",
+      "cardId": 151,
+      "level": 1,
+      "initiative": 75,
+      "actions": [
+        {
+          "type": "box",
+          "value": "%data.custom.gh2e.mindthief.augment%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.151.1%"
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "diamond"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.151.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 2,
+              "enhancementTypes": [
+                "diamond"
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "attack",
+          "value": 1,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "wound"
+            }
+          ]
+        }
+      ],
+      "xp": 1,
+      "persistent": true
+    },
+    {
+      "name": "Pilfer",
+      "cardId": 152,
+      "level": 1,
+      "initiative": 79,
+      "actions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 2,
+              "enhancementTypes": [
+                "diamond"
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.152.1%",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "loot",
+          "value": 1
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4
+        }
+      ]
+    },
+    {
+      "name": "Perverse Edge",
+      "cardId": 153,
+      "level": 1,
+      "initiative": 8,
+      "lost": true,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.153.1%",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "dark"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "element",
+          "value": "ice",
+          "valueType": "minus",
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "stun",
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 1
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Empathetic Assault",
+      "cardId": 154,
+      "level": 1,
+      "initiative": 12,
+      "lost": true,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 4,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 5,
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "disarm",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ]
+        },
+        {
+          "type": "heal",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "self",
+              "small": true
+            }
+          ]
+        }
+      ],
+      "xp": 2
+    },
+    {
+      "name": "Psychic Blade",
+      "cardId": 155,
+      "level": 1,
+      "initiative": 77,
+      "actions": [
+        {
+          "type": "box",
+          "value": "%data.custom.gh2e.mindthief.augment%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.155.1%"
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "curse",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.155.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 1
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.155.3%",
+          "small": true
+        }
+      ],
+      "persistent": true,
+      "xp": 1,
+      "bottomRound": true
+    },
+    {
+      "name": "Feedback Loop",
+      "cardId": 156,
+      "level": 1,
+      "initiative": 51,
+      "actions": [
+        {
+          "type": "box",
+          "value": "%data.custom.gh2e.mindthief.augment%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.156.1%"
+            },
+            {
+              "type": "attack",
+              "value": 0,
+              "valueType": "plus"
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.156.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 0,
+              "valueType": "plus"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "concatenation",
+          "subActions": [
+            {
+              "type": "move",
+              "value": 4,
+              "enhancementTypes": [
+                "square"
+              ],
+              "subActions": [
+                {
+                  "type": "jump",
+                  "value": "",
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.156.3%",
+              "small": true
+            }
+          ]
+        }
+      ],
+      "xp": "1",
+      "persistent": true
+    },
+    {
+      "name": "Possession",
+      "cardId": 157,
+      "level": "X",
+      "initiative": 71,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.157.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 3,
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "condition",
+                  "value": "muddle",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.157.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 2,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Gnawing Horde",
+      "cardId": 158,
+      "level": "X",
+      "initiative": 82,
+      "lost": true,
+      "actions": [
+        {
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "rat-swarm",
+            "health": 5,
+            "attack": 2,
+            "movement": 2,
+            "enhancements": [
+              "heal",
+              "attack",
+              "move"
+            ],
+            "action": {
+              "type": "condition",
+              "value": "poison"
+            }
+          },
+          "small": true
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4
+        }
+      ],
+      "persistent": true,
+      "xp": 2
+    },
+    {
+      "name": "Fearsome Blade",
+      "cardId": 159,
+      "level": 2,
+      "initiative": 27,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "push",
+              "value": 2,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "condition",
+              "value": "curse",
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "attack",
+                  "value": 2,
+                  "valueType": "add",
+                  "small": true
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "condition",
+          "value": "wound",
+          "subActions": [
+            {
+              "type": "range",
+              "value": 1,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "move",
+          "value": 4
+        }
+      ]
+    },
+    {
+      "name": "Hostile Takeover",
+      "cardId": 160,
+      "level": 2,
+      "initiative": 9,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "immobilize",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.160.1%",
+          "small": true
+        }
+      ],
+      "bottomRound": true,
+      "bottomXp": 2
+    },
+    {
+      "name": "Brain Leech",
+      "cardId": 161,
+      "level": 3,
+      "initiative": 21,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.161.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 2,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "attack",
+              "value": 2,
+              "enhancementTypes": [
+                "diamond"
+              ]
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "condition",
+                  "value": "wound",
+                  "small": true
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "attack",
+          "value": 1,
+          "enhancementTypes": [
+            "square"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.161.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "strengthen",
+              "subActions": [
+                {
+                  "type": "specialTarget",
+                  "value": "self",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Cranium Overload",
+      "cardId": 162,
+      "level": 3,
+      "initiative": 5,
+      "lost": true,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.162.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 6,
+              "subActions": [
+                {
+                  "type": "target",
+                  "value": "%data.custom.gh2e.mindthief.abilities.162.2%",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.162.3%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 2,
+              "subActions": [
+                {
+                  "type": "target",
+                  "value": "%data.custom.gh2e.mindthief.abilities.162.4%",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 5,
+          "enhancementTypes": [
+            "circle"
+          ],
+          "subActions": [
+            {
+              "type": "jump",
+              "value": "",
+              "small": true
+            }
+          ]
+        }
+      ],
+      "xp": 2
+    },
+    {
+      "name": "Frozen Shiv",
+      "cardId": 163,
+      "level": 4,
+      "initiative": 16,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 4,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "pierce",
+              "value": 1,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ]
+        },
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomXp": 2
+    },
+    {
+      "name": "Silent Scream",
+      "cardId": 164,
+      "level": 4,
+      "initiative": 83,
+      "actions": [
+        {
+          "type": "box",
+          "value": "%data.custom.gh2e.mindthief.augment%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.164.1%"
+            },
+            {
+              "type": "heal",
+              "value": 2,
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 2,
+                  "small": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "disarm",
+              "small": true
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.164.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 1,
+              "valueType": "minus"
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "persistent": true,
+      "xp": 1
+    },
+    {
+      "name": "Mass Hysteria",
+      "cardId": 165,
+      "level": 5,
+      "initiative": 11,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "target",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "range",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "pierce",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "muddle",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "move",
+              "value": 3,
+              "enhancementTypes": [
+                "square"
+              ],
+              "subActions": [
+                {
+                  "type": "jump",
+                  "value": "",
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.165.1%",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "dark"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Gangling Abomination",
+      "cardId": 166,
+      "level": 5,
+      "initiative": 81,
+      "lost": true,
+      "actions": [
+        {
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "rat-monstrosity",
+            "health": "8",
+            "attack": "3",
+            "movement": "3",
+            "count": 1,
+            "enhancements": [
+              "heal",
+              "move",
+              "attack"
+            ],
+            "action": {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.166.1%"
+            }
+          },
+          "small": true
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 2,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ]
+        }
+      ],
+      "persistent": true,
+      "xp": 2
+    },
+    {
+      "name": "Telepathic Command",
+      "cardId": 167,
+      "level": 6,
+      "initiative": 17,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.167.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 0,
+              "valueType": "plus"
+            },
+            {
+              "type": "condition",
+              "value": "invisible",
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "specialTarget",
+                  "value": "self",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.167.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 4,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Dark Frenzy",
+      "cardId": 168,
+      "level": 6,
+      "initiative": 39,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": ",",
+                  "subActions": [
+                    {
+                      "type": "attack",
+                      "value": 2,
+                      "valueType": "add",
+                      "small": true
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "value": "dark",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": ",",
+                  "subActions": [
+                    {
+                      "type": "attack",
+                      "value": 2,
+                      "valueType": "add",
+                      "small": true
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.168.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "value": "ice",
+          "valueType": "minus",
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.168.2%",
+              "small": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Domination",
+      "cardId": 169,
+      "level": 7,
+      "initiative": 13,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.169.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 3,
+              "enhancementTypes": [
+                "diamond"
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.169.2%",
+          "small": true
+        }
+      ],
+      "bottomPersistent": true
+    },
+    {
+      "name": "Psychic Projection",
+      "cardId": 170,
+      "level": 7,
+      "initiative": 92,
+      "actions": [
+        {
+          "type": "box",
+          "value": "%data.custom.gh2e.mindthief.augment%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.170.1%"
+            }
+          ]
+        },
+        {
+          "type": "pull",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.170.2%",
+          "small": true
+        },
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 3,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.170.3%",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "dark"
+            }
+          ]
+        }
+      ],
+      "persistent": true,
+      "xp": 1
+    },
+    {
+      "name": "Shared Nightmare",
+      "cardId": 171,
+      "level": 8,
+      "initiative": 7,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "target",
+              "value": 2,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "range",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "poison",
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "dark",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": ",",
+                  "small": true,
+                  "subActions": [
+                    {
+                      "type": "condition",
+                      "value": "curse"
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 1,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 2,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": "",
+                  "subActions": [
+                    {
+                      "type": "condition",
+                      "value": "stun",
+                      "small": true
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1",
+                      "small": true
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Corrupting Embrace",
+      "cardId": 172,
+      "level": 8,
+      "initiative": 15,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 1,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "wound",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "muddle",
+              "small": true
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.172.1%",
+          "small": true
+        },
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "card",
+              "value": "slotStart"
+            },
+            {
+              "type": "card",
+              "value": "slotXpFh:1"
+            },
+            {
+              "type": "card",
+              "value": "slot"
+            },
+            {
+              "type": "card",
+              "value": "slotEndXp:1"
+            }
+          ]
+        }
+      ],
+      "bottomPersistent": true
+    },
+    {
+      "name": "Many as One",
+      "cardId": 173,
+      "level": 9,
+      "initiative": 91,
+      "lost": true,
+      "actions": [
+        {
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "rat-king",
+            "health": "10",
+            "attack": "X",
+            "movement": "3",
+            "count": 1,
+            "enhancements": [
+              "heal",
+              "move"
+            ],
+            "action": {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.173.1%"
+            }
+          },
+          "small": true
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.mindthief.abilities.173.2%",
+          "small": true
+        }
+      ],
+      "persistent": true,
+      "xp": 2,
+      "bottomPersistent": true,
+      "bottomXp": 2
+    },
+    {
+      "name": "Phantasmal Killer",
+      "cardId": 174,
+      "level": 9,
+      "initiative": 67,
+      "actions": [
+        {
+          "type": "box",
+          "value": "%data.custom.gh2e.mindthief.augment%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "concatenation",
+              "value": "",
+              "subActions": [
+                {
+                  "type": "custom",
+                  "value": "%data.custom.gh2e.mindthief.abilities.174.1%"
+                },
+                {
+                  "type": "attack",
+                  "value": 3
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.mindthief.abilities.174.2%",
+              "subActions": [
+                {
+                  "type": "element",
+                  "value": "dark",
+                  "valueType": "minus",
+                  "subActions": [
+                    {
+                      "type": "custom",
+                      "value": "%data.custom.gh2e.mindthief.abilities.174.3%"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 3,
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "wound"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 2,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "loot",
+          "value": 1
+        },
+        {
+          "type": "condition",
+          "value": "invisible",
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "self",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "dark"
+            }
+          ]
+        }
+      ],
+      "persistent": true,
+      "xp": 1
+    }
+  ]
+}

--- a/data/gh2e/character/deck/spellweaver.json
+++ b/data/gh2e/character/deck/spellweaver.json
@@ -1,0 +1,2079 @@
+{
+  "name": "spellweaver",
+  "edition": "gh2e",
+  "character": true,
+  "abilities": [
+    {
+      "name": "Reviving Ether",
+      "cardId": 61,
+      "level": 1,
+      "initiative": 80,
+      "lost": true,
+      "loss": true,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.61.1%",
+          "small": true
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "wild"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "jump",
+              "value": "",
+              "small": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Fire Orbs",
+      "cardId": 62,
+      "level": 1,
+      "initiative": 69,
+      "lost": true,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "target",
+              "value": 3,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4,
+          "enhancementTypes": [
+            "square"
+          ]
+        }
+      ],
+      "xp": 1
+    },
+    {
+      "name": "Arcane Bolt",
+      "cardId": 63,
+      "level": 1,
+      "initiative": 70,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "element",
+              "value": "wild",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": ",",
+                  "subActions": [
+                    {
+                      "type": "attack",
+                      "value": 1,
+                      "valueType": "add",
+                      "small": true
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1",
+                      "small": true
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "attack",
+          "value": 4,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "fire",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": ",",
+                  "subActions": [
+                    {
+                      "type": "attack",
+                      "value": 1,
+                      "valueType": "add",
+                      "small": true
+                    },
+                    {
+                      "type": "pierce",
+                      "value": 3,
+                      "small": true
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1",
+                      "small": true
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomXp": 1
+    },
+    {
+      "name": "Flame Strike",
+      "cardId": 64,
+      "level": 1,
+      "initiative": 26,
+      "actions": [
+        {
+          "type": "condition",
+          "value": "strengthen",
+          "enhancementTypes": [
+            "diamond_plus"
+          ],
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "self",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "loot",
+          "value": 1
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "attack",
+          "value": 1,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "element",
+              "value": "fire",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": ",",
+                  "subActions": [
+                    {
+                      "type": "attack",
+                      "value": 1,
+                      "valueType": "add",
+                      "small": true
+                    },
+                    {
+                      "type": "condition",
+                      "value": "wound",
+                      "small": true
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1",
+                      "small": true
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Icy Blast",
+      "cardId": 65,
+      "level": 1,
+      "initiative": 20,
+      "lost": true,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,target)|(1,0,target)|(1,1,target)|(1,2,target)|(2,0,target)|(2,1,target)|(2,2,target)"
+            },
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "attack",
+                  "value": 1,
+                  "valueType": "add"
+                },
+                {
+                  "type": "condition",
+                  "value": "muddle"
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4,
+          "enhancementTypes": [
+            "square"
+          ]
+        }
+      ],
+      "xp": 1
+    },
+    {
+      "name": "Aid from the Ether",
+      "cardId": 66,
+      "level": 1,
+      "initiative": 36,
+      "actions": [
+        {
+          "type": "heal",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond_plus"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "wild",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": ",",
+                  "subActions": [
+                    {
+                      "type": "heal",
+                      "value": 1,
+                      "valueType": "add"
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.66.1%",
+          "small": true
+        }
+      ],
+      "bottomRound": true
+    },
+    {
+      "name": "Frost Strike",
+      "cardId": 67,
+      "level": 1,
+      "initiative": 78,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "condition",
+                  "value": "stun",
+                  "small": true
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ]
+        },
+        {
+          "type": "element",
+          "value": "fire",
+          "valueType": "minus",
+          "subActions": [
+            {
+              "type": "concatenation",
+              "value": "",
+              "subActions": [
+                {
+                  "type": "custom",
+                  "value": "%data.custom.gh2e.spellweaver.abilities.67.1%",
+                  "small": true
+                },
+                {
+                  "type": "card",
+                  "value": "round",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Emberfrost",
+      "cardId": 68,
+      "level": 1,
+      "initiative": 7,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "pierce",
+              "value": 1,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.spellweaver.abilities.68.1%",
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "custom",
+              "value": ":",
+              "small": true
+            },
+            {
+              "type": "shield",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomRound": true
+    },
+    {
+      "name": "Flameswell",
+      "cardId": 69,
+      "level": "X",
+      "initiative": 83,
+      "lost": true,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.69.1%",
+          "small": true
+        },
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "card",
+              "value": "slotStart"
+            },
+            {
+              "type": "card",
+              "value": "slotXpFh:1"
+            },
+            {
+              "type": "card",
+              "value": "slot"
+            },
+            {
+              "type": "card",
+              "value": "slotEndXp:1"
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "heal",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": ",",
+                  "subActions": [
+                    {
+                      "type": "condition",
+                      "value": "ward"
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "persistent": true
+    },
+    {
+      "name": "Ice Armor",
+      "cardId": 70,
+      "level": "X",
+      "initiative": 25,
+      "lost": true,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.70.1%",
+          "small": true
+        },
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "concatenationSpacer",
+              "value": 1
+            },
+            {
+              "type": "card",
+              "value": "slotStartXp:1"
+            },
+            {
+              "type": "card",
+              "value": "slot"
+            },
+            {
+              "type": "card",
+              "value": "slotEndXp:1"
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "value": 0,
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.70.2%",
+          "small": true
+        },
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "concatenationSpacer",
+              "value": 1
+            },
+            {
+              "type": "card",
+              "value": "slotStartXp:1"
+            },
+            {
+              "type": "card",
+              "value": "slot"
+            },
+            {
+              "type": "card",
+              "value": "slotEndXp:1"
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "value": 0,
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "persistent": true,
+      "bottomPersistent": true
+    },
+    {
+      "name": "Impaling Eruption",
+      "cardId": 71,
+      "level": "X",
+      "initiative": 91,
+      "lost": true,
+      "actions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 3,
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "condition",
+                  "value": "immobilize",
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "area",
+              "value": "(0,1,active)|(1,1,target)|(2,0,target)|(2,1,target)|(3,0,enhance)|(3,1,target)|(3,2,enhance)|(4,1,target)|(4,2,target)|(5,1,enhance)",
+              "enhancementTypes": [
+                "hex",
+                "hex",
+                "hex"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "earth"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4,
+          "enhancementTypes": [
+            "square"
+          ]
+        }
+      ],
+      "xp": 1
+    },
+    {
+      "name": "Freezing Nova",
+      "cardId": 72,
+      "level": 2,
+      "initiative": 22,
+      "lost": true,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "target",
+              "value": "%data.custom.gh2e.spellweaver.abilities.72.1%",
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "immobilize",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 4,
+          "enhancementTypes": [
+            "square"
+          ]
+        }
+      ],
+      "xp": 1
+    },
+    {
+      "name": "Etheric Echo",
+      "cardId": 73,
+      "level": 2,
+      "initiative": 50,
+      "lost": true,
+      "actions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.73.1%",
+          "small": true
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "wild"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.73.2%",
+          "small": true
+        }
+      ],
+      "bottomRound": true
+    },
+    {
+      "name": "Heatwave",
+      "cardId": 74,
+      "level": 3,
+      "initiative": 12,
+      "lost": true,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 4,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,target)|(0,2,active)|(1,0,target)|(1,1,target)|(1,2,target)|(2,0,enhance)|(2,1,enhance)|(2,2,target)",
+              "enhancementTypes": [
+                "hex",
+                "hex"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "strengthen",
+              "enhancementTypes": [
+                "diamond_plus"
+              ],
+              "subActions": [
+                {
+                  "type": "specialTarget",
+                  "value": "ally",
+                  "small": true
+                },
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true,
+                  "enhancementTypes": [
+                    "square"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.spellweaver.abilities.74.1%",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ]
+        }
+      ],
+      "xp": 1,
+      "bottomRound": true
+    },
+    {
+      "name": "Arctic Shards",
+      "cardId": 75,
+      "level": 3,
+      "initiative": 24,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "target",
+              "value": 2,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "muddle",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "heal",
+          "value": 10,
+          "enhancementTypes": [
+            "diamond_plus"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "light"
+            }
+          ]
+        }
+      ],
+      "bottomXp": 1
+    },
+    {
+      "name": "Dancing Gales",
+      "cardId": 76,
+      "level": 4,
+      "initiative": 33,
+      "actions": [
+        {
+          "type": "element",
+          "value": "fire",
+          "valueType": "minus",
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "strengthen",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "specialTarget",
+                  "value": "self"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "value": "ice",
+          "valueType": "minus",
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 2,
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true
+                },
+                {
+                  "type": "condition",
+                  "value": "muddle",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "air"
+            }
+          ]
+        }
+      ],
+      "xp": 1,
+      "bottomXp": 1
+    },
+    {
+      "name": "Cold Fire",
+      "cardId": 77,
+      "level": 4,
+      "initiative": 67,
+      "actions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 1,
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true
+                },
+                {
+                  "type": "element",
+                  "value": "fire",
+                  "valueType": "minus",
+                  "small": true,
+                  "subActions": [
+                    {
+                      "type": "attack",
+                      "value": 2,
+                      "valueType": "add"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "value": "ice",
+                  "valueType": "minus",
+                  "small": true,
+                  "subActions": [
+                    {
+                      "type": "condition",
+                      "value": "immobilize"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "area",
+              "value": "(0,1,target)|(1,0,target)|(1,1,target)|(2,0,enhance)",
+              "enhancementTypes": [
+                "hex"
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "element",
+          "value": "wild",
+          "valueType": "minus",
+          "small": true,
+          "subActions": [
+            {
+              "type": "concatenation",
+              "value": "",
+              "subActions": [
+                {
+                  "type": "custom",
+                  "value": "%data.custom.gh2e.spellweaver.abilities.77.1%",
+                  "small": true
+                },
+                {
+                  "type": "card",
+                  "value": "round",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "xp": 1
+    },
+    {
+      "name": "Warm Up",
+      "cardId": 78,
+      "level": 5,
+      "initiative": 60,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.78.1%",
+          "small": true
+        },
+        {
+          "type": "card",
+          "value": "slotStart"
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 2,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "loot",
+          "value": 2
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "wild"
+            }
+          ]
+        }
+      ],
+      "persistent": true
+    },
+    {
+      "name": "Cool Down",
+      "cardId": 79,
+      "level": 5,
+      "initiative": 30,
+      "actions": [
+        {
+          "type": "heal",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "target",
+              "value": 2,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "wild",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "heal",
+                  "value": 1,
+                  "valueType": "add"
+                },
+                {
+                  "type": "range",
+                  "value": 1,
+                  "valueType": "add"
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "pierce",
+              "value": 1,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Elemental Rays",
+      "cardId": 80,
+      "level": 6,
+      "initiative": 15,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "target",
+              "value": 2,
+              "small": true
+            },
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "wild",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "attack",
+                  "value": 1,
+                  "valueType": "add"
+                },
+                {
+                  "type": "range",
+                  "value": 1,
+                  "valueType": "add"
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "concatenation",
+          "value": ",",
+          "subActions": [
+            {
+              "type": "condition",
+              "value": "stun"
+            },
+            {
+              "type": "condition",
+              "value": "curse",
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "target",
+                  "value": 3,
+                  "small": true,
+                  "enhancementTypes": [
+                    "square"
+                  ]
+                },
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "dark"
+            }
+          ]
+        }
+      ],
+      "bottomXp": 1
+    },
+    {
+      "name": "Searing Glacier",
+      "cardId": 81,
+      "level": 6,
+      "initiative": 90,
+      "lost": true,
+      "actions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 5,
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true
+                },
+                {
+                  "type": "element",
+                  "value": "fire",
+                  "valueType": "minus",
+                  "small": true,
+                  "subActions": [
+                    {
+                      "type": "pierce",
+                      "value": 3
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "area",
+              "value": "(0,1,target)|(1,2,target)|(1,3,target)|(2,4,target)|(2,5,target)"
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.81.1%",
+          "small": true
+        }
+      ],
+      "xp": 1,
+      "bottomRound": true
+    },
+    {
+      "name": "Spell Mastery",
+      "cardId": 82,
+      "level": 7,
+      "initiative": 71,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 3,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 4,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.82.1%",
+          "small": true
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "wild"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 5,
+          "enhancementTypes": [
+            "circle"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Chromatic Explosion",
+      "cardId": 83,
+      "level": 7,
+      "initiative": 10,
+      "lost": true,
+      "actions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 4,
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true
+                },
+                {
+                  "type": "condition",
+                  "value": "poison",
+                  "small": true
+                },
+                {
+                  "type": "condition",
+                  "value": "muddle",
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "area",
+              "value": "(0,0,target)|(0,1,target)|(1,0,target)|(1,1,target)|(1,2,enhance)",
+              "small": true,
+              "enhancementTypes": [
+                "hex"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "heal",
+          "value": 4,
+          "subActions": [
+            {
+              "type": "target",
+              "value": "%data.custom.gh2e.spellweaver.abilities.83.1%",
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "strengthen",
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "bless",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            },
+            {
+              "type": "element",
+              "value": "ice"
+            },
+            {
+              "type": "element",
+              "value": "air"
+            },
+            {
+              "type": "element",
+              "value": "earth"
+            },
+            {
+              "type": "element",
+              "value": "light"
+            },
+            {
+              "type": "element",
+              "value": "dark"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.83.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "custom",
+                  "value": "%data.custom.gh2e.spellweaver.abilities.83.3%",
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "subActions": [
+                {
+                  "type": "shield",
+                  "value": 3,
+                  "valueType": "add",
+                  "small": true
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1",
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "xp": 1
+    },
+    {
+      "name": "Frostflare Orbs",
+      "cardId": 84,
+      "level": 8,
+      "initiative": 46,
+      "lost": true,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 5,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "target",
+              "value": 3,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "range",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "condition",
+                  "value": "stun"
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 1,
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true
+                },
+                {
+                  "type": "element",
+                  "value": "wild",
+                  "valueType": "minus",
+                  "small": true,
+                  "subActions": [
+                    {
+                      "type": "attack",
+                      "value": 1,
+                      "valueType": "add"
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "area",
+              "value": "(0,1,target)|(1,0,target)|(1,1,target)|(2,0,enhance)",
+              "enhancementTypes": [
+                "hex"
+              ]
+            }
+          ]
+        }
+      ],
+      "xp": 1
+    },
+    {
+      "name": "Twin Beams",
+      "cardId": 85,
+      "level": 8,
+      "initiative": 19,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 1,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,0,active)|(1,0,target)|(2,0,target)"
+            },
+            {
+              "type": "element",
+              "value": "fire",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "attack",
+                  "value": 1,
+                  "valueType": "add"
+                },
+                {
+                  "type": "condition",
+                  "value": "wound"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 1,
+          "enhancementTypes": [
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,0,active)|(1,0,target)|(2,0,target)"
+            },
+            {
+              "type": "element",
+              "value": "ice",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "attack",
+                  "value": 1,
+                  "valueType": "add"
+                },
+                {
+                  "type": "push",
+                  "value": 2
+                },
+                {
+                  "type": "condition",
+                  "value": "muddle"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "move",
+          "value": 3,
+          "enhancementTypes": [
+            "circle"
+          ]
+        },
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.spellweaver.abilities.85.1%",
+              "small": true
+            },
+            {
+              "type": "attack",
+              "value": 3,
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "xp": 1,
+      "bottomRound": true
+    },
+    {
+      "name": "Freezing Vortex",
+      "cardId": 86,
+      "level": 9,
+      "initiative": 41,
+      "lost": true,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 5,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,target)|(1,0,target)|(1,1,target)|(1,2,target)|(2,0,target)|(2,1,target)|(2,2,target)"
+            },
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.spellweaver.abilities.86.1%",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "bottomActions": [
+        {
+          "type": "concatenation",
+          "value": "",
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.spellweaver.abilities.86.2%",
+              "small": true
+            },
+            {
+              "type": "pull",
+              "value": 3,
+              "subActions": [
+                {
+                  "type": "target",
+                  "value": "%data.custom.gh2e.spellweaver.abilities.86.3%",
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.spellweaver.abilities.86.4%",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "ice"
+            }
+          ]
+        }
+      ],
+      "xp": 1
+    },
+    {
+      "name": "Inferno",
+      "cardId": 87,
+      "level": 9,
+      "initiative": 96,
+      "actions": [
+        {
+          "type": "attack",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "target",
+              "value": "%data.custom.gh2e.spellweaver.abilities.87.1%",
+              "small": true
+            },
+            {
+              "type": "pierce",
+              "value": 2,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.gh2e.spellweaver.abilities.87.2%"
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ]
+        }
+      ],
+      "bottomLost": true,
+      "bottomActions": [
+        {
+          "type": "custom",
+          "value": "%data.custom.gh2e.spellweaver.abilities.87.3%",
+          "small": true
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ]
+        }
+      ],
+      "bottomXp": 1
+    }
+  ]
+}

--- a/data/gh2e/label/en.json
+++ b/data/gh2e/label/en.json
@@ -1,4 +1,62 @@
 {
+  "ability": {
+    "Aid from the Ether": "Aid from the Ether",
+    "Arcane Bolt": "Arcane Bolt",
+    "Arctic Shards": "Arctic Shards",
+    "Brain Leech": "Brain Leech",
+    "Chromatic Explosion": "Chromatic Explosion",
+    "Cold Fire": "Cold Fire",
+    "Cool Down": "Cool Down",
+    "Corrupting Embrace": "Corrupting Embrace",
+    "Cranium Overload": "Cranium Overload",
+    "Dancing Gales": "Dancing Gales",
+    "Dark Frenzy": "Dark Frenzy",
+    "Domination": "Domination",
+    "Elemental Rays": "Elemental Rays",
+    "Emberfrost": "Emberfrost",
+    "Empathetic Assault": "Empathetic Assault",
+    "Etheric Echo": "Etheric Echo",
+    "Fearsome Blade": "Fearsome Blade",
+    "Feedback Loop": "Feedback Loop",
+    "Fire Orbs": "Fire Orbs",
+    "Flame Strike": "Flame Strike",
+    "Flameswell": "Flameswell",
+    "Freezing Nova": "Freezing Nova",
+    "Freezing Vortex": "Freezing Vortex",
+    "Frigid Apparition": "Frigid Apparition",
+    "Frost Strike": "Frost Strike",
+    "Frostflare Orbs": "Frostflare Orbs",
+    "Frozen Shiv": "Frozen Shiv",
+    "Gangling Abomination": "Gangling Abomination",
+    "Gnawing Horde": "Gnawing Horde",
+    "Heatwave": "Heatwave",
+    "Hidden in the Shadows": "Hidden in the Shadows",
+    "Hostile Takeover": "Hostile Takeover",
+    "Ice Armor": "Ice Armor",
+    "Icy Blast": "Icy Blast",
+    "Impaling Eruption": "Impaling Eruption",
+    "Inferno": "Inferno",
+    "Many as One": "Many as One",
+    "Mass Hysteria": "Mass Hysteria",
+    "Perverse Edge": "Perverse Edge",
+    "Phantasmal Killer": "Phantasmal Killer",
+    "Pilfer": "Pilfer",
+    "Possession": "Possession",
+    "Psychic Blade": "Psychic Blade",
+    "Psychic Projection": "Psychic Projection",
+    "Reviving Ether": "Reviving Ether",
+    "Scurry": "Scurry",
+    "Searing Glacier": "Searing Glacier",
+    "Shared Nightmare": "Shared Nightmare",
+    "Silent Scream": "Silent Scream",
+    "Spell Mastery": "Spell Mastery",
+    "Submissive Affliction": "Submissive Affliction",
+    "Telepathic Command": "Telepathic Command",
+    "The Mind's Weakness": "The Mind's Weakness",
+    "Twin Beams": "Twin Beams",
+    "Warm Up": "Warm Up",
+    "Withering Claw": "Withering Claw"
+  },
   "battleGoals": {
     "1016": {
       "": "Accountant",
@@ -357,7 +415,99 @@
         "6": "You are considered to be last in initiative order when determining monster focus",
         "7": "At the end of each of your rests, you may %game.elementHalf.consume:ice|dark% to control one enemy within %game.action.range:5%: %game.action.attack% 1",
         "8": "In a single scenario, kill 5 or more enemies with control abilities",
-        "9": "In a single scenario, trigger the on-attack effect from four different Augments at least 3 times each"
+        "9": "In a single scenario, trigger the on-attack effect from four different Augments at least 3 times each",
+        "abilities": {
+          "146": {
+            "1": "Add +1 %game.action.attack% for each negative condition the target has.",
+            "2": "Control one enemy within %game.action.range:4%:",
+            "3": "The controlled enemy suffers %game.damage:2%"
+          },
+          "147": {
+            "1": "If the attack ability killed an enemy, perform:",
+            "2": "If you have not moved this round, perform:",
+            "3": "You cannot perform move abilities this round. At the end of the round, lose %game.condition.invisible%."
+          },
+          "149": {
+            "1": "Add %game.condition.poison%, %game.condition.muddle% to all your melee attacks.",
+            "2": "Control one enemy within %game.action.range:4%:"
+          },
+          "151": {
+            "1": "Add +1 %game.action.attack% to all your melee attacks.",
+            "2": "Control the target of the attack ability:"
+          },
+          "152": {
+            "1": "If this attack does not kill the target, gain a money token."
+          },
+          "153": {
+            "1": "Add +2 %game.action.attack% and gain %game.card.experience:1% for each negative condition the target has."
+          },
+          "155": {
+            "1": "Your single-target melee attack abilities may target enemies within 2 hexes (of you).",
+            "2": "Control the target of the attack ability:",
+            "3": "Add %game.condition.curse% to all your melee attacks this round."
+          },
+          "156": {
+            "1": "After each of your melee attack abilities, grant one of your summons:",
+            "2": "Grant one of your summons:",
+            "3": "If you end this movement in the same hex as you start, all enemies moved through gain %game.condition.muddle%."
+          },
+          "157": {
+            "1": "Control one enemy within %game.action.range:4%:",
+            "2": "Grant one of your summons:"
+          },
+          "160": {
+            "1": "Place a character token on a normal or elite enemy within %game.action.range:4%. This round, during that enemy's turn, it treats its enemies as allies and its allies as enemies, with you controlling its abilities."
+          },
+          "161": {
+            "1": "Control one enemy within %game.action.range:4%:",
+            "2": "If you performed the attack ability, perform:"
+          },
+          "162": {
+            "1": "Designate a hex containing an enemy within %game.action.range:4% to perform:",
+            "2": "the enemy in the designated hex, %game.action.pierce:5%",
+            "3": "If the attack ability killed an enemy, perform:",
+            "4": "all enemies adjacent to the designated hex"
+          },
+          "164": {
+            "1": "After each of your melee attack abilities, perform:",
+            "2": "Control one enemy within %game.action.range:4%:"
+          },
+          "165": {
+            "1": "All enemies moved through gain %game.condition.poison%."
+          },
+          "166": {
+            "1": "Add +1 %game.action.attack% if the target has a negative condition."
+          },
+          "167": {
+            "1": "Grant one of your summons:"
+          },
+          "168": {
+            "1": "Control two enemies within %game.action.range:4%:",
+            "2": "The controlled enemies suffer %game.damage:1%, %game.card.experience:1%."
+          },
+          "169": {
+            "1": "Control two enemies within %game.action.range:4% that are adjacent to each other:",
+            "2": "You may have two %game.customAction:gh2e-augment% active at once. If you play a third %game.customAction:gh2e-augment%, you must discard either of the other two. If you discard this card and you have two active %game.customAction:gh2e-augment%, you must discard one."
+          },
+          "170": {
+            "1": "Add +1 %game.action.attack% to your melee attacks for each negative condition the target has.",
+            "2": "Designate an unoccupied hex within %game.action.range:4%.",
+            "3": "Perform this attack as though you occupied the designated hex."
+          },
+          "172": {
+            "1": "On your next four melee attacks, add %game.condition.stun%, %game.condition.curse% to the attack."
+          },
+          "173": {
+            "1": "Where X is half the Rat King's current hit point value (rounded up).",
+            "2": "Each round, the first of your allies who performs a melee attack ability gains the effects of each of your active %game.customAction:gh2e-augment% for that attack ability."
+          },
+          "174": {
+            "1": "After each of your melee attack abilities, control one target of the attack ability:",
+            "2": "After each of your control abilities, you may perform:",
+            "3": "One controlled enemy suffers %game.damage:3%."
+          }
+        },
+        "augment": "%game.customAction:gh2e-augment% Augment"
       },
       "night-demon": {
         "1": "All adjacent allies and<br>enemies suffer %game.damage:1%.",
@@ -387,7 +537,69 @@
         "3": "Whenever you short rest, if <i>Reviving Ether</i> is in your discard pile, first %game.card.recover% it",
         "4": "At the end of each of your turns during which you performed an action with %game.card.lost%, gain %game.condition.bless%",
         "5": "In a single scenario, consume both %game.element.fire% and %game.element.ice% during the same turn 6 times",
-        "6": "In a single scenario, perform 4 different %game.card.lost% actions twice each"
+        "6": "In a single scenario, perform 4 different %game.card.lost% actions twice each",
+        "abilities": {
+          "61": {
+            "1": "%game.card.recover% all cards in your lost pile."
+          },
+          "66": {
+            "1": "When you next perform an action with %game.card.lost% this round, %game.element.wild%."
+          },
+          "67": {
+            "1": "Gain advantage on all your attacks this round, %game.card.experience:1%."
+          },
+          "68": {
+            "1": "Grant one ally within %game.action.range:3%"
+          },
+          "69": {
+            "1": "On your next four single-target ranged attack abilities, add +2%game.action.attack% to the attack."
+          },
+          "70": {
+            "1": "Place a character token on one ally within %game.action.range:3%. On the next three sources of 2 or more %game.damage% they would suffer, negate the %game.damage%.",
+            "2": "On the next tree sources of 2 or more %game.damage% you would suffer, negate the %game.damage%."
+          },
+          "72": {
+            "1": "the 4 enemies closest to you within 5 hexes"
+          },
+          "73": {
+            "1": "Play one Level 1 card from your lost pile other than Reviving Ether to perform an action with %game.card.lost% of the card.",
+            "2": "When you next perform an action with %game.card.lost% this round, gain %game.condition.ward%."
+          },
+          "74": {
+            "1": "The target add +2%game.action.attack% to their next attack this round."
+          },
+          "77": {
+            "1": "Add +1%game.action.attack% to all your attacks this round, %game.card.experience:1%."
+          },
+          "78": {
+            "1": "On the next attack ability you perform from an action with %game.card.lost%, add +1%game.action.attack% to all your attacks."
+          },
+          "81": {
+            "1": "When you next perform an action with %game.card.lost% this round, %game.card.recover% one card from your discard pile."
+          },
+          "82": {
+            "1": "You may play one card from your discard pile to perform an action with %game.card.lost% of the card (the card is moved to your lost pile)."
+          },
+          "83": {
+            "1": "all allies in the red hexes of the attack ability",
+            "2": "Choose an ally within %game.action.range:3%. That ally gains %game.action.shield:3% for the next attack targeting them this round.",
+            "3": "The attacker suffers %game.damage:3%, %game.card.experience:1%."
+          },
+          "85": {
+            "1": "When you next perform an action with %game.card.lost% this round, after the action perform:"
+          },
+          "86": {
+            "1": "After the attack ability, kill each target whose hit point value is 2 or less and create one 1-hex obstacle tile in the featureless hex they occupied.",
+            "2": "Designate a hex within %game.action.range:4%.",
+            "3": "all enemies within %game.action.range:4% of the designated hex",
+            "4": "Pull toward the designated hex."
+          },
+          "87": {
+            "1": "all enemies within 2 hexes",
+            "2": "All allies within %game.action.range:2% suffer %game.damage:2%.",
+            "3": "All allies and enemies in the same room as you suffer %game.damage:4%."
+          }
+        }
       },
       "stone-construct": {
         "1": "If the move ability was performed, Stone Construct suffers %game.damage:1%.",


### PR DESCRIPTION
# Description

I added the ability cards for the GH 2 Edition characters mindthief and spellweaver. I will continuing with cragheart and then the other starters. Hopefully it will help someone to have the cards in the app.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change that adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)