### PR TITLE
add abilities for GH2e cragheart

### DIFF
--- a/data/gh2e/character/deck/cragheart.json
+++ b/data/gh2e/character/deck/cragheart.json
@@ -410,9 +410,6 @@
           "type": "custom",
           "value": "%data.custom.gh2e.cragheart.abilities.122.1%",
           "small": true,
-          "enhancementTypes": [
-            "square"
-          ],
           "subActions": [
             {
               "type": "element",
@@ -949,8 +946,8 @@
               "value": "immobilize",
               "subActions": [
                 {
-                  "type": "target",
-                  "value": "%data.custom.gh2e.cragheart.abilities.129.1%",
+                  "type": "specialTarget",
+                  "value": "enemiesMovedThrough",
                   "small": true
                 }
               ]
@@ -1277,10 +1274,7 @@
             {
               "type": "custom",
               "value": "%data.custom.gh2e.cragheart.abilities.134.1%",
-              "small": true,
-              "enhancementTypes": [
-                "square"
-              ]
+              "small": true
             },
             {
               "type": "custom",

--- a/data/gh2e/label/en.json
+++ b/data/gh2e/label/en.json
@@ -404,7 +404,7 @@
             "1": "On your next four single-target ranged attack abilities, add +1%game.action.target%."
           },
           "122": {
-            "1": "Create a 1-hex obstacle tile in empty hexes within %game.action.range:3%.",
+            "1": "Create a 1-hex obstacle tile in empty hexes within %game.action.range:3% %game.enhancement.square% .",
             "2": "All allies adjacent to at least one created tile suffer %game.damage:1% and gain %game.condition.ward%, %game.card.experience:1%."
           },
           "123": {
@@ -443,7 +443,7 @@
             "3": "Destroy all obstacles, hazardous terrain, difficult terrain, and traps in hexes you enter."
           },
           "134": {
-            "1": "Create three 1-hex obstacle tiles in empty hexes within %game.action.range:3%",
+            "1": "Create three 1-hex obstacle tiles in empty hexes within %game.action.range:3% %game.enhancement.square% .",
             "2": "All allies and enemies adjacent to at least one created tile suffer %game.damage:1% and gain %game.condition.muddle%.",
             "3": "Designate one enemy within %game.action.range:4%. Destroy all obstacles within %game.action.range:2% of the designated enemy to perform:",
             "4": "the designated enemy",


### PR DESCRIPTION
# Description

I added the ability cards for Cragheart.

I run in 2 problems while creating the ability card, maybe you can solve these easily.

First, I can not implement an enhancement when it is included in a text, like in Earthen Bulwark:

<img width="303" height="132" alt="image" src="https://github.com/user-attachments/assets/110fccd3-a1e2-442f-9542-33cd5e467a2d" />

Second, I can't implement the AOE pattern of Wave of Destruction in the right orientation, it is twisted by 45°.

<img width="563" height="415" alt="image" src="https://github.com/user-attachments/assets/bffff3ff-4615-479f-af5c-6b543a1573a8" /> 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change that adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)