### PR TITLE
GH2E character automation

### DIFF
--- a/data/gh2e/character/three-spears.json
+++ b/data/gh2e/character/three-spears.json
@@ -17,6 +17,11 @@
   ],
   "color": "#cd8229",
   "spoiler": true,
+  "specialActions": [
+    {
+      "name": "supply_tokens"
+    }
+  ],
   "stats": [
     {
       "level": 1,

--- a/data/gh2e/label/spoiler/en.json
+++ b/data/gh2e/label/spoiler/en.json
@@ -20,7 +20,16 @@
       "saw": "Sawbones",
       "squidface": "Plagueherald",
       "sun": "Sunkeeper",
-      "three-spears": "Quartermaster",
+      "three-spears": {
+        "": "Quartermaster",
+        "tokens": {
+          "supplies": "Supplies"
+        },
+        "supply_tokens": {
+          "": "Supply Token",
+          "hint": "Gain 1 Supply Token (10 supplies) at the start of the scenario, as well as during each rest (with Perk 11)."
+        }
+      },
       "triangles": {
         "": "Elementalist",
         "element_waning": {

--- a/src/app/game/businesslogic/RoundManager.ts
+++ b/src/app/game/businesslogic/RoundManager.ts
@@ -459,6 +459,10 @@ export class RoundManager {
         gameManager.entityManager.addCondition(figure, figure, new Condition(ConditionName.heal, heal));
         gameManager.entityManager.applyCondition(figure, figure, ConditionName.heal, true);
       }
+
+      if (figure.name == 'three-spears' && figure.tags.find((tag) => tag === 'supply_tokens') && figure.primaryToken == 0 && figure.tokenValues[0] < 5 && figure.progress.perks[10] >= 2) {
+        figure.tokenValues[0] += 1;
+      }
     }
 
     if (figure instanceof Character && !gameManager.entityManager.isAlive(figure) || figure instanceof Monster && figure.entities.every((entity) => !gameManager.entityManager.isAlive(entity)) || figure instanceof ObjectiveContainer && figure.entities.every((entity) => !gameManager.entityManager.isAlive(entity))) {
@@ -688,6 +692,16 @@ export class RoundManager {
         if (figure.name == 'shards' && figure.tags.find((tag) => tag === 'extra_resonance_tokens') && figure.primaryToken == 0) {
           figure.tokenValues[0] += 2;
           gameManager.entityManager.addCondition(figure, figure, new Condition(ConditionName.brittle));
+        }
+
+        if (figure.name == 'three-spears' && figure.tags.find((tag) => tag === 'supply_tokens') && figure.primaryToken == 0) {
+          figure.tokenValues[0] += 1;
+        }
+
+        if (figure.name == 'eclipse' && figure.edition == 'gh2e') {
+          let eclipseInvisible = new EntityCondition(ConditionName.invisible);
+          eclipseInvisible.permanent = true;
+          figure.entityConditions.push(eclipseInvisible);
         }
 
         figure.availableSummons.filter((summonData) => summonData.special).forEach((summonData) => gameManager.characterManager.createSpecialSummon(figure, summonData));


### PR DESCRIPTION
# Description

- Adds automation for giving Three Spears supplies at the start of scenario and during long rest
  - Must be enabled in the character's popout menu
- Automatically applies permanent invisible to Eclipse at the start of the scenario

## Type of change

- [x] New feature (non-breaking change that adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)