### PR TITLE
Fix GH2E Living Corpse Nothing Special initiative

### DIFF
--- a/data/gh2e/monster/deck/living-corpse.json
+++ b/data/gh2e/monster/deck/living-corpse.json
@@ -75,7 +75,7 @@
     {
       "name": "Nothing Special",
       "cardId": 755,
-      "initiative": 68,
+      "initiative": 66,
       "shuffle": true,
       "actions": [
         {
@@ -93,7 +93,7 @@
     {
       "name": "Nothing Special",
       "cardId": 756,
-      "initiative": 68,
+      "initiative": 66,
       "shuffle": true,
       "actions": [
         {


### PR DESCRIPTION
# Description

Initiative for one Living Corpse ability is slightly wrong.

## Type of change

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)