### PR TITLE
GH2E scenario errata & fixes

### DIFF
--- a/data/fh/label/en.json
+++ b/data/fh/label/en.json
@@ -1529,7 +1529,7 @@
         "scenario117": "1st Printing: This scenario setup has 5 Polar bears but there are only 4 standees. A fifth Polar bear should be 'proxied' from other available standees or minis. (Fixed in GHS!)",
         "scenario130": "1st Printing: Key - Shrike Fiend has an image of Night Demon. (Fixed in GHS!)",
         "scenario18": "1st Printing: Map layout and map: The right 11 tile should be 11-C.",
-        "scenario28": "1st Printing: Archers should spawn at D and Guards at E. The exit hexes are likewise swapped.(Fixed in GHS!)",
+        "scenario28": "1st Printing: Archers should spawn at D and Guards at E. The exit hexes are likewise swapped. (Fixed in GHS!)",
         "scenario36-37": "1st Printing: Add the blueprint for Item 067 to the Scenario Rewards. (Fixed in GHS!)",
         "scenario37": "1st Printing: Treasure Chest should be #56. (Fixed in GHS!)",
         "scenario60": "1st Printing: should have Item 224 as a scenario reward. (Fixed in GHS!)",

--- a/data/gh2e/label/en.json
+++ b/data/gh2e/label/en.json
@@ -791,7 +791,8 @@
         "scenario26": "Monsters on tiles 2-D and 10-B should not be set up at the start of the scenario, with the exception of the City Archers located adjacent to the wall section overlays. (Fixed in GHS!)",
         "scenario56": "The Gloom treats all %game.attackmodifier.null% cards as %game.attackmodifier.plus0%, not as %game.attackmodifier.null%. The Gloom's Boss Specials 1 and 2 should say \"a viable attack hex\" instead of \"an empty hex,\" choosing a non-negative hex when possible.",
         "scenario62": "The map layout has Tile 06 with only slots and no tabs. The flat side should be laid adjacent to the other tiles, with the tab side facing out.",
-        "scenario80": "There aren't enough Stone Colossus standees for a 4-player setup. Proxy another standee for the 5th."
+        "scenario80": "There aren't enough Stone Colossus standees for a 4-player setup. Proxy another standee for the 5th.",
+        "section112-3": "The Gloom treats all %game.attackmodifier.null% cards as %game.attackmodifier.plus0%, not as %game.attackmodifier.null%."
       },
       "flame-demon": {
         "1": "Create one %game.damage:4% trap in an adjacent<br>empty hex closest to an enemy",

--- a/data/gh2e/label/en.json
+++ b/data/gh2e/label/en.json
@@ -786,6 +786,13 @@
         "1": "If the attack ability was performed",
         "2": "in an empty hex adjacent to the target<br>of the attack ability"
       },
