### PR TITLE
Cragheart Solo fix(es)

### DIFF
--- a/data/gh2e/scenarios/solo89_cragheart.json
+++ b/data/gh2e/scenarios/solo89_cragheart.json
@@ -74,7 +74,9 @@
     {
       "roomNumber": 1,
       "initial": true,
-      "monster": []
+      "objectives": [
+        1
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Description

- Corrects Black Imp spawns to correctly include an Elite
- _Attempts_ to correct the Crystal objective so that it actually spawns... but the fix doesn't seem to work, and I'm not sure what I'm missing. @Lurkars if you've got any idea, I don't know what the deal is with that, exactly.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)