### PR TITLE
Correct Sewer Monstrosity summon stats

### DIFF
--- a/data/mp/character/anaphi.json
+++ b/data/mp/character/anaphi.json
@@ -53,8 +53,8 @@
       "thumbnail": true,
       "level": 1,
       "health": 4,
-      "attack": 3,
-      "movement": 2
+      "attack": 2,
+      "movement": 3
     },
     {
       "name": "duskrat-swarm",


### PR DESCRIPTION
# Description

The Sewer Monstrosity move and attack stats were swapped.
<img src="https://github.com/user-attachments/assets/ec1ea49e-f828-4d44-923c-d71905be2fd9" width="200px" />


Fixes # (link to related issue here)

## Type of change

Please delete options that are not relevant.

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)