### PR TITLE
GH2e scenario 13 fix monster count and visible doors

### DIFF
--- a/data/gh2e/sections/14-1.json
+++ b/data/gh2e/sections/14-1.json
@@ -45,6 +45,7 @@
         },
         {
           "name": "spitting-drake",
+          "player3": "elite",
           "player4": "elite"
         }
       ]

--- a/data/gh2e/sections/35-3.json
+++ b/data/gh2e/sections/35-3.json
@@ -3,6 +3,12 @@
   "name": "Icecrag Ascent",
   "edition": "gh2e",
   "parent": "13",
+  "parentSections": [
+    [
+      "14.1"
+    ]
+  ],
+  "marker": "2",
   "monsters": [
     "rending-drake",
     "spitting-drake"
@@ -24,7 +30,8 @@
         },
         {
           "name": "rending-drake",
-          "player3": "normal"
+          "player3": "normal",
+          "player4": "elite"
         },
         {
           "name": "spitting-drake",


### PR DESCRIPTION
# Description

I fixed the monster count and visibility of door 2 at scenario 13 of GH2e

## Type of change

Please delete options that are not relevant.

- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
