### PR TITLE
add monsters and special rules for scenario 9

### DIFF
--- a/data/gh2e/label/en.json
+++ b/data/gh2e/label/en.json
@@ -1041,6 +1041,12 @@
           "2": "At the end of his turn the Bandit Commander Performs %game.action.move% 20 %game.action.jump% to end on door %game.mapMarker.3% opening it.",
           "3": "At the end of his turn the Bandit Commander Performs %game.action.move% 20 %game.action.jump% to end on door %game.mapMarker.4% opening it.",
           "4": "At the end of his turn the Bandit Commander Performs %game.action.move% 20 %game.action.jump% to end on door %game.mapMarker.5% opening it."
+        },
+        "9": {
+          "1": "Draw a token and spawn the monster on %game.mapMarker.b%.",
+          "2": "Draw a token and spawn the monster on %game.mapMarker.c%.",
+          "3": "Draw two tokens and spawn the monsters on %game.mapMarker.b% and %game.mapMarker.c%.",
+          "4": "Draw two tokens and spawn the monsters on %game.mapMarker.d% and %game.mapMarker.e%."
         }
       }
     },

--- a/data/gh2e/scenarios/009.json
+++ b/data/gh2e/scenarios/009.json
@@ -13,7 +13,15 @@
       "military:1"
     ]
   },
-  "monsters": [],
+  "monsters": [
+    "chaos-demon",
+    "earth-demon",
+    "flame-demon",
+    "frost-demon",
+    "night-demon",
+    "sun-demon",
+    "wind-demon"
+  ],
   "objectives": [
     {
       "name": "Hail",
@@ -66,6 +74,28 @@
           ]
         }
       ]
+    }
+  ],
+  "rules": [
+    {
+      "round": "R == 1",
+      "start": true,
+      "note": "%data.scenario.rules.gh2e.9.1%"
+    },
+    {
+      "round": "R == 2",
+      "start": true,
+      "note": "%data.scenario.rules.gh2e.9.2%"
+    },
+    {
+      "round": "R > 2 && R % 2 == 0",
+      "start": true,
+      "note": "%data.scenario.rules.gh2e.9.3%"
+    },
+    {
+      "round": "R > 2 && R % 2 == 1",
+      "start": true,
+      "note": "%data.scenario.rules.gh2e.9.4%"
     }
   ],
   "rooms": [


### PR DESCRIPTION
# Description

In this scenario at the beginning are now monsters, but it will spawn each round random demons. I add all demons to the scenario key and the spawn notes on every round, where to spawn the random monsters.

## Type of change

Please delete options that are not relevant.

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)