### PR TITLE
add tear hex tokens to eclipse ability cards

### DIFF
--- a/data/gh2e/character/deck/eclipse.json
+++ b/data/gh2e/character/deck/eclipse.json
@@ -15,7 +15,7 @@
           "subActions": [
             {
               "type": "area",
-              "value": "(0,1,active)|(1,1,target)|(2,1,target)|(3,1,enhance)",
+              "value": "(0,1,active)|(1,1,target)|(2,0,custom:gh2e-tear)|(2,1,target)|(3,1,enhance)",
               "enhancementTypes": [
                 "hex"
               ]
@@ -353,7 +353,7 @@
             },
             {
               "type": "area",
-              "value": "(0,0,active)|(1,0,target)"
+              "value": "(0,0,active)|(1,0,target)|(2,0,custom:gh2e-tear)"
             }
           ]
         }
@@ -942,7 +942,7 @@
           "subActions": [
             {
               "type": "area",
-              "value": "(0,1,target)|(0,2,active)|(1,0,target)|(1,1,target)|(1,2,target)|(2,0,target)|(2,1,target)|(2,2,target)|(3,0,enhance)|(3,1,enhance)|(3,2,enhance)",
+              "value": "(0,0,custom:gh2e-tear)|(0,1,target)|(0,2,active)|(1,0,target)|(1,1,target)|(1,2,target)|(2,0,target)|(2,1,target)|(2,2,target)|(3,0,enhance)|(3,1,enhance)|(3,2,enhance)",
               "enhancementTypes": [
                 "hex",
                 "hex",
@@ -1053,7 +1053,7 @@
           "subActions": [
             {
               "type": "area",
-              "value": "(0,1,active)|(1,0,target)|(1,2,target)"
+              "value": "(0,1,active)|(1,0,target)|(1,1,custom:gh2e-tear)|(1,2,target)"
             }
           ]
         },
@@ -1578,7 +1578,7 @@
             },
             {
               "type": "area",
-              "value": "(0,1,active)|(1,0,target)|(1,1,target)|(2,1,enhance)",
+              "value": "(0,1,active)|(1,0,target)|(1,1,target)|(2,0,custom:gh2e-tear)|(2,1,enhance)",
               "enhancementTypes": [
                 "hex"
               ]
@@ -1770,7 +1770,7 @@
             },
             {
               "type": "area",
-              "value": "(0,1,target)|(0,2,active)|(1,1,target)|(1,2,target)|(2,0,enhance)|(2,1,enhance)",
+              "value": "(0,1,target)|(0,2,active)|(1,0,custom:gh2e-tear)|(1,1,target)|(1,2,target)|(2,0,enhance)|(2,1,enhance)|(2,2,custom:gh2e-tear)",
               "enhancementTypes": [
                 "hex",
                 "hex"

--- a/scripts/sort/sorter/action.mjs
+++ b/scripts/sort/sorter/action.mjs
@@ -32,7 +32,7 @@ export const sortAction = function (action) {
         let hexes = [];
 
         action.value.split('|').forEach((hexString) => {
-            let groups = new RegExp(/^\((\d+),(\d+),(active|target|conditional|ally|blank|enhance|invisible)(\:(\w*))?\)$/).exec(hexString);
+            let groups = new RegExp(/^\((\d+),(\d+),(active|target|conditional|ally|blank|enhance|invisible|custom)(\:([\w-]*))?\)$/).exec(hexString);
             if (groups == null) {
                 return null;
             }


### PR DESCRIPTION
# Description

Adds tear hex tokens to eclipse ability cards and fix the commit hook to not remove the tear token hexes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)