+      "errata": {
+        "scenario8": "Scenario Goals should read, \"The scenario is complete when the Bandit Commander and all revealed enemies are dead\"",
+        "scenario26": "Monsters on tiles 2-D and 10-B should not be set up at the start of the scenario, with the exception of the City Archers located adjacent to the wall section overlays. (Fixed in GHS!)",
+        "scenario56": "The Gloom treats all %game.attackmodifier.null% cards as %game.attackmodifier.plus0%, not as %game.attackmodifier.null%. The Gloom's Boss Specials 1 and 2 should say \"a viable attack hex\" instead of \"an empty hex,\" choosing a non-negative hex when possible.",
+        "scenario62": "The map layout has Tile 06 with only slots and no tabs. The flat side should be laid adjacent to the other tiles, with the tab side facing out.",
+        "scenario80": "There aren't enough Stone Colossus standees for a 4-player setup. Proxy another standee for the 5th."
+      },
       "flame-demon": {
         "1": "Create one %game.damage:4% trap in an adjacent<br>empty hex closest to an enemy",
         "2": "%game.damage:1%",

--- a/data/gh2e/monster/deck/cultist-scenario-54.json
+++ b/data/gh2e/monster/deck/cultist-scenario-54.json
@@ -154,7 +154,7 @@
       "actions": [
         {
           "type": "custom",
-          "value": "The highest health enemy within %game.action.range% 5 and within line-of-sight suffers Damage X."
+          "value": "The highest health enemy within %game.action.range:5% and within line-of-sight suffers %game.damage:X%."
         },
         {
           "type": "grid",
@@ -165,8 +165,8 @@
               "value": "X",
               "subActions": [
                 {
-                  "type": "specialTarget",
-                  "value": "self",
+                  "type": "range",
+                  "value": 5,
                   "small": true
                 }
               ]

--- a/data/gh2e/monster/stone-construct-scenario-80.json
+++ b/data/gh2e/monster/stone-construct-scenario-80.json
@@ -1,0 +1,210 @@
+{
+  "name": "stone-construct-scenario-80",
+  "edition": "gh2e",
+  "deck": "stone-construct",
+  "hidden": true,
+  "standeeCount": 5,
+  "standeeShare": "stone-construct",
+  "baseStat": {
+    "type": "normal",
+    "immunities": [
+      "immobilize"
+    ]
+  },
+  "stats": [
+    {
+      "level": 0,
+      "health": 10,
+      "movement": 1,
+      "attack": 3
+    },
+    {
+      "level": 1,
+      "health": 10,
+      "movement": 1,
+      "attack": 3,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "level": 2,
+      "health": 11,
+      "movement": 1,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "level": 3,
+      "health": 11,
+      "movement": 1,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 4,
+      "health": 12,
+      "movement": 2,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 5,
+      "health": 13,
+      "movement": 2,
+      "attack": 5,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 6,
+      "health": 19,
+      "movement": 2,
+      "attack": 5,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "level": 7,
+      "health": 22,
+      "movement": 2,
+      "attack": 5,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 0,
+      "health": 10,
+      "movement": 2,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 1,
+      "health": 11,
+      "movement": 2,
+      "attack": 4,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 2,
+      "health": 14,
+      "movement": 2,
+      "attack": 5,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 3,
+      "health": 15,
+      "movement": 2,
+      "attack": 5,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 4,
+      "health": 17,
+      "movement": 2,
+      "attack": 6,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 5,
+      "health": 19,
+      "movement": 3,
+      "attack": 6,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 6,
+      "health": 23,
+      "movement": 3,
+      "attack": 7,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "type": "elite",
+      "level": 7,
+      "health": 26,
+      "movement": 3,
+      "attack": 7,
+      "actions": [
+        {
+          "type": "shield",
+          "value": 4
+        }
+      ]
+    }
+  ]
+}

--- a/data/gh2e/monster/the-gloom.json
+++ b/data/gh2e/monster/the-gloom.json
@@ -19,13 +19,88 @@
       [
         {
           "type": "custom",
-          "value": "See monster stat sheet."
+          "value": "Focus on the lowest hit point character with a viable attack hex adjacent to them"
+        },
+        {
+          "type": "move",
+          "value": 0,
+          "valueType": "plus",
+          "subActions": [
+            {
+              "type": "jump",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": "C+3",
+              "valueType": "plus"
+            },
+            {
+              "type": "custom",
+              "value": "%game.damage% suffered from this attack is divided evenly between the target and all allies adjacent to them",
+              "small": true
+            }
+          ]
         }
       ],
       [
         {
           "type": "custom",
-          "value": "See monster stat sheet."
+          "value": "Focus on the highest hit point character with a viable attack hex adjacent to them"
+        },
+        {
+          "type": "move",
+          "value": 0,
+          "valueType": "plus",
+          "subActions": [
+            {
+              "type": "jump",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 0,
+              "valueType": "plus"
+            },
+            {
+              "type": "custom",
+              "value": "Add %game.condition.wound%, %game.condition.poison%, and %game.condition.immobilize% if you have %game.condition.ward%.",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 2,
+              "subActions": [
+                {
+                  "type": "jump",
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "Move as far from the focus as possible",
+              "small": true
+            }
+          ]
         }
       ]
     ]

--- a/data/gh2e/monster/the-gloom.json
+++ b/data/gh2e/monster/the-gloom.json
@@ -43,7 +43,7 @@
             },
             {
               "type": "custom",
-              "value": "%game.damage% suffered from this attack is divided evenly between the target and all allies adjacent to them",
+              "value": "%game.damage% suffered from this attack is divided evenly between the target and all enemies adjacent to them",
               "small": true
             }
           ]
@@ -76,7 +76,7 @@
             },
             {
               "type": "custom",
-              "value": "Add %game.condition.wound%, %game.condition.poison%, and %game.condition.immobilize% if you have %game.condition.ward%.",
+              "value": "Add %game.condition.wound%, %game.condition.poison%, and %game.condition.immobilize% if The Gloom has %game.condition.ward%.",
               "small": true
             }
           ]

