### PR TITLE
Fix set-aside character icons for GH2E

### DIFF
--- a/src/app/ui/figures/party/party-sheet-dialog.html
+++ b/src/app/ui/figures/party/party-sheet-dialog.html
@@ -1110,7 +1110,7 @@
                   <a class="available-character" ghs-pointer-input (singleClick)="openCharacterSheet(characterModel)"
                     (doubleClick)="replayCharacter(characterModel)" [ghs-tooltip]="'character.replay.hint'">
                     <img
-                      [src]="'./assets/images/character/icons/' + characterModel.edition + '-' + characterModel.name + '.svg'" />
+                      [src]="'./assets/images/character/icons/' + (characterModel.edition === 'gh2e' ? 'gh' : characterModel.edition) + '-' + characterModel.name + '.svg'" />
                   </a>
                   }
                 </div>


### PR DESCRIPTION
# Description
Currently, the list of set-aside characters has broken icons when using GH2E characters, due to how editions are handled for that element. This change fixes the issue and renders the icons as normal.

Before:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/5e2a8014-0162-489b-8abe-17d7db4070b2" />

After:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/a955956d-4a97-4821-9e49-175385d5d8c6" />


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)