### PR TITLE
GH2E item 120 fix

### DIFF
--- a/data/gh2e/items.json
+++ b/data/gh2e/items.json
@@ -2552,12 +2552,6 @@
         "value": "%data.items.gh2e-120.1%",
         "small": true
       }
-    ],
-    "effects": [
-      {
-        "type": "condition",
-        "value": "strengthen"
-      }
     ]
   },
   {

--- a/src/app/game/businesslogic/RoundManager.ts
+++ b/src/app/game/businesslogic/RoundManager.ts
@@ -533,6 +533,17 @@ export class RoundManager {
       ) {
         figure.tokenValues[0] += 1;
       }
+
+      if (settingsManager.settings.characterItemsApply) {
+        figure.progress.equippedItems.forEach((identifier) => {
+          if (identifier.tags) {
+            const item = gameManager.itemManager.getItem(identifier.name, identifier.edition, true);
+            if (item && item.id == 120 && item.edition === 'gh2e') {
+              gameManager.entityManager.addCondition(figure, figure, new Condition(ConditionName.strengthen));
+            }
+          }
+        });
+      }
     }
 
     if (


### PR DESCRIPTION
# Description

Currently, item 120 incorrectly applies strengthen at the beginning of the scenario, rather than during long rests. This PR resolves this issue. This implementation only causes the item to have an effect if the _Apply item actions_ setting is enabled.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)