--- a/data/gh2e/scenarios/008.json
+++ b/data/gh2e/scenarios/008.json
@@ -2,6 +2,7 @@
   "index": "8",
   "name": "Barrow Lair",
   "flowChartGroup": "merchant-guild",
+  "errata": "scenario8",
   "edition": "gh2e",
   "eventType": "road",
   "unlocks": [

--- a/data/gh2e/scenarios/026.json
+++ b/data/gh2e/scenarios/026.json
@@ -2,6 +2,7 @@
   "index": "26",
   "name": "Gloomhaven Battlements B",
   "flowChartGroup": "demons",
+  "errata": "scenario26",
   "edition": "gh2e",
   "unlocks": [
     "23"

--- a/data/gh2e/scenarios/055.json
+++ b/data/gh2e/scenarios/055.json
@@ -20,12 +20,20 @@
       "name": "Hail",
       "escort": true,
       "health": "4+(2xL)",
-      "initiative": 99
+      "initiative": 99,
+      "marker": "a",
+      "actions": [
+        {
+          "type": "custom",
+          "value": "Remove one damage token from the pile next to the map."
+        }
+      ]
     },
     {
-      "name": "Stone Pillar H",
+      "name": "Stone Pillar",
       "health": "8+CxL",
-      "initiative": 99
+      "initiative": 99,
+      "marker": "h"
     }
   ],
   "rules": [

--- a/data/gh2e/scenarios/056.json
+++ b/data/gh2e/scenarios/056.json
@@ -18,6 +18,74 @@
     "harrower-infester",
     "the-gloom"
   ],
+  "rules": [
+    {
+      "round": "R % 3 != 0",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "the-gloom"
+          },
+          "type": "permanentCondition",
+          "value": "ward",
+          "scenarioEffect": false
+        }
+      ]
+    },
+    {
+      "round": "R % 3 == 0",
+      "start": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "the-gloom"
+          },
+          "type": "losePermanentCondition",
+          "value": "ward",
+          "scenarioEffect": false
+        }
+      ],
+      "spawns": [
+        {
+          "monster": {
+            "name": "chaos-demon",
+            "player2": "normal",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "black-imp",
+            "player2": "normal"
+          },
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "black-imp",
+            "player3": "normal",
+            "player4": "normal"
+          },
+          "count": 2,
+          "marker": "c"
+        },
+        {
+          "monster": {
+            "name": "harrower-infester",
+            "player2": "normal",
+            "player3": "elite",
+            "player4": "elite"
+          },
+          "marker": "c"
+        }
+      ]
+    }
+  ],
   "rooms": [
     {
       "roomNumber": 1,

--- a/data/gh2e/scenarios/056.json
+++ b/data/gh2e/scenarios/056.json
@@ -2,6 +2,7 @@
   "index": "56",
   "name": "The Gloom",
   "flowChartGroup": "the-gloom",
+  "errata": "scenario56",
   "edition": "gh2e",
   "rewards": {
     "globalAchievements": [

--- a/data/gh2e/scenarios/062.json
+++ b/data/gh2e/scenarios/062.json
@@ -2,6 +2,7 @@
   "index": "62",
   "name": "Alchemy Lab",
   "flowChartGroup": "personal-quests",
+  "errata": "scenario62",
   "edition": "gh2e",
   "rewards": {
     "prosperity": 1

--- a/data/gh2e/scenarios/080.json
+++ b/data/gh2e/scenarios/080.json
@@ -1,6 +1,7 @@
 {
   "index": "80",
   "name": "Lost Temple",
+  "errata": "scenario80",
   "edition": "gh2e",
   "eventType": "road",
   "rewards": {
@@ -14,7 +15,7 @@
     }
   },
   "monsters": [
-    "stone-construct"
+    "stone-construct-scenario-80"
   ],
   "objectives": [
     {
@@ -30,24 +31,24 @@
       "initial": true,
       "monster": [
         {
-          "name": "stone-construct",
+          "name": "stone-construct-scenario-80",
           "type": "normal"
         },
         {
-          "name": "stone-construct",
+          "name": "stone-construct-scenario-80",
           "type": "elite"
         },
         {
-          "name": "stone-construct",
+          "name": "stone-construct-scenario-80",
           "type": "elite"
         },
         {
-          "name": "stone-construct",
+          "name": "stone-construct-scenario-80",
           "player3": "elite",
           "player4": "elite"
         },
         {
-          "name": "stone-construct",
+          "name": "stone-construct-scenario-80",
           "player4": "elite"
         }
       ],

--- a/data/gh2e/scenarios/080.json
+++ b/data/gh2e/scenarios/080.json
@@ -22,7 +22,24 @@
       "name": "Chereth",
       "escort": true,
       "health": "6+2xL",
-      "initiative": 99
+      "initiative": 99,
+      "actions": [
+        {
+          "type": "move",
+          "value": "to starting location"
+        },
+        {
+          "type": "attack",
+          "value": 3,
+          "subActions": [
+            {
+              "type": "target",
+              "value": "all adjacent enemies",
+              "small": true
+            }
+          ]
+        }
+      ]
     }
   ],
   "rooms": [

--- a/data/gh2e/sections/112-3.json
+++ b/data/gh2e/sections/112-3.json
@@ -1,9 +1,28 @@
 {
   "index": "112.3",
+  "errata": "section112-3",
   "edition": "gh2e",
   "parent": "54",
   "monsters": [
     "the-gloom"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "start": true,
+      "always": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "monster",
+            "name": "the-gloom"
+          },
+          "type": "permanentCondition",
+          "value": "ward",
+          "scenarioEffect": false
+        }
+      ]
+    }
   ],
   "rooms": [
     {

--- a/data/gh2e/sections/88-1.json
+++ b/data/gh2e/sections/88-1.json
@@ -1,0 +1,63 @@
+{
+  "index": "88.1",
+  "edition": "gh2e",
+  "parent": "80",
+  "marker": "1",
+  "monsters": [
+    "giant-viper",
+    "the-betrayer"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Chereth"
+          },
+          "type": "remove"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "giant-viper",
+            "type": "elite"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "giant-viper",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    }
+  ],
+  "rooms": [
+    {
+      "roomNumber": 2,
+      "initial": true,
+      "treasures": [
+        14
+      ],
+      "monster": [
+        {
+          "name": "the-betrayer",
+          "type": "boss"
+        }
+      ]
+    }
+  ]
+}

--- a/data/gh2e/sections/92-1.json
+++ b/data/gh2e/sections/92-1.json
@@ -1,0 +1,63 @@
+{
+  "index": "92.1",
+  "edition": "gh2e",
+  "parent": "80",
+  "marker": "1",
+  "monsters": [
+    "giant-viper",
+    "the-betrayer"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Chereth"
+          },
+          "type": "remove"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "giant-viper",
+            "type": "elite"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "giant-viper",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    }
+  ],
+  "rooms": [
+    {
+      "roomNumber": 2,
+      "initial": true,
+      "treasures": [
+        14
+      ],
+      "monster": [
+        {
+          "name": "the-betrayer",
+          "type": "boss"
+        }
+      ]
+    }
+  ]
+}

--- a/data/gh2e/sections/96-1.json
+++ b/data/gh2e/sections/96-1.json
@@ -1,0 +1,63 @@
+{
+  "index": "96.1",
+  "edition": "gh2e",
+  "parent": "80",
+  "marker": "1",
+  "monsters": [
+    "giant-viper",
+    "the-betrayer"
+  ],
+  "rules": [
+    {
+      "round": "true",
+      "always": true,
+      "once": true,
+      "figures": [
+        {
+          "identifier": {
+            "type": "objective",
+            "edition": "objective",
+            "name": "Chereth"
+          },
+          "type": "remove"
+        }
+      ]
+    },
+    {
+      "round": "true",
+      "start": true,
+      "spawns": [
+        {
+          "monster": {
+            "name": "giant-viper",
+            "type": "elite"
+          },
+          "marker": "d"
+        },
+        {
+          "monster": {
+            "name": "giant-viper",
+            "player3": "normal",
+            "player4": "elite"
+          },
+          "marker": "e"
+        }
+      ]
+    }
+  ],
+  "rooms": [
+    {
+      "roomNumber": 2,
+      "initial": true,
+      "treasures": [
+        14
+      ],
+      "monster": [
+        {
+          "name": "the-betrayer",
+          "type": "boss"
+        }
+      ]
+    }
+  ]
+}

--- a/data/schema.json
+++ b/data/schema.json
@@ -1582,6 +1582,7 @@
                         "setHp",
                         "killed",
                         "loseCondition",
+                        "losePermanentCondition",
                         "present",
                         "remove",
                         "toggleOff",

--- a/src/app/game/businesslogic/ScenarioRulesManager.ts
+++ b/src/app/game/businesslogic/ScenarioRulesManager.ts
@@ -863,6 +863,7 @@ export class ScenarioRulesManager {
               figureRule.type === 'gainCondition' ||
               figureRule.type === 'permanentCondition' ||
               figureRule.type === 'loseCondition' ||
+              figureRule.type === 'losePermanentCondition' ||
               figureRule.type === 'damage' ||
               figureRule.type === 'heal' ||
               figureRule.type === 'setHp' ||
@@ -895,6 +896,12 @@ export class ScenarioRulesManager {
                     const loseCondition = new Condition(figureRule.value);
                     if (gameManager.entityManager.hasCondition(entity, loseCondition)) {
                       gameManager.entityManager.removeCondition(entity, figure, loseCondition);
+                    }
+                    break;
+                  case 'losePermanentCondition':
+                    const losePermanentCondition = new Condition(figureRule.value);
+                    if (gameManager.entityManager.hasCondition(entity, losePermanentCondition, true)) {
+                      gameManager.entityManager.removeCondition(entity, figure, losePermanentCondition, true);
                     }
                     break;
                   case 'damage':

--- a/src/app/game/model/data/ScenarioRule.ts
+++ b/src/app/game/model/data/ScenarioRule.ts
@@ -91,6 +91,7 @@ export type ScenarioFigureRuleTypes =
   | 'initiative'
   | 'gainCondition'
   | 'loseCondition'
+  | 'losePermanentCondition'
   | 'permanentCondition'
   | 'damage'
   | 'setHp'

--- a/src/app/ui/footer/scenario-rules/scenario-rule.ts
+++ b/src/app/ui/footer/scenario-rules/scenario-rule.ts
@@ -156,7 +156,12 @@ export class ScenarioRuleComponent implements OnInit {
             return false;
           }
 
-          if (figureRule.type === 'gainCondition' || figureRule.type === 'permanentCondition' || figureRule.type === 'loseCondition') {
+          if (
+            figureRule.type === 'gainCondition' ||
+            figureRule.type === 'permanentCondition' ||
+            figureRule.type === 'loseCondition' ||
+            figureRule.type === 'losePermanentCondition'
+          ) {
             return figures.some((figure) => {
               if (figureRule.type === 'gainCondition') {
                 const entities: Entity[] = gameManager.entityManager.entities(figure);
@@ -174,6 +179,12 @@ export class ScenarioRuleComponent implements OnInit {
                 const entities: Entity[] = gameManager.entityManager.entities(figure);
                 const loseCondition = new Condition(figureRule.value);
                 if (entities.every((entity) => !gameManager.entityManager.hasCondition(entity, loseCondition))) {
+                  return false;
+                }
+              } else if (figureRule.type === 'losePermanentCondition') {
+                const entities: Entity[] = gameManager.entityManager.entities(figure);
+                const losePermanentCondition = new Condition(figureRule.value);
+                if (entities.every((entity) => !gameManager.entityManager.hasCondition(entity, losePermanentCondition, true))) {
                   return false;
                 }
               }
@@ -214,6 +225,12 @@ export class ScenarioRuleComponent implements OnInit {
               const entities: Entity[] = gameManager.entityManager.entities(figure);
               const loseCondition = new Condition(figureRule.value);
               if (entities.every((entity) => !gameManager.entityManager.hasCondition(entity, loseCondition))) {
+                return false;
+              }
+            } else if (figureRule.type === 'losePermanentCondition') {
+              const entities: Entity[] = gameManager.entityManager.entities(figure);
+              const losePermanentCondition = new Condition(figureRule.value);
+              if (entities.every((entity) => !gameManager.entityManager.hasCondition(entity, losePermanentCondition, true))) {
                 return false;
               }
             } else if (figureRule.type === 'toggleOn' || figureRule.type === 'toggleOff') {

--- a/src/app/ui/footer/scenario-rules/scenario-rules.ts
+++ b/src/app/ui/footer/scenario-rules/scenario-rules.ts
@@ -156,7 +156,12 @@ export class ScenarioRulesComponent {
             return false;
           }
 
-          if (figureRule.type === 'gainCondition' || figureRule.type === 'permanentCondition' || figureRule.type === 'loseCondition') {
+          if (
+            figureRule.type === 'gainCondition' ||
+            figureRule.type === 'permanentCondition' ||
+            figureRule.type === 'loseCondition' ||
+            figureRule.type === 'losePermanentCondition'
+          ) {
             return figures.some((figure) => {
               if (figureRule.type === 'gainCondition') {
                 const entities: Entity[] = gameManager.entityManager.entities(figure);
@@ -174,6 +179,12 @@ export class ScenarioRulesComponent {
                 const entities: Entity[] = gameManager.entityManager.entities(figure);
                 const loseCondition = new Condition(figureRule.value);
                 if (entities.every((entity) => !gameManager.entityManager.hasCondition(entity, loseCondition))) {
+                  return false;
+                }
+              } else if (figureRule.type === 'losePermanentCondition') {
+                const entities: Entity[] = gameManager.entityManager.entities(figure);
+                const losePermanentCondition = new Condition(figureRule.value);
+                if (entities.every((entity) => !gameManager.entityManager.hasCondition(entity, losePermanentCondition, true))) {
                   return false;
                 }
               }

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -2077,6 +2077,7 @@
         "gainCondition": "{0} gain %game.condition.{1}%",
         "heal": "{0} %game.action.heal% {2}",
         "loseCondition": "{0} lose %game.condition.{1}%",
+        "losePermanentCondition": "{0} lose permanent %game.condition.{1}%",
         "permanentCondition": "{0} gain permanent %game.condition.{1}%",
         "remove": "Remove {0}",
         "removeAbility": "Remove ability card '{1}' of {0}",


### PR DESCRIPTION
# Description

- Adds errata notices for GH2E scenarios. Also allows 5 Stone Constructs to be spawned during scenario 80 to account for its errata.
- Adds special rules and fixes for scenarios 54, 55, 56, and 80.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)