### PR TITLE
add NGINX_ACCESS_LOG env variable to toggle access logs when using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine as builder
+FROM node:24-alpine AS builder
 WORKDIR /src
 COPY package.json /src/
 COPY package-lock.json /src/
@@ -8,4 +8,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=builder /src/dist/gloomhavensecretariat /usr/share/nginx/html
+COPY docker-entrypoint.d/ /docker-entrypoint.d/
+RUN chmod +x /docker-entrypoint.d/*.sh
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -231,6 +231,12 @@ docker run --rm -p 80:80 --name ghs gloomhavensecretariat/ghs
 
 For use with docker compose, just run `docker compose up -d`.
 
+#### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NGINX_ACCESS_LOG` | `on` (nginx default) | Set to `off` to disable nginx access logs. |
+
 ## Building from source
 
 If you want to create your own custom build (e.g. for [self-hosting](#Selfhosting)), prepare a [development setup](#development). Then run `npm run build` ([available options](https://angular.io/cli/build#options)) and access the build at `./dist/gloomhavensecretariat`.

--- a/docker-entrypoint.d/40-access-log.sh
+++ b/docker-entrypoint.d/40-access-log.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+if [ "${NGINX_ACCESS_LOG:-on}" = "off" ]; then
+    sed -i 's|access_log .*|access_log off;|' /etc/nginx/nginx.conf
+fi


### PR DESCRIPTION
Add a docker-entrypoint.d/40-access-log.sh script that disables nginx access logs when NGINX_ACCESS_LOG=off is set. The script is picked up automatically by the nginx image's entrypoint, leaving all other nginx defaults intact. Documented the variable in README.md.

# Description

I have not created an issue. But I do not like that every request i logged, so I enabled ENV variable when running in docker that will disable the access logs.

## Type of change

Please delete options that are not relevant.

- [X ] New feature (non-breaking change that adds functionality)

# Checklist:

- [ X] I have performed a self-review of my code
- [ X] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)