### PR TITLE
GH2E item fixes

### DIFF
--- a/data/gh2e/label/spoiler/en.json
+++ b/data/gh2e/label/spoiler/en.json
@@ -628,7 +628,7 @@
     },
     "gh2e-115": {
       "": "Rod of Transference",
-      "1": "When an ally within %game.action.range:3% would suffer %game.damage% you suffer the %game.damage% instead"
+      "1": "When an ally within %game.action.range:3% would suffer %game.damage%, you suffer the %game.damage% instead."
     },
     "gh2e-116": {
       "": "Fated Verses",

--- a/data/gh2e/label/spoiler/en.json
+++ b/data/gh2e/label/spoiler/en.json
@@ -1025,7 +1025,7 @@
     },
     "gh2e-49": {
       "": "Horned Helm",
-      "1": "After you move 4 of more hexes on your turn, add %game.action.attack.valueSign:1% to your next melee attack this turn."
+      "1": "After you move 4 or more hexes on your turn, add %game.action.attack.valueSign:1% to your next melee attack this turn."
     },
     "gh2e-5": {
       "": "Scouting Lens",

--- a/data/gh2e/label/spoiler/en.json
+++ b/data/gh2e/label/spoiler/en.json
@@ -637,11 +637,11 @@
     },
     "gh2e-117": {
       "": "Dawnblade",
-      "1": "During your turn, if %game.element.dark% is strong or waning, add %game.action.attack.valueSign:1% to your next melee attack. If you brought <i>Duskbrand</i> %game.element.light%."
+      "1": "During your turn, if %game.element.dark% is strong or waning, add %game.action.attack.valueSign:1% to your next melee attack. If you brought <i>Duskbrand</i>, %game.element.light%."
     },
     "gh2e-118": {
       "": "Duskbrand",
-      "1": "During your turn, if %game.element.light% is strong or waning, add %game.action.attack.valueSign:1% to your next melee attack. If you brought <i>Dawnblade</i> %game.element.dark%."
+      "1": "During your turn, if %game.element.light% is strong or waning, add %game.action.attack.valueSign:1% to your next melee attack. If you brought <i>Dawnblade</i>, %game.element.dark%."
     },
     "gh2e-119": {
       "": "Drakescale Boots",

--- a/data/gh2e/label/spoiler/en.json
+++ b/data/gh2e/label/spoiler/en.json
@@ -658,7 +658,7 @@
     "gh2e-121": {
       "": "Drakescale Helm",
       "1": "During your turn, perform:",
-      "2": "If you brought Drakescale Boots and Drakescale Armor, add %game.action.target.valueSign:1%."
+      "2": "If you brought <i>Drakescale Boots</i> and <i>Drakescale Armor</i>, add %game.action.target.valueSign:1%."
     },
     "gh2e-122": {
       "": "Frost Beetle Lantern",

--- a/data/gh2e/label/spoiler/en.json
+++ b/data/gh2e/label/spoiler/en.json
@@ -637,11 +637,11 @@
     },
     "gh2e-117": {
       "": "Dawnblade",
-      "1": "During your turn, if %game.element.dark% is strong or waning add %game.action.attack.valueSign:1% to your next melee attack. If you brought Duskbrand %game.element.light%."
+      "1": "During your turn, if %game.element.dark% is strong or waning, add %game.action.attack.valueSign:1% to your next melee attack. If you brought <i>Duskbrand</i> %game.element.light%."
     },
     "gh2e-118": {
       "": "Duskbrand",
-      "1": "During your turn if %game.element.light% is strong or waning add %game.action.attack.valueSign:1% to your next melee attack. If you brought Dawnblade %game.element.dark%."
+      "1": "During your turn, if %game.element.light% is strong or waning, add %game.action.attack.valueSign:1% to your next melee attack. If you brought <i>Dawnblade</i> %game.element.dark%."
     },
     "gh2e-119": {
       "": "Drakescale Boots",

--- a/data/gh2e/label/spoiler/en.json
+++ b/data/gh2e/label/spoiler/en.json
@@ -1064,7 +1064,7 @@
     },
     "gh2e-57": {
       "": "Strategist's Ring",
-      "1": "At the end of the turn, play one card from your hand perform all persistent and mandatory abilities on either the top or bottom action of the card."
+      "1": "At the end of the turn, play one card from your hand and perform all persistent and mandatory abilities on either the top or bottom action of the card."
     },
     "gh2e-58": {
       "": "Major Stamina Potion",


### PR DESCRIPTION
# Description

Fixes a variety of small differences between the printed GH2E item cards and their data. Affects items 49, 57, 115, 117, 118, and 121.

## Type of change

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
