### PR TITLE
Feature/attack resolve

### DIFF
--- a/resources/keyboard-shortcuts.md
+++ b/resources/keyboard-shortcuts.md
@@ -1,60 +1,8 @@
 # Keyboard Shortcuts
 
-The following keyboard shortcuts are currently implemented:
+A **print-friendly reference** is available at:
 
-- <kbd>CTRL</kbd> + <kbd>z</kbd>: Undo
-- <kbd>CTRL</kbd> + <kbd>y</kbd> | <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>Z</kbd>: Redo
-- <kbd>ESC</kbd> | <kdb>←</kdb>: open main menu (In most browsers, the ESC key exits full-screen mode; use the BACKSPACE key instead)
-- <kbd>↑</kbd> | <kbd>+</kbd>: Zoom-In
-- <kbd>↓</kbd> | <kbd>-</kbd>: Zoom-Out
-- <kbd>CTRL</kbd> + <kbd>r</kbd>: reset zoom
-- <kbd>f</kbd>: Toggle Fullscreen
-- <kbd>↹</kbd>: toggle active figure when drawn / toggle initiative input when focused input
-- <kbd>n</kbd>: next round / draw
-- <kbd>m</kbd>: draw AM card (deck depending on active figure, monster deck when not active, disabled when **Draw**)
-- <kbd>a</kbd> like <kbd>m</kbd>, but draw with Advantage if enabled
-- <kbd>d</kbd> like <kbd>m<</kbd>, but draw with Disadvantage if enabled
-- <kbd>l</kbd>: draw from LootDeck / Inc. Moneytokens for active Character
-- <kbd>SHIFT</kbd> + <kbd>l</kbd>: Dec. Moneytokens for active Character
-- <kbd>1-6</kbd>: toggle through element state
-- <kbd>h</kbd>: toggle _Hide absent figures_
-- <kbd>s</kbd>: select figure/standee for opening menu with number key (<kbd>0-9</kbd>)
-- <kbd>w</kbd>: select figure/standee for opening menu in fixed order with number key (<kbd>0-9</kbd>)
-- <kbd>x</kbd>: difficulty/level menu
-- <kbd>ALT</kbd> + <kbd>x</kbd>: Inc. XP for active Character
-- <kbd>SHIFT</kbd> + <kbd>X</kbd>: Dec. XP for active Character
-- <kbd>e</kbd>: scenario effects menu
-- <kbd>SHIFT</kbd> + <kbd>f</kbd>: (finish) scenario menu
-- <kbd>p</kbd>: open party sheet
-- <kbd>g</kbd>: open global map
-- <kbd>c</kbd>: open scenario chart
-- <kbd>SHIFT</kbd> + <kbd>H</kbd>: toggle _Display hand size and level_
-- <kbd>t</kbd>: toggle _Display traits_
-- <kbd>#</kbd>: toggle _Display player number_
-- <kbd>i</kbd>: toggle _Damage instead of HP_
-- <kbd>?</kbd>: show keyboard shortcuts
+- In the app: open keyboard shortcuts (`?`) and click **Print shortcut reference**
+- Direct URL: `/assets/keyboard-shortcuts-print.html` (add `?print=1` to open the print dialog automatically)
 
-On any open figure/standee menu, those shortcuts are disabled, currently shortcuts available in figure/standee:
-
-- <kbd>→</kbd>: inc. current HP
-- <kbd>←</kbd>: dec. current HP
-- <kbd>0</kbd>-<kbd>9</kbd>: toggle condition/condition modifier
-- <kbd>x</kbd>: inc. XP
-- <kbd>SHIFT</kbd> + <kbd>X</kbd>: dec. XP
-- <kbd>l</kbd>: inc. Loot
-- <kbd>SHIFT</kbd> + <kbd>L</kbd>: dec. Loot
-- <kbd>b</kbd>: inc. Bless
-- <kbd>SHIFT</kbd> + <kbd>B</kbd>: dec. Bless
-- <kbd>c</kbd>: inc. Curse
-- <kbd>SHIFT</kbd> + <kbd>C</kbd>: dec. Curse
-- <kbd>k</kbd> | <kbd>d</kbd>: kill/exhaust
-- <kbd>↑</kbd>: inc. max. HP
-- <kbd>↓</kbd>: dec. max. HP
-- <kbd>s</kbd>: open character sheet
-- <kbd>a</kbd>: toggle character absent
-
-On open menu:
-
-- <kbd>↵</kbd> | <kbd>SPACE</kbd>: confirm action / open submenu
-- <kbd>ESC</kbd> | <kdb>⌫</kdb>: decline action / close menu (In most browsers, the ESC key exits full-screen mode; use the BACKSPACE key instead)
-- <kbd>↹</kbd>: select action
+The printable page uses a clean black-on-white layout with tables grouped by context (global, figure menu, main menu).

--- a/src/app/game/businesslogic/AttackResolveManager.ts
+++ b/src/app/game/businesslogic/AttackResolveManager.ts
@@ -1,0 +1,1029 @@
+import { GameManager } from 'src/app/game/businesslogic/GameManager';
+import { settingsManager } from 'src/app/game/businesslogic/SettingsManager';
+import { Character } from 'src/app/game/model/Character';
+import {
+  AttackModifierDeck,
+  AttackModifierEffect,
+  AttackModifierEffectType,
+  AttackResult
+} from 'src/app/game/model/data/AttackModifier';
+import { Action, ActionType, ActionValueType } from 'src/app/game/model/data/Action';
+import { Condition, ConditionName, ConditionType, EntityCondition, EntityConditionState } from 'src/app/game/model/data/Condition';
+import { MonsterStat } from 'src/app/game/model/data/MonsterStat';
+import { Entity, EntityExpressionRegex, EntityValueFunction, EntityValueRegex } from 'src/app/game/model/Entity';
+import { Figure } from 'src/app/game/model/Figure';
+import { GameState } from 'src/app/game/model/Game';
+import { Monster } from 'src/app/game/model/Monster';
+import { MonsterEntity } from 'src/app/game/model/MonsterEntity';
+import { ObjectiveContainer } from 'src/app/game/model/ObjectiveContainer';
+import { Summon, SummonState } from 'src/app/game/model/Summon';
+import { AttackModiferDeckChange } from 'src/app/ui/figures/attackmodifier/attackmodifierdeck';
+import { ghsValueSign } from 'src/app/ui/helper/Static';
+
+export type AttackResolvePhase = 'idle' | 'pickTarget' | 'configure';
+export type AttackResolveTarget = { entity: Entity; figure: Figure };
+export type AttackResolveInputField = 'attack' | 'pierce' | 'damage';
+
+type AttackResolveConfigureSnapshot = {
+  baseAttack: number;
+  pierce: number;
+  pierceBase: number;
+  pendingAttackerConditions: EntityCondition[];
+  pendingTargetConditions: EntityCondition[];
+};
+
+export class AttackResolveManager {
+  phase: AttackResolvePhase = 'idle';
+  character: Character | undefined;
+  monster: Monster | undefined;
+  target: AttackResolveTarget | undefined;
+  baseAttack: number = 0;
+  pierce: number = 0;
+  private pierceBase: number = 0;
+  damageValue: number = 0;
+  private damageManuallySet: boolean = false;
+  private inputOverwrite: boolean = true;
+  inputField: AttackResolveInputField = 'attack';
+  numpadOpen: boolean = false;
+  pendingAttackerConditions: EntityCondition[] = [];
+  pendingTargetConditions: EntityCondition[] = [];
+  attackResult: AttackResult | undefined;
+  applied: boolean = false;
+  conditionType: string = 'monster';
+  private configureSnapshot: AttackResolveConfigureSnapshot | undefined;
+  private deckChangeCount: number = 0;
+  private damageEditSnapshot: { value: number; manual: boolean } | undefined;
+  private targetIndex: number = -1;
+
+  constructor(private gameManager: GameManager) {}
+
+  get hasAttacker(): boolean {
+    return !!this.character || !!this.monster;
+  }
+
+  get attackerLabel(): string {
+    if (this.character) {
+      return this.gameManager.characterManager.characterName(this.character, true);
+    }
+    if (this.monster) {
+      const nameKey = this.monster.statEffect?.name ? this.monster.statEffect.name : this.monster.name;
+      return settingsManager.getLabel('data.monster.' + nameKey);
+    }
+    return '';
+  }
+
+  get attackModifierDeck(): AttackModifierDeck | undefined {
+    if (this.character) {
+      return this.character.attackModifierDeck;
+    }
+    if (this.monster) {
+      return this.monsterUsesAllyDeck(this.monster)
+        ? this.gameManager.game.allyAttackModifierDeck
+        : this.gameManager.game.monsterAttackModifierDeck;
+    }
+    return undefined;
+  }
+
+  get deckNumeration(): string {
+    if (this.character) {
+      return '' + this.character.number;
+    }
+    return this.monsterUsesAllyDeck(this.monster!) ? 'A' : 'm';
+  }
+
+  get deckIconUrl(): string {
+    return this.character?.iconUrl || '';
+  }
+
+  get attackerEntity(): Entity | undefined {
+    if (this.character) {
+      return this.character;
+    }
+    if (this.monster) {
+      return this.activeMonsterEntity(this.monster);
+    }
+    return undefined;
+  }
+
+  get attackerFigure(): Figure | undefined {
+    return this.character || this.monster;
+  }
+
+  get conditionAttackBonus(): number {
+    const target = this.target;
+    if (!target) {
+      return 0;
+    }
+    return this.gameManager.entityManager.attackConditionBonus(target.entity, target.figure);
+  }
+
+  get effectiveBaseAttack(): number {
+    return this.baseAttack + this.conditionAttackBonus;
+  }
+
+  get targetShield(): number {
+    const target = this.target;
+    if (!target) {
+      return 0;
+    }
+    return this.gameManager.entityManager.entityShieldValue(target.entity, target.figure);
+  }
+
+  get targetRetaliate(): number {
+    const target = this.target;
+    if (!target) {
+      return 0;
+    }
+    return this.gameManager.entityManager.entityRetaliateValue(target.entity, target.figure);
+  }
+
+  get shieldBlocked(): number {
+    return this.gameManager.entityManager.shieldBlockedByAttack(this.targetShield, this.pierce);
+  }
+
+  get calculatedDamage(): number {
+    if (!this.attackResult) {
+      return 0;
+    }
+    return Math.max(0, this.attackResult.result - this.shieldBlocked);
+  }
+
+  get damageIsManual(): boolean {
+    return this.damageManuallySet;
+  }
+
+  get finalDamage(): number {
+    if (!this.attackResult) {
+      return 0;
+    }
+    return this.damageManuallySet ? this.damageValue : this.calculatedDamage;
+  }
+
+  get attackerConditionType(): string {
+    if (this.character) {
+      return 'character';
+    }
+    if (this.monster) {
+      return 'monster';
+    }
+    return 'monster';
+  }
+
+  monsterUsesAllyDeck(monster: Monster): boolean {
+    return monster.isAlly || monster.isAllied;
+  }
+
+  footerAttackCharacter(): Character | undefined {
+    const figures = this.gameManager.game.figures;
+
+    if (!settingsManager.settings.characterAttackModifierDeck) {
+      return undefined;
+    }
+
+    if (settingsManager.settings.characterAttackModifierDeckActiveBottom) {
+      return figures.find(
+        (figure) => figure instanceof Character && (figure.attackModifierDeckVisible || this.gameManager.bbRules())
+      ) as Character;
+    }
+
+    if (settingsManager.settings.attackResolveGuided && this.gameManager.game.scenario) {
+      if (this.phase !== 'idle' && this.character) {
+        return this.character;
+      }
+      return figures.find((figure) => figure instanceof Character && figure.active) as Character;
+    }
+
+    return undefined;
+  }
+
+  footerAttackMonster(): Monster | undefined {
+    if (!settingsManager.settings.attackResolveGuided || !this.gameManager.game.scenario) {
+      return undefined;
+    }
+    if (this.phase !== 'idle' && this.monster) {
+      return this.monster;
+    }
+    return this.gameManager.game.figures.find((figure) => figure instanceof Monster && figure.active) as Monster;
+  }
+
+  enabledFor(character: Character | undefined): boolean {
+    return (
+      settingsManager.settings.attackResolveGuided &&
+      !!character &&
+      !!this.gameManager.game.scenario &&
+      this.gameManager.game.state === GameState.next &&
+      character === this.footerAttackCharacter()
+    );
+  }
+
+  enabledForMonster(monster: Monster | undefined): boolean {
+    return (
+      settingsManager.settings.attackResolveGuided &&
+      !!monster &&
+      !!this.gameManager.game.scenario &&
+      this.gameManager.game.state === GameState.next &&
+      monster.active &&
+      monster === this.footerAttackMonster()
+    );
+  }
+
+  isPickingTarget(character: Character | undefined): boolean {
+    return this.phase === 'pickTarget' && this.character === character;
+  }
+
+  isPickingTargetMonster(monster: Monster | undefined): boolean {
+    return this.phase === 'pickTarget' && this.monster === monster;
+  }
+
+  isConfiguring(character: Character | undefined): boolean {
+    return this.phase === 'configure' && this.character === character;
+  }
+
+  isConfiguringMonster(monster: Monster | undefined): boolean {
+    return this.phase === 'configure' && this.monster === monster;
+  }
+
+  startAttack(character: Character): void {
+    if (!this.enabledFor(character)) {
+      return;
+    }
+    this.cancel(false);
+    this.character = character;
+    this.monster = undefined;
+    this.phase = 'pickTarget';
+    this.resetConfigureFields();
+    character.attackModifierDeck.active = false;
+    this.syncBodyPhaseClass();
+    this.gameManager.triggerUiChange(false);
+  }
+
+  startMonsterAttack(monster: Monster): void {
+    if (!this.enabledForMonster(monster)) {
+      return;
+    }
+    this.cancel(false);
+    this.monster = monster;
+    this.character = undefined;
+    this.phase = 'pickTarget';
+    this.resetConfigureFields();
+    this.attackModifierDeck!.active = false;
+    this.syncBodyPhaseClass();
+    this.gameManager.triggerUiChange(false);
+  }
+
+  handleStandeeClick(entity: Entity, figure: Figure): boolean {
+    if (this.phase !== 'pickTarget' || !this.hasAttacker) {
+      return false;
+    }
+    this.selectTarget(entity, figure);
+    return true;
+  }
+
+  selectTarget(entity: Entity, figure: Figure): void {
+    if (this.phase !== 'pickTarget' || !this.hasAttacker) {
+      return;
+    }
+    this.target = { entity, figure };
+    this.targetIndex = this.gameManager.entityManager.getIndexForEntity(entity, true);
+    this.phase = 'configure';
+    this.attackResult = undefined;
+    this.applied = false;
+    this.updateConditionType();
+    if (this.monster) {
+      this.applyMonsterAbilitySuggestions();
+    } else {
+      this.baseAttack = 0;
+      this.pierce = 0;
+      this.pierceBase = 0;
+      this.pendingAttackerConditions = [];
+      this.pendingTargetConditions = [];
+    }
+    this.inputField = 'attack';
+    this.inputOverwrite = true;
+    this.numpadOpen = false;
+    const deck = this.attackModifierDeck;
+    if (deck) {
+      deck.active = false;
+    }
+    this.saveConfigureSnapshot();
+    this.deckChangeCount = 0;
+    this.damageEditSnapshot = undefined;
+    this.syncBodyPhaseClass();
+    this.gameManager.triggerUiChange(false);
+  }
+
+  cancel(trigger: boolean = true): void {
+    this.phase = 'idle';
+    this.character = undefined;
+    this.monster = undefined;
+    this.target = undefined;
+    this.resetConfigureFields();
+    this.syncBodyPhaseClass();
+    if (trigger) {
+      this.gameManager.triggerUiChange(false);
+    }
+  }
+
+  setInputField(field: AttackResolveInputField): void {
+    if (this.phase !== 'configure') {
+      return;
+    }
+    if (field === 'damage' && !this.attackResult) {
+      return;
+    }
+    if (field === 'damage') {
+      this.damageEditSnapshot = {
+        value: this.damageManuallySet ? this.damageValue : this.calculatedDamage,
+        manual: this.damageManuallySet
+      };
+    }
+    this.inputField = field;
+    this.inputOverwrite = true;
+    this.numpadOpen = true;
+    this.gameManager.triggerUiChange(false);
+  }
+
+  closeNumpad(): void {
+    if (!this.numpadOpen) {
+      return;
+    }
+    this.numpadOpen = false;
+    this.damageEditSnapshot = undefined;
+    this.gameManager.triggerUiChange(false);
+  }
+
+  cancelDamageEdit(): void {
+    if (this.inputField === 'damage' && this.damageEditSnapshot) {
+      this.damageValue = this.damageEditSnapshot.value;
+      this.damageManuallySet = this.damageEditSnapshot.manual;
+    }
+    this.damageEditSnapshot = undefined;
+    this.closeNumpad();
+  }
+
+  appendDigit(digit: number): void {
+    if (this.phase !== 'configure') {
+      return;
+    }
+    if (this.inputField === 'damage') {
+      if (!this.attackResult) {
+        return;
+      }
+      if (this.inputOverwrite) {
+        this.damageValue = digit;
+        this.inputOverwrite = false;
+      } else {
+        this.damageValue = Math.min(999, this.damageValue * 10 + digit);
+      }
+      this.damageManuallySet = true;
+    } else if (this.inputField === 'pierce') {
+      if (this.inputOverwrite) {
+        this.pierceBase = digit;
+        this.inputOverwrite = false;
+      } else {
+        this.pierceBase = Math.min(99, this.pierceBase * 10 + digit);
+      }
+      this.pierce = this.pierceBase;
+      this.resetDamageFromCalculation();
+    } else {
+      if (this.inputOverwrite) {
+        this.baseAttack = digit;
+        this.inputOverwrite = false;
+      } else {
+        this.baseAttack = Math.min(999, this.baseAttack * 10 + digit);
+      }
+      this.attackResult = undefined;
+      this.damageManuallySet = false;
+      this.damageValue = 0;
+    }
+    this.gameManager.triggerUiChange(false);
+  }
+
+  backspaceDigit(): void {
+    if (this.phase !== 'configure') {
+      return;
+    }
+    if (this.inputField === 'damage') {
+      if (!this.attackResult) {
+        return;
+      }
+      this.damageValue = Math.floor(this.damageValue / 10);
+      this.damageManuallySet = true;
+      this.inputOverwrite = false;
+    } else if (this.inputField === 'pierce') {
+      this.pierceBase = Math.floor(this.pierceBase / 10);
+      this.pierce = this.pierceBase;
+      this.inputOverwrite = false;
+      this.resetDamageFromCalculation();
+    } else {
+      this.baseAttack = Math.floor(this.baseAttack / 10);
+      this.attackResult = undefined;
+      this.damageManuallySet = false;
+      this.damageValue = 0;
+      this.inputOverwrite = false;
+    }
+    this.gameManager.triggerUiChange(false);
+  }
+
+  clearActiveInput(): void {
+    if (this.phase !== 'configure') {
+      return;
+    }
+    if (this.inputField === 'damage') {
+      if (!this.attackResult) {
+        return;
+      }
+      this.damageValue = 0;
+      this.damageManuallySet = true;
+      this.inputOverwrite = true;
+    } else if (this.inputField === 'pierce') {
+      this.pierceBase = 0;
+      this.pierce = 0;
+      this.inputOverwrite = true;
+      this.resetDamageFromCalculation();
+    } else {
+      this.baseAttack = 0;
+      this.attackResult = undefined;
+      this.damageManuallySet = false;
+      this.damageValue = 0;
+      this.inputOverwrite = true;
+    }
+    this.gameManager.triggerUiChange(false);
+  }
+
+  private resetDamageFromCalculation(): void {
+    if (this.attackResult) {
+      this.damageManuallySet = false;
+      this.syncDamageFromCalculation();
+    }
+  }
+
+  private syncDamageFromCalculation(): void {
+    this.damageValue = this.calculatedDamage;
+    this.damageManuallySet = false;
+    this.inputOverwrite = true;
+  }
+
+  setPendingAttackerConditions(conditions: EntityCondition[]): void {
+    this.pendingAttackerConditions = conditions;
+    this.gameManager.triggerUiChange(false);
+  }
+
+  setPendingTargetConditions(conditions: EntityCondition[]): void {
+    this.pendingTargetConditions = conditions;
+    this.gameManager.triggerUiChange(false);
+  }
+
+  get canDraw(): boolean {
+    return this.phase === 'configure' && !!this.target && this.baseAttack >= 0 && this.hasAttacker;
+  }
+
+  get needsShuffle(): boolean {
+    const deck = this.attackModifierDeck;
+    return !!deck && deck.current >= deck.cards.length - 1;
+  }
+
+  get canUndoAttack(): boolean {
+    if (this.phase !== 'configure' || !this.configureSnapshot) {
+      return false;
+    }
+    return (
+      this.deckChangeCount > 0 ||
+      !!this.attackResult ||
+      this.baseAttack !== this.configureSnapshot.baseAttack ||
+      this.pierce !== this.configureSnapshot.pierce ||
+      this.damageManuallySet ||
+      !this.pendingConditionsMatch(this.pendingAttackerConditions, this.configureSnapshot.pendingAttackerConditions) ||
+      !this.pendingConditionsMatch(this.pendingTargetConditions, this.configureSnapshot.pendingTargetConditions)
+    );
+  }
+
+  drawModifier(state?: 'advantage' | 'disadvantage'): void {
+    const deck = this.attackModifierDeck;
+    if (!this.canDraw || !deck) {
+      return;
+    }
+
+    const changeType = this.needsShuffle ? 'shuffle' : 'draw' + (state ? state : '');
+    this.beforeDeck(new AttackModiferDeckChange(deck, changeType));
+    deck.active = true;
+    if (this.needsShuffle) {
+      this.gameManager.attackModifierManager.shuffleModifiers(deck);
+    } else {
+      this.gameManager.attackModifierManager.drawModifier(deck, state);
+    }
+    this.deckChangeCount++;
+    this.afterDeck(new AttackModiferDeckChange(deck, changeType));
+  }
+
+  undoAttack(): void {
+    if (!this.canUndoAttack) {
+      return;
+    }
+    if (this.deckChangeCount > 0) {
+      this.gameManager.stateManager.fixedUndo(this.deckChangeCount, false);
+      this.deckChangeCount = 0;
+      this.refreshResolveReferences();
+    }
+    this.restoreConfigureSnapshot();
+    const deck = this.attackModifierDeck;
+    if (deck) {
+      deck.active = false;
+    }
+    this.gameManager.triggerUiChange(false);
+  }
+
+  toggleAttackResult(): void {
+    const deck = this.attackModifierDeck;
+    if (!this.attackResult || !this.attackResult.chooseOffset || !deck) {
+      return;
+    }
+    this.attackResult = this.gameManager.attackModifierManager.calculateAttackResult(
+      deck,
+      this.effectiveBaseAttack,
+      this.attackResult.index + this.attackResult.chooseOffset
+    );
+    this.applyModifierPierce();
+    this.syncDamageFromCalculation();
+    this.gameManager.triggerUiChange(false);
+  }
+
+  applyAttack(): void {
+    const target = this.target;
+    const deck = this.attackModifierDeck;
+    if (!target || !this.attackResult || this.applied || !deck) {
+      return;
+    }
+
+    const damage = this.finalDamage;
+    const skipPoisonHighlight = this.conditionAttackBonus > 0;
+    this.gameManager.stateManager.before('changeDamage', ghsValueSign(-damage), this.targetLabel(target));
+    this.gameManager.entityManager.changeHealth(target.entity, target.figure, -damage, true, skipPoisonHighlight);
+
+    if (this.shieldBlocked > 0) {
+      this.gameManager.entityManager.consumeShieldForAttack(target.entity, target.figure, this.shieldBlocked);
+    }
+
+    const attacker = this.attackerEntity;
+    const attackerFigure = this.attackerFigure;
+
+    this.pendingAttackerConditions
+      .filter((condition) => condition.state === EntityConditionState.new && !condition.expired)
+      .forEach((condition) => {
+        if (attacker && attackerFigure && !this.gameManager.entityManager.isImmune(attacker, attackerFigure, condition.name)) {
+          this.gameManager.entityManager.addCondition(attacker, attackerFigure, new Condition(condition.name, condition.value));
+        }
+      });
+
+    this.pendingTargetConditions
+      .filter((condition) => condition.state === EntityConditionState.new && !condition.expired)
+      .forEach((condition) => {
+        if (!this.gameManager.entityManager.isImmune(target.entity, target.figure, condition.name)) {
+          this.gameManager.entityManager.addCondition(target.entity, target.figure, new Condition(condition.name, condition.value));
+        }
+      });
+
+    this.attackResult.effects.forEach((effect) => {
+      if (effect.type === AttackModifierEffectType.condition && effect.value) {
+        const name = effect.value as ConditionName;
+        if (!this.gameManager.entityManager.isImmune(target.entity, target.figure, name)) {
+          this.gameManager.entityManager.addCondition(target.entity, target.figure, new Condition(name));
+        }
+      }
+    });
+
+    this.gameManager.stateManager.after();
+    this.finish();
+  }
+
+  finish(): void {
+    const deck = this.attackModifierDeck;
+    if (deck) {
+      deck.active = false;
+    }
+    this.cancel();
+  }
+
+  targetLabel(entry: AttackResolveTarget): string {
+    if (entry.figure instanceof Character && entry.entity === entry.figure) {
+      return this.gameManager.characterManager.characterName(entry.figure, true);
+    }
+    if (entry.figure instanceof Character && entry.entity instanceof Summon) {
+      return settingsManager.getLabel('data.summon.' + entry.entity.name);
+    }
+    if (entry.figure instanceof Monster && entry.entity instanceof MonsterEntity) {
+      const monster = entry.figure;
+      const nameKey = monster.statEffect?.name ? monster.statEffect.name : monster.name;
+      const entityNum = monster.entities.indexOf(entry.entity) + 1;
+      return settingsManager.getLabel('data.monster.' + nameKey) + ' #' + entityNum;
+    }
+    if (entry.figure instanceof ObjectiveContainer) {
+      return settingsManager.getLabel('data.objective.' + entry.figure.name);
+    }
+    const index = this.gameManager.entityManager.getIndexForEntity(entry.entity, true) + 1;
+    return '' + index;
+  }
+
+  deckHintLabelKey(): string {
+    if (this.monster) {
+      return this.monsterUsesAllyDeck(this.monster) ? 'game.attackResolve.deckHintAlly' : 'game.attackResolve.deckHintMonster';
+    }
+    return 'game.attackResolve.deckHint';
+  }
+
+  private resetConfigureFields(): void {
+    this.target = undefined;
+    this.baseAttack = 0;
+    this.pierce = 0;
+    this.pierceBase = 0;
+    this.damageValue = 0;
+    this.damageManuallySet = false;
+    this.inputOverwrite = true;
+    this.inputField = 'attack';
+    this.numpadOpen = false;
+    this.pendingAttackerConditions = [];
+    this.pendingTargetConditions = [];
+    this.attackResult = undefined;
+    this.applied = false;
+    this.configureSnapshot = undefined;
+    this.deckChangeCount = 0;
+    this.damageEditSnapshot = undefined;
+    this.targetIndex = -1;
+  }
+
+  private saveConfigureSnapshot(): void {
+    this.configureSnapshot = {
+      baseAttack: this.baseAttack,
+      pierce: this.pierce,
+      pierceBase: this.pierceBase,
+      pendingAttackerConditions: this.clonePendingConditions(this.pendingAttackerConditions),
+      pendingTargetConditions: this.clonePendingConditions(this.pendingTargetConditions)
+    };
+  }
+
+  private restoreConfigureSnapshot(): void {
+    const snapshot = this.configureSnapshot;
+    if (!snapshot) {
+      return;
+    }
+    this.baseAttack = snapshot.baseAttack;
+    this.pierce = snapshot.pierce;
+    this.pierceBase = snapshot.pierceBase;
+    this.pendingAttackerConditions = this.clonePendingConditions(snapshot.pendingAttackerConditions);
+    this.pendingTargetConditions = this.clonePendingConditions(snapshot.pendingTargetConditions);
+    this.attackResult = undefined;
+    this.damageValue = 0;
+    this.damageManuallySet = false;
+    this.inputOverwrite = true;
+    this.inputField = 'attack';
+    this.numpadOpen = false;
+    this.damageEditSnapshot = undefined;
+  }
+
+  private clonePendingConditions(conditions: EntityCondition[]): EntityCondition[] {
+    return conditions.map((condition) => {
+      const copy = new EntityCondition(condition.name, condition.value);
+      copy.state = condition.state;
+      copy.lastState = condition.lastState;
+      copy.permanent = condition.permanent;
+      copy.expired = condition.expired;
+      copy.highlight = condition.highlight;
+      copy.highlightValue = condition.highlightValue;
+      return copy;
+    });
+  }
+
+  private refreshResolveReferences(): void {
+    if (this.character) {
+      const number = this.character.number;
+      const figure = this.gameManager.game.figures.find((f) => f instanceof Character && f.number === number);
+      if (figure instanceof Character) {
+        this.character = figure;
+      }
+    } else if (this.monster) {
+      const name = this.monster.name;
+      const figure =
+        this.gameManager.game.figures.find((f) => f instanceof Monster && f.name === name && f.active) ||
+        this.gameManager.game.figures.find((f) => f instanceof Monster && f.name === name);
+      if (figure instanceof Monster) {
+        this.monster = figure;
+      }
+    }
+    if (this.targetIndex >= 0) {
+      const indexed = this.gameManager.entityManager.getIndexedEntities(true)[this.targetIndex];
+      if (indexed) {
+        this.target = { entity: indexed.entity, figure: indexed.figure };
+      }
+    }
+  }
+
+  private pendingConditionsMatch(current: EntityCondition[], snapshot: EntityCondition[]): boolean {
+    if (current.length !== snapshot.length) {
+      return false;
+    }
+    return current.every((condition, index) => {
+      const other = snapshot[index];
+      return (
+        condition.name === other.name &&
+        condition.value === other.value &&
+        condition.state === other.state &&
+        condition.expired === other.expired
+      );
+    });
+  }
+
+  refreshMonsterAbilitySuggestions(): void {
+    if (this.phase !== 'configure' || !this.monster) {
+      return;
+    }
+    this.applyMonsterAbilitySuggestions();
+    this.saveConfigureSnapshot();
+    this.gameManager.triggerUiChange(false);
+  }
+
+  private applyMonsterAbilitySuggestions(): void {
+    if (!this.monster) {
+      return;
+    }
+    const attack = this.monsterAbilityAttackValue(this.monster);
+    this.baseAttack = attack !== undefined ? attack : 0;
+    this.pierceBase = this.monsterAbilityPierceValue(this.monster);
+    this.pierce = this.pierceBase;
+    const pending = this.pendingConditionsFromMonsterAbility(this.monster);
+    this.pendingAttackerConditions = pending.attacker;
+    this.pendingTargetConditions = pending.target;
+  }
+
+  private activeMonsterEntity(monster: Monster): MonsterEntity | undefined {
+    if (settingsManager.settings.monsterStandeeTurns) {
+      return monster.entities.find(
+        (entity) => entity.active && !entity.dead && entity.summon !== SummonState.new
+      );
+    }
+    return (
+      monster.entities.find((entity) => entity.active && !entity.dead) ||
+      monster.entities.find((entity) => !entity.dead)
+    );
+  }
+
+  private monsterAbilityAttackValue(monster: Monster): number | undefined {
+    const ability = this.gameManager.monsterManager.getAbility(monster);
+    if (!ability) {
+      return undefined;
+    }
+    const entity = this.activeMonsterEntity(monster);
+    const stat = entity ? this.gameManager.monsterManager.getStat(monster, entity.type) : undefined;
+    const level = entity?.level ?? monster.level ?? 0;
+
+    for (const action of this.findAttackActions(ability.actions)) {
+      const value = this.resolveAttackActionValue(action, stat, level);
+      if (value !== undefined) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  private pendingConditionsFromMonsterAbility(monster: Monster): { attacker: EntityCondition[]; target: EntityCondition[] } {
+    const ability = this.gameManager.monsterManager.getAbility(monster);
+    if (!ability) {
+      return { attacker: [], target: [] };
+    }
+    const entity = this.activeMonsterEntity(monster);
+    const stat = entity ? this.gameManager.monsterManager.getStat(monster, entity.type) : undefined;
+    const names = new Set<ConditionName>();
+
+    ability.actions.forEach((action) => {
+      this.gameManager.actionConditions(action, stat).forEach((name) => names.add(name));
+    });
+
+    const attacker: EntityCondition[] = [];
+    const target: EntityCondition[] = [];
+
+    Array.from(names).forEach((name) => {
+      const condition = new EntityCondition(name);
+      condition.state = EntityConditionState.new;
+      if (new Condition(name).types.includes(ConditionType.positive)) {
+        attacker.push(condition);
+      } else {
+        target.push(condition);
+      }
+    });
+
+    return { attacker, target };
+  }
+
+  private monsterAbilityPierceValue(monster: Monster): number {
+    const ability = this.gameManager.monsterManager.getAbility(monster);
+    if (!ability) {
+      return 0;
+    }
+    const entity = this.activeMonsterEntity(monster);
+    const stat = entity ? this.gameManager.monsterManager.getStat(monster, entity.type) : undefined;
+    const level = entity?.level ?? monster.level ?? 0;
+    let pierce = 0;
+
+    this.findAttackActions(ability.actions).forEach((action) => {
+      pierce = Math.max(pierce, this.pierceFromActions(action, level));
+    });
+
+    stat?.actions?.forEach((statAction) => {
+      if (statAction.type === ActionType.pierce) {
+        pierce = Math.max(pierce, EntityValueFunction(statAction.value, level));
+      }
+    });
+
+    return pierce;
+  }
+
+  private pierceFromActions(action: Action, level: number): number {
+    let pierce = 0;
+    if (action.type === ActionType.pierce) {
+      pierce = Math.max(pierce, EntityValueFunction(action.value, level));
+    }
+    action.subActions?.forEach((subAction) => {
+      pierce = Math.max(pierce, this.pierceFromActions(subAction, level));
+    });
+    return pierce;
+  }
+
+  private pierceFromModifierEffects(effects: AttackModifierEffect[]): number {
+    let pierce = 0;
+    effects.forEach((effect) => {
+      if (effect.type === AttackModifierEffectType.pierce && effect.value !== undefined && effect.value !== '') {
+        try {
+          pierce += EntityValueFunction(effect.value);
+        } catch {
+          const parsed = parseInt('' + effect.value, 10);
+          if (!isNaN(parsed)) {
+            pierce += parsed;
+          }
+        }
+      }
+    });
+    return pierce;
+  }
+
+  private applyModifierPierce(): void {
+    if (!this.attackResult) {
+      this.pierce = this.pierceBase;
+      return;
+    }
+    this.pierce = this.pierceBase + this.pierceFromModifierEffects(this.attackResult.effects);
+  }
+
+  private findAttackActions(actions: Action[]): Action[] {
+    const result: Action[] = [];
+    actions.forEach((action) => {
+      if (action.type === ActionType.attack) {
+        result.push(action);
+      }
+      if (action.subActions?.length) {
+        result.push(...this.findAttackActions(action.subActions));
+      }
+    });
+    return result;
+  }
+
+  private resolveAttackActionValue(action: Action, stat: MonsterStat | undefined, level: number): number | undefined {
+    if (action.type !== ActionType.attack) {
+      return undefined;
+    }
+
+    if (settingsManager.settings.calculate && stat) {
+      let statValue = 0;
+      let hasStatAttack = false;
+
+      if (typeof stat.attack === 'number') {
+        statValue = stat.attack;
+        hasStatAttack = true;
+      } else if (typeof stat.attack === 'string' && stat.attack.includes('X')) {
+        return undefined;
+      } else if (typeof stat.attack === 'string') {
+        try {
+          statValue = EntityValueFunction(stat.attack, level);
+          hasStatAttack = true;
+        } catch {
+          return undefined;
+        }
+      }
+
+      if (stat.actions) {
+        stat.actions.forEach((statAction) => {
+          if (statAction.type === ActionType.attack) {
+            if (statAction.valueType === ActionValueType.add) {
+              statValue += EntityValueFunction(statAction.value, level);
+              hasStatAttack = true;
+            } else if (statAction.valueType === ActionValueType.subtract) {
+              statValue -= EntityValueFunction(statAction.value, level);
+              hasStatAttack = true;
+            }
+          }
+        });
+      }
+
+      if (
+        action.value !== '' &&
+        (action.value || action.value === 0) &&
+        (typeof action.value === 'number' ||
+          (typeof action.value === 'string' &&
+            (action.value.match(EntityExpressionRegex) || action.value.match(EntityValueRegex))))
+      ) {
+        if (action.valueType === ActionValueType.plus) {
+          return statValue + EntityValueFunction(action.value, level);
+        }
+        if (action.valueType === ActionValueType.minus) {
+          return Math.max(0, statValue - EntityValueFunction(action.value, level));
+        }
+        if (action.valueType === ActionValueType.fixed) {
+          return EntityValueFunction(action.value, level);
+        }
+      }
+
+      return hasStatAttack ? statValue : undefined;
+    }
+
+    if (typeof action.value === 'number') {
+      return action.value;
+    }
+
+    if (
+      typeof action.value === 'string' &&
+      (action.value.match(EntityExpressionRegex) || action.value.match(EntityValueRegex))
+    ) {
+      try {
+        return EntityValueFunction(action.value, level);
+      } catch {
+        return undefined;
+      }
+    }
+
+    return undefined;
+  }
+
+  private updateConditionType(): void {
+    const target = this.target;
+    if (!target) {
+      this.conditionType = 'monster';
+      return;
+    }
+    if (target.entity instanceof Character) {
+      this.conditionType = 'character';
+    } else if (target.entity instanceof MonsterEntity || target.entity instanceof Summon) {
+      this.conditionType = 'monster';
+    } else {
+      this.conditionType = 'objective';
+    }
+  }
+
+  private beforeDeck(change: AttackModiferDeckChange): void {
+    if (!this.hasAttacker) {
+      return;
+    }
+    this.attackResult = undefined;
+    this.gameManager.stateManager.before('updateAttackModifierDeck.' + change.type, this.attackerStateLabel(), ...change.values);
+  }
+
+  private afterDeck(change: AttackModiferDeckChange): void {
+    const deck = this.attackModifierDeck;
+    if (!deck) {
+      return;
+    }
+    if (this.character) {
+      this.character.attackModifierDeck = change.deck;
+    } else if (this.monsterUsesAllyDeck(this.monster!)) {
+      this.gameManager.game.allyAttackModifierDeck = change.deck;
+    } else {
+      this.gameManager.game.monsterAttackModifierDeck = change.deck;
+    }
+    this.gameManager.stateManager.after();
+    if (deck.current < 0) {
+      this.attackResult = undefined;
+    } else {
+      this.attackResult = this.gameManager.attackModifierManager.calculateAttackResult(deck, this.effectiveBaseAttack);
+      this.applyModifierPierce();
+      this.syncDamageFromCalculation();
+    }
+    this.gameManager.triggerUiChange(false);
+  }
+
+  private attackerStateLabel(): string {
+    if (this.character) {
+      return this.gameManager.characterManager.characterName(this.character, true, true);
+    }
+    if (this.monster) {
+      const nameKey = this.monster.statEffect?.name ? this.monster.statEffect.name : this.monster.name;
+      return settingsManager.getLabel('data.monster.' + nameKey);
+    }
+    return '';
+  }
+
+  private syncBodyPhaseClass(): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    document.body.classList.toggle('attack-resolve-picking', this.phase === 'pickTarget');
+    document.body.classList.toggle('attack-resolve-configuring', this.phase === 'configure');
+  }
+}
+

--- a/src/app/game/businesslogic/AttackResolveManager.ts
+++ b/src/app/game/businesslogic/AttackResolveManager.ts
@@ -560,10 +560,6 @@ export class AttackResolveManager {
     this.gameManager.stateManager.before('changeDamage', ghsValueSign(-damage), this.targetLabel(target));
     this.gameManager.entityManager.changeHealth(target.entity, target.figure, -damage, true, skipPoisonHighlight);
 
-    if (this.shieldBlocked > 0) {
-      this.gameManager.entityManager.consumeShieldForAttack(target.entity, target.figure, this.shieldBlocked);
-    }
-
     const attacker = this.attackerEntity;
     const attackerFigure = this.attackerFigure;
 

--- a/src/app/game/businesslogic/GameManager.ts
+++ b/src/app/game/businesslogic/GameManager.ts
@@ -1,6 +1,7 @@
 import { signal, WritableSignal } from '@angular/core';
 import { ActionsManager } from 'src/app/game/businesslogic/ActionsManager';
 import { AttackModifierManager } from 'src/app/game/businesslogic/AttackModifierManager';
+import { AttackResolveManager } from 'src/app/game/businesslogic/AttackResolveManager';
 import { BattleGoalManager } from 'src/app/game/businesslogic/BattleGoalManager';
 import { BuildingsManager } from 'src/app/game/businesslogic/BuildingsManager';
 import { ChallengesManager } from 'src/app/game/businesslogic/ChallengesManager';
@@ -90,6 +91,7 @@ export class GameManager {
   enhancementsManager: EnhancementsManager;
   imbuementManager: ImbuementManager;
   specialActionsManager: SpecialActionsManager;
+  attackResolveManager: AttackResolveManager;
 
   uiChangeSignal: WritableSignal<number> = signal(0);
   uiChangeFromServer: WritableSignal<boolean> = signal(false);
@@ -122,6 +124,7 @@ export class GameManager {
     this.enhancementsManager = new EnhancementsManager(this.game);
     this.imbuementManager = new ImbuementManager(this.game);
     this.specialActionsManager = new SpecialActionsManager(this.game);
+    this.attackResolveManager = new AttackResolveManager(this);
   }
 
   editions(all: boolean = false, additional: boolean = false): string[] {

--- a/src/app/game/businesslogic/MonsterManager.ts
+++ b/src/app/game/businesslogic/MonsterManager.ts
@@ -1167,6 +1167,63 @@ export class MonsterManager {
     return gameManager.monsterManager.sortEntitiesByNumber(a, b);
   }
 
+  aliveStandeeEntities(monster: Monster): MonsterEntity[] {
+    return monster.entities
+      .filter((entity) => gameManager.entityManager.isAlive(entity) && entity.summon !== SummonState.new)
+      .sort((a, b) => this.sortEntities(a, b));
+  }
+
+  hasRemainingStandeeTurns(monster: Monster): boolean {
+    if (!settingsManager.settings.monsterStandeeTurns) {
+      return false;
+    }
+    const entities = this.aliveStandeeEntities(monster);
+    const activeEntity = entities.find((entity) => entity.active);
+    return !!activeEntity && entities.indexOf(activeEntity) < entities.length - 1;
+  }
+
+  activateStandeeTurn(monster: Monster): MonsterEntity | undefined {
+    monster.entities.forEach((entity) => {
+      if (gameManager.entityManager.isAlive(entity) && entity.summon !== SummonState.new) {
+        entity.active = false;
+      }
+    });
+    const first = this.aliveStandeeEntities(monster)[0];
+    if (first) {
+      first.active = true;
+      first.off = false;
+      gameManager.specialActionsManager.turn(first, monster);
+      this.notifyAttackResolveStandeeChange(monster);
+    }
+    return first;
+  }
+
+  advanceStandeeTurn(monster: Monster): boolean {
+    const entities = this.aliveStandeeEntities(monster);
+    const activeEntity = entities.find((entity) => entity.active);
+    if (!activeEntity) {
+      return false;
+    }
+    gameManager.specialActionsManager.afterTurn(activeEntity);
+    activeEntity.active = false;
+    const index = entities.indexOf(activeEntity);
+    if (index < entities.length - 1) {
+      const next = entities[index + 1];
+      next.active = true;
+      next.off = false;
+      gameManager.specialActionsManager.turn(next, monster);
+      this.notifyAttackResolveStandeeChange(monster);
+      return true;
+    }
+    return false;
+  }
+
+  private notifyAttackResolveStandeeChange(monster: Monster): void {
+    if (settingsManager.settings.monsterStandeeTurns && gameManager.attackResolveManager.isConfiguringMonster(monster)) {
+      gameManager.attackResolveManager.refreshMonsterAbilitySuggestions();
+    }
+  }
+
   sortEntitiesByNumber(a: MonsterEntity, b: MonsterEntity): number {
     if (a.summon === SummonState.new && b.summon !== SummonState.new) {
       return 1;

--- a/src/app/game/businesslogic/RoundManager.ts
+++ b/src/app/game/businesslogic/RoundManager.ts
@@ -211,6 +211,15 @@ export class RoundManager {
       }
     }
 
+    if (
+      settingsManager.settings.monsterStandeeTurns &&
+      toggleFigure instanceof Monster &&
+      gameManager.monsterManager.hasRemainingStandeeTurns(toggleFigure)
+    ) {
+      nextFigure = false;
+      gameManager.monsterManager.advanceStandeeTurn(toggleFigure);
+    }
+
     if (nextFigure) {
       this.afterTurn(toggleFigure);
       figure = figures.find((other, otherIndex) => gameManager.gameplayFigure(other) && !other.off && otherIndex !== index);
@@ -271,9 +280,13 @@ export class RoundManager {
       figure.off = false;
 
       if (figure instanceof Monster) {
-        figure.entities.forEach((monsterEntity) => {
-          monsterEntity.active = figure.active && !monsterEntity.off;
-        });
+        if (settingsManager.settings.monsterStandeeTurns) {
+          gameManager.monsterManager.activateStandeeTurn(figure);
+        } else {
+          figure.entities.forEach((monsterEntity) => {
+            monsterEntity.active = figure.active && !monsterEntity.off;
+          });
+        }
       }
 
       gameManager.entityManager.entitiesAll(figure, false).forEach((entity) => {
@@ -316,10 +329,14 @@ export class RoundManager {
         }
       }
     } else if (figure instanceof Monster && !figure.entities.find((entity) => entity.active)) {
-      figure.entities.forEach((monsterEntity) => {
-        monsterEntity.active = figure.active;
-        monsterEntity.off = false;
-      });
+      if (settingsManager.settings.monsterStandeeTurns) {
+        gameManager.monsterManager.activateStandeeTurn(figure);
+      } else {
+        figure.entities.forEach((monsterEntity) => {
+          monsterEntity.active = figure.active;
+          monsterEntity.off = false;
+        });
+      }
     }
 
     if (figure instanceof Character && settingsManager.settings.activeSummons) {
@@ -363,12 +380,16 @@ export class RoundManager {
     gameManager.scenarioRulesManager.addActiveFigureRule(figure);
 
     if (figure instanceof Monster && !figure.entities.find((entity) => entity.active)) {
-      figure.entities.forEach((monsterEntity) => {
-        if (!figure.off && monsterEntity.summon !== SummonState.new && gameManager.entityManager.isAlive(monsterEntity)) {
-          monsterEntity.active = true;
-          gameManager.specialActionsManager.turn(monsterEntity, figure);
-        }
-      });
+      if (settingsManager.settings.monsterStandeeTurns) {
+        gameManager.monsterManager.activateStandeeTurn(figure);
+      } else {
+        figure.entities.forEach((monsterEntity) => {
+          if (!figure.off && monsterEntity.summon !== SummonState.new && gameManager.entityManager.isAlive(monsterEntity)) {
+            monsterEntity.active = true;
+            gameManager.specialActionsManager.turn(monsterEntity, figure);
+          }
+        });
+      }
     }
 
     if (

--- a/src/app/game/businesslogic/SettingsManager.ts
+++ b/src/app/game/businesslogic/SettingsManager.ts
@@ -113,6 +113,7 @@ export class SettingsManager {
     await this.apply('fontsize', this.settings.fontsize);
     await this.apply('globalFontsize', this.settings.globalFontsize);
     await this.apply('portraitMode', this.settings.portraitMode);
+    await this.apply('presentationMode', this.settings.presentationMode);
     await this.apply('zoom', this.settings.zoom);
     await this.apply('customCss', this.settings.customCss);
   }
@@ -271,6 +272,12 @@ export class SettingsManager {
         document.body.classList.add('portrait-mode');
       } else {
         document.body.classList.remove('portrait-mode');
+      }
+    } else if (setting === 'presentationMode') {
+      if (value) {
+        document.body.classList.add('presentation-mode');
+      } else {
+        document.body.classList.remove('presentation-mode');
       }
     } else if (setting === 'theme' && this.settings.automaticTheme) {
       if (value === 'fh' || value === 'bb') {

--- a/src/app/game/commands/figure/FigureNext.ts
+++ b/src/app/game/commands/figure/FigureNext.ts
@@ -58,10 +58,14 @@ export class FigureNextCommand extends CommandImpl {
         gameManager.roundManager.toggleFigure(activeFigure);
       } else if (activeFigure instanceof Monster) {
         let toggleFigure = true;
-        const entities = activeFigure.entities.filter(
-          (entity) => gameManager.entityManager.isAlive(entity) && entity.summon !== SummonState.new
-        );
-        if (settingsManager.settings.activeStandees) {
+        const entities = settingsManager.settings.monsterStandeeTurns
+          ? gameManager.monsterManager.aliveStandeeEntities(activeFigure)
+          : activeFigure.entities.filter((entity) => gameManager.entityManager.isAlive(entity) && entity.summon !== SummonState.new);
+        if (settingsManager.settings.monsterStandeeTurns && !reverse) {
+          if (gameManager.monsterManager.advanceStandeeTurn(activeFigure)) {
+            toggleFigure = false;
+          }
+        } else if (settingsManager.settings.activeStandees) {
           let activeEntity = entities.find((entity) => entity.active);
           if (!activeEntity && entities.length > 0 && reverse && activeFigure.active) {
             activeEntity = entities[entities.length - 1];

--- a/src/app/game/model/Settings.ts
+++ b/src/app/game/model/Settings.ts
@@ -11,6 +11,7 @@ export class Settings {
   activeApplyConditionsExcludes: ConditionName[] = [ConditionName.shield];
   activeStandees: boolean = true;
   activeSummons: boolean = true;
+  monsterStandeeTurns: boolean = false;
   addAllMonsters: boolean = false;
   allyAttackModifierDeck: boolean = true;
   alwaysAllyAttackModifierDeck: boolean = false;
@@ -23,6 +24,7 @@ export class Settings {
   alwaysLootDeck: boolean = false;
   amAdvantage: boolean = true;
   amAdvantageHouseRule: boolean = false;
+  attackResolveGuided: boolean = true;
   animations: boolean = true;
   animationSpeed: number = 1;
   applyBuildingRewards: boolean = true;
@@ -174,6 +176,7 @@ export class Settings {
   lootDeck: boolean = true;
   maxUndo: number = 100;
   portraitMode: boolean = true;
+  presentationMode: boolean = false;
   monsters: boolean = true;
   monsterAttackModifierDeck: boolean = true;
   monsterInitativeRange: boolean = false;
@@ -302,6 +305,7 @@ export const localSettings: string[] = [
   'logServerMessages',
   'pinchZoom',
   'portraitMode',
+  'presentationMode',
   'pressDoubleClick',
   'serverAutoconnect',
   'serverCode',

--- a/src/app/ui/figures/attackmodifier/attack-resolve-panel.html
+++ b/src/app/ui/figures/attackmodifier/attack-resolve-panel.html
@@ -1,0 +1,323 @@
+@if (manager.phase === 'pickTarget') {
+  <div class="attack-resolve-pick-overlay" aria-hidden="true"></div>
+}
+
+@if (visible) {
+  <div
+    class="attack-resolve-panel"
+    [ngClass]="{ fh: settingsManager.settings.theme === 'fh', modern: settingsManager.settings.theme === 'modern' }"
+  >
+    <div class="header">
+      <span class="title" [ghs-label]="'game.attackResolve.title'" [ghs-label-args]="[manager.attackerLabel]"></span>
+      <button
+        type="button"
+        class="cancel"
+        title="Close"
+        [attr.aria-label]="closeButtonLabel"
+        (click)="manager.finish()"
+      >
+        <img src="./assets/images/close_dialog.svg" title="Close" alt="Close" aria-hidden="true" />
+      </button>
+    </div>
+
+    <div class="target-line">
+      <span [ghs-label]="'game.attackResolve.target'"></span>
+      <strong>{{ manager.targetLabel(target) }}</strong>
+      @if (manager.targetShield > 0) {
+        @if (manager.pierce > 0 && manager.shieldBlocked < manager.targetShield) {
+          <span
+            class="shield"
+            [ghs-label]="'game.attackResolve.shieldAfterPierce'"
+            [ghs-label-args]="[manager.targetShield, manager.shieldBlocked]"
+          ></span>
+        } @else {
+          <span class="shield" [ghs-label]="'game.attackResolve.shield'" [ghs-label-args]="[manager.targetShield]"></span>
+        }
+      }
+      @if (manager.targetRetaliate > 0) {
+        <span class="retaliate" [ghs-label]="'game.attackResolve.retaliate'" [ghs-label-args]="[manager.targetRetaliate]"></span>
+      }
+    </div>
+
+    <div class="body">
+      <div class="left" [class.numpad-active]="manager.numpadOpen">
+        <div class="value-inputs-row">
+          <button
+            type="button"
+            class="value-field compact"
+            [class.active]="manager.inputField === 'attack'"
+            title="Attack"
+            [attr.aria-label]="inputFieldLabel('attack')"
+            (click)="openInputField('attack', $event)"
+          >
+            <img [src]="actionIconUrl('attack')" title="Attack" [attr.alt]="actionAltLabel('attack')" aria-hidden="true" />
+            <span class="field-value">
+              {{ manager.baseAttack }}
+              @if (manager.conditionAttackBonus > 0) {
+                <span class="condition-bonus">+{{ manager.conditionAttackBonus }}</span>
+              }
+            </span>
+          </button>
+          <button
+            type="button"
+            class="value-field compact pierce-field"
+            [class.active]="manager.inputField === 'pierce'"
+            title="Pierce"
+            [attr.aria-label]="inputFieldLabel('pierce')"
+            (click)="openInputField('pierce', $event)"
+          >
+            <img [src]="actionIconUrl('pierce')" title="Pierce" [attr.alt]="actionAltLabel('pierce')" aria-hidden="true" />
+            <span class="field-value">{{ manager.pierce }}</span>
+          </button>
+        </div>
+
+        <div class="draw-actions">
+          @if (manager.canUndoAttack) {
+            <button
+              type="button"
+              class="undo"
+              title="Undo attack"
+              [attr.aria-label]="undoButtonLabel"
+              (click)="manager.undoAttack()"
+            >
+              <span [ghs-label]="'game.attackResolve.undo'"></span>
+            </button>
+          }
+          <button
+            type="button"
+            class="draw"
+            title="Draw"
+            [disabled]="!manager.canDraw"
+            (click)="manager.drawModifier()"
+            [ghs-label]="manager.needsShuffle ? 'game.cards.shuffle' : 'game.cards.draw'"
+            [ghs-label-attribute]="'aria-label'"
+          >
+            @if (manager.needsShuffle) {
+              <span [ghs-label]="'game.cards.shuffle'"></span>
+            } @else {
+              <span [ghs-label]="'game.cards.draw'"></span>
+            }
+          </button>
+          @if (settingsManager.settings.amAdvantage && !manager.needsShuffle) {
+            <button
+              type="button"
+              class="advantage"
+              title="Draw with Advantage"
+              [disabled]="!manager.canDraw"
+              (click)="manager.drawModifier('advantage')"
+              [ghs-label]="'game.cards.drawAdvantage'"
+              [ghs-label-attribute]="'aria-label'"
+            >
+              <img
+                [src]="'./assets/images/' + (settingsManager.settings.fhStyle ? 'fh/' : '') + 'condition/strengthen.svg'"
+                title="Draw with Advantage"
+                [attr.alt]="drawAdvantageAltLabel"
+                aria-hidden="true"
+              />
+            </button>
+            <button
+              type="button"
+              class="disadvantage"
+              title="Draw with Disadvantage"
+              [disabled]="!manager.canDraw"
+              (click)="manager.drawModifier('disadvantage')"
+              [ghs-label]="'game.cards.drawDisadvantage'"
+              [ghs-label-attribute]="'aria-label'"
+            >
+              <img
+                [src]="'./assets/images/' + (settingsManager.settings.fhStyle ? 'fh/' : '') + 'condition/muddle.svg'"
+                title="Draw with Disadvantage"
+                [attr.alt]="drawDisadvantageAltLabel"
+                aria-hidden="true"
+              />
+            </button>
+          }
+        </div>
+
+        @if (manager.attackResult && attackDeck) {
+          <div class="result">
+            <div class="calc-line">
+              <img
+                class="calc-icon ghs-svg"
+                [src]="actionIconUrl('attack')"
+                title="Attack"
+                [attr.alt]="actionAltLabel('attack')"
+              />
+              <span class="calc-value">{{ manager.attackResult.result }}</span>
+              @if (manager.attackResult.stringified) {
+                <span class="calc-modifier">({{ manager.attackResult.stringified }})</span>
+              }
+              @if (manager.shieldBlocked > 0) {
+                <span class="calc-op">−</span>
+                <img
+                  class="calc-icon ghs-svg shield-icon"
+                  [src]="actionIconUrl('shield')"
+                  title="Shield"
+                  [attr.alt]="actionAltLabel('shield')"
+                />
+                <span class="calc-value">{{ manager.shieldBlocked }}</span>
+              }
+              <span class="calc-op">=</span>
+              <button
+                type="button"
+                class="damage-inline"
+                [class.active]="manager.inputField === 'damage'"
+                [class.manual]="manager.damageIsManual"
+                title="Damage"
+                [attr.aria-label]="inputFieldLabel('damage')"
+                (click)="openInputField('damage', $event)"
+              >
+                <img
+                  class="calc-icon ghs-svg"
+                  [src]="actionIconUrl('damage')"
+                  title="Damage"
+                  [attr.alt]="actionAltLabel('damage')"
+                  aria-hidden="true"
+                />
+                <span class="calc-value">{{ manager.finalDamage }}</span>
+              </button>
+            </div>
+            @if (!manager.numpadOpen || manager.inputField !== 'damage') {
+              <p class="edit-damage-hint" [ghs-label]="'game.attackResolve.editDamageHint'"></p>
+            }
+            @if (manager.attackResult.chooseOffset) {
+              <p class="choose-hint" [ghs-label]="'game.attackResolve.chooseCard'"></p>
+              <div class="choose">
+                <ghs-attackmodifier
+                  (click)="manager.toggleAttackResult()"
+                  [attackModifier]="attackDeck.cards[manager.attackResult.index + manager.attackResult.chooseOffset]"
+                  [numeration]="deckNumeration"
+                  [characterIcon]="deckIconUrl"
+                  [flipped]="true"
+                  [newStyle]="newStyle"
+                ></ghs-attackmodifier>
+                <ghs-attackmodifier
+                  [attackModifier]="attackDeck.cards[manager.attackResult.index]"
+                  [numeration]="deckNumeration"
+                  [characterIcon]="deckIconUrl"
+                  [flipped]="true"
+                  [newStyle]="newStyle"
+                ></ghs-attackmodifier>
+              </div>
+            }
+          </div>
+        }
+
+        @if (manager.numpadOpen) {
+          <div class="numpad-backdrop" (click)="manager.closeNumpad()"></div>
+          <div class="numpad-popup" (click)="$event.stopPropagation()">
+            @if (manager.inputField === 'damage') {
+              <button
+                type="button"
+                class="numpad-close"
+                title="Cancel"
+                [attr.aria-label]="cancelDamageLabel"
+                (click)="manager.cancelDamageEdit()"
+              >
+                <img src="./assets/images/close_dialog.svg" title="Cancel" alt="Cancel" aria-hidden="true" />
+              </button>
+            }
+            <div class="number-container">
+              <span></span>
+              <span class="numpad-value">{{ activeInputDisplay }}</span>
+              <span></span>
+              @for (key of numpadKeys; track key) {
+                <button
+                  type="button"
+                  class="number-button"
+                  [title]="key"
+                  [attr.aria-label]="numpadDigitLabel(key)"
+                  (click)="manager.appendDigit(key)"
+                >
+                  <span class="number">{{ key }}</span>
+                </button>
+              }
+              <span></span>
+              <button
+                type="button"
+                class="number-button"
+                title="0"
+                [attr.aria-label]="numpadDigitLabel(0)"
+                (click)="manager.appendDigit(0)"
+              >
+                <span class="number">0</span>
+              </button>
+              <span></span>
+            </div>
+            <div class="numpad-actions">
+              <button
+                type="button"
+                class="numpad-action"
+                title="Clear"
+                [attr.aria-label]="clearButtonLabel"
+                (click)="manager.clearActiveInput()"
+              >
+                <span [ghs-label]="'game.attackResolve.clear'"></span>
+              </button>
+              <button
+                type="button"
+                class="numpad-action"
+                title="Del"
+                [attr.aria-label]="backspaceButtonLabel"
+                (click)="manager.backspaceDigit()"
+              >
+                <span [ghs-label]="'game.attackResolve.backspace'"></span>
+              </button>
+            </div>
+            <button
+              type="button"
+              class="numpad-done"
+              title="Done"
+              [attr.aria-label]="numpadDoneLabel"
+              (click)="acceptNumpad()"
+            >
+              <span [ghs-label]="'game.attackResolve.numpadDone'"></span>
+            </button>
+          </div>
+        }
+
+        <button
+          type="button"
+          class="apply"
+          title="Apply damage &amp; conditions"
+          [disabled]="!manager.attackResult || manager.applied"
+          [attr.aria-label]="applyButtonLabel"
+          (click)="manager.applyAttack()"
+        >
+          <span [ghs-label]="manager.applied ? 'game.attackResolve.applied' : 'game.attackResolve.apply'"></span>
+        </button>
+      </div>
+
+      <div class="right">
+        <span class="section-title" [ghs-label]="'game.attackResolve.conditionsTarget'"></span>
+        <ghs-conditions
+          [entity]="target.entity"
+          [figure]="target.figure"
+          [entityConditions]="manager.pendingTargetConditions"
+          [immunities]="target.entity.immunities"
+          [type]="manager.conditionType"
+          [negativeOnly]="true"
+          [hideToggles]="true"
+          [columns]="3"
+          (conditionChange)="manager.setPendingTargetConditions($event)"
+        ></ghs-conditions>
+        @if (attackerEntity) {
+          <span class="section-title" [ghs-label]="'game.attackResolve.conditionsAttacker'"></span>
+          <ghs-conditions
+            [entity]="attackerEntity"
+            [figure]="attackerFigure"
+            [entityConditions]="manager.pendingAttackerConditions"
+            [immunities]="attackerEntity.immunities"
+            [type]="manager.attackerConditionType"
+            [positiveOnly]="true"
+            [hideToggles]="true"
+            [columns]="3"
+            (conditionChange)="manager.setPendingAttackerConditions($event)"
+          ></ghs-conditions>
+        }
+      </div>
+    </div>
+
+    <p class="deck-hint" [ghs-label]="manager.deckHintLabelKey()"></p>
+  </div>
+}

--- a/src/app/ui/figures/attackmodifier/attack-resolve-panel.scss
+++ b/src/app/ui/figures/attackmodifier/attack-resolve-panel.scss
@@ -1,0 +1,453 @@
+.attack-resolve-panel {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 200;
+  width: fit-content;
+  max-width: min(96vw, calc(var(--ghs-unit) * 70 * var(--ghs-text-factor) * var(--ghs-barsize)));
+  max-height: min(94vh, calc(100vh - var(--ghs-unit) * 12 * var(--ghs-text-factor) * var(--ghs-barsize)));
+  overflow: auto;
+  padding: calc(var(--ghs-unit) * 2 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+  &:has(.numpad-active) {
+    overflow: visible;
+  }
+  color: var(--ghs-color-white);
+  font-size: calc(var(--ghs-unit) * 2.2 * var(--ghs-text-factor) * var(--ghs-dialog-factor));
+  background-color: var(--ghs-color-black);
+  background-image: url('../../../../assets/images/dialog_background.png');
+  background-size: cover;
+  border: calc(var(--ghs-unit) * 0.3 * var(--ghs-text-factor) * var(--ghs-barsize)) solid var(--ghs-color-gray);
+  border-radius: calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize));
+  box-shadow: 0 0 calc(var(--ghs-unit) * 2 * var(--ghs-text-factor) * var(--ghs-barsize)) rgba(0, 0, 0, 0.6);
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+    .title {
+      font-size: calc(var(--ghs-unit) * 2.2 * var(--ghs-text-factor) * var(--ghs-dialog-factor));
+      font-weight: 600;
+    }
+
+    .cancel {
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      padding: 0;
+
+      img {
+        width: calc(var(--ghs-unit) * 2.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+        filter: var(--ghs-filter-white);
+      }
+    }
+  }
+
+  .target-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+    margin-bottom: calc(var(--ghs-unit) * 1 * var(--ghs-text-factor) * var(--ghs-barsize));
+    padding-bottom: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+
+    .shield,
+    .retaliate {
+      padding: 0.1em 0.4em;
+      border-radius: 0.25em;
+      font-size: 0.85em;
+    }
+
+    .shield {
+      background: rgba(100, 149, 237, 0.35);
+    }
+
+    .retaliate {
+      background: rgba(220, 80, 80, 0.35);
+    }
+  }
+
+  .body {
+    display: flex;
+    gap: calc(var(--ghs-unit) * 1 * var(--ghs-text-factor) * var(--ghs-barsize));
+    align-items: flex-start;
+    width: fit-content;
+  }
+
+  .left {
+    position: relative;
+    flex: 0 0 auto;
+    width: calc(var(--ghs-unit) * 22 * var(--ghs-text-factor) * var(--ghs-barsize));
+    overflow: visible;
+
+    &.numpad-active {
+      min-height: calc(var(--ghs-unit) * 34 * var(--ghs-text-factor) * var(--ghs-barsize));
+    }
+
+    .value-inputs-row {
+      display: flex;
+      gap: calc(var(--ghs-unit) * 0.4 * var(--ghs-text-factor) * var(--ghs-barsize));
+      margin-bottom: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+    }
+
+    .value-field.compact {
+      flex: 1 1 0;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: calc(var(--ghs-unit) * 0.2 * var(--ghs-text-factor) * var(--ghs-barsize));
+      cursor: pointer;
+      color: var(--ghs-color-white);
+      background: rgba(0, 0, 0, 0.35);
+      border: 1px solid var(--ghs-color-gray);
+      border-radius: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+      padding: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize))
+        calc(var(--ghs-unit) * 0.25 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+      &.active {
+        border-color: var(--ghs-color-white);
+        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.35);
+      }
+
+      img {
+        width: calc(var(--ghs-unit) * 1.8 * var(--ghs-text-factor) * var(--ghs-barsize));
+        height: calc(var(--ghs-unit) * 1.8 * var(--ghs-text-factor) * var(--ghs-barsize));
+        filter: var(--ghs-filter-white);
+      }
+
+      .field-value {
+        font-size: calc(var(--ghs-unit) * 2.2 * var(--ghs-text-factor) * var(--ghs-dialog-factor));
+        font-weight: 700;
+        line-height: 1;
+      }
+
+      .condition-bonus {
+        margin-left: 0.15em;
+        font-size: 0.55em;
+        font-weight: 600;
+        color: var(--ghs-color-green, #6c6);
+      }
+
+      &.pierce-field .field-value {
+        font-size: calc(var(--ghs-unit) * 2 * var(--ghs-text-factor) * var(--ghs-dialog-factor));
+      }
+    }
+
+    .numpad-backdrop {
+      position: absolute;
+      inset: 0;
+      z-index: 5;
+      cursor: default;
+    }
+
+    .numpad-popup {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      z-index: 10;
+
+      .numpad-close {
+        position: absolute;
+        top: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+        right: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+        cursor: pointer;
+        background: transparent;
+        border: none;
+        padding: 0;
+        z-index: 1;
+
+        img {
+          width: calc(var(--ghs-unit) * 2 * var(--ghs-text-factor) * var(--ghs-barsize));
+          filter: var(--ghs-filter-white);
+        }
+
+        &:hover img {
+          filter: var(--ghs-filter-gray);
+        }
+      }
+      width: calc(100% - var(--ghs-unit) * 1 * var(--ghs-text-factor) * var(--ghs-barsize));
+      max-width: calc(var(--ghs-unit) * 20 * var(--ghs-text-factor) * var(--ghs-barsize));
+      padding: calc(var(--ghs-unit) * 1 * var(--ghs-text-factor) * var(--ghs-barsize));
+      background: rgba(0, 0, 0, 0.92);
+      border: 1px solid var(--ghs-color-gray);
+      border-radius: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+      box-shadow: 0 0 calc(var(--ghs-unit) * 1.5 * var(--ghs-text-factor) * var(--ghs-barsize)) rgba(0, 0, 0, 0.7);
+
+      .number-container {
+        display: grid;
+        grid-template-columns: repeat(3, calc(var(--ghs-unit) * 5 * var(--ghs-text-factor) * var(--ghs-barsize)));
+        justify-items: center;
+        justify-content: center;
+        gap: calc(var(--ghs-unit) * 0.15 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+        .numpad-value {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: calc(var(--ghs-unit) * 4.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+          width: calc(var(--ghs-unit) * 4.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+          font-family: var(--ghs-font-title);
+          font-size: calc(var(--ghs-unit) * 2.2 * var(--ghs-text-factor) * var(--ghs-dialog-factor));
+          font-weight: 700;
+          color: var(--ghs-color-white);
+          text-shadow: var(--ghs-outline);
+        }
+
+        .number-button {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: calc(var(--ghs-unit) * 4.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+          width: calc(var(--ghs-unit) * 4.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+          cursor: pointer;
+          font-family: var(--ghs-font-title);
+          font-size: calc(var(--ghs-unit) * 2.2 * var(--ghs-text-factor) * var(--ghs-dialog-factor));
+          color: var(--ghs-color-gray);
+          text-shadow: var(--ghs-outline);
+          background: transparent;
+          border: none;
+          padding: 0;
+
+          &:hover {
+            color: var(--ghs-color-white);
+          }
+        }
+      }
+
+      .numpad-actions {
+        display: flex;
+        justify-content: center;
+        gap: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+        margin-top: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+        .numpad-action {
+          cursor: pointer;
+          color: var(--ghs-color-gray);
+          background: transparent;
+          border: 1px solid var(--ghs-color-gray);
+          border-radius: calc(var(--ghs-unit) * 0.25 * var(--ghs-text-factor) * var(--ghs-barsize));
+          padding: calc(var(--ghs-unit) * 0.2 * var(--ghs-text-factor) * var(--ghs-barsize))
+            calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+          font-size: 0.85em;
+
+          &:hover {
+            color: var(--ghs-color-white);
+            border-color: var(--ghs-color-white);
+          }
+        }
+      }
+
+      .numpad-done {
+        display: block;
+        width: 100%;
+        margin-top: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+        cursor: pointer;
+        color: var(--ghs-color-white);
+        background: rgba(232, 168, 56, 0.25);
+        border: 1px solid var(--ghs-color-gold, #d4af37);
+        border-radius: calc(var(--ghs-unit) * 0.25 * var(--ghs-text-factor) * var(--ghs-barsize));
+        padding: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+        font-weight: 600;
+        font-size: inherit;
+
+        &:hover {
+          background: rgba(232, 168, 56, 0.4);
+        }
+      }
+    }
+  }
+
+  .right .section-title:not(:first-child) {
+    margin-top: calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize));
+  }
+
+  .right {
+    flex: 0 1 auto;
+    width: calc(var(--ghs-unit) * 28 * var(--ghs-text-factor) * var(--ghs-barsize));
+    max-width: calc(var(--ghs-unit) * 32 * var(--ghs-text-factor) * var(--ghs-barsize));
+    max-height: calc(var(--ghs-unit) * 40 * var(--ghs-text-factor) * var(--ghs-barsize));
+    overflow: auto;
+  }
+
+  .section-title {
+    display: block;
+    font-weight: 600;
+    margin-bottom: calc(var(--ghs-unit) * 0.4 * var(--ghs-text-factor) * var(--ghs-barsize));
+  }
+
+  .draw-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+    margin-bottom: calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+    button {
+      cursor: pointer;
+      color: var(--ghs-color-white);
+      background: rgba(0, 0, 0, 0.4);
+      border: 1px solid var(--ghs-color-gray);
+      border-radius: calc(var(--ghs-unit) * 0.25 * var(--ghs-text-factor) * var(--ghs-barsize));
+      padding: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize))
+        calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+      &.undo {
+        border-color: rgba(220, 120, 120, 0.75);
+        color: #f0b0b0;
+      }
+
+      &:disabled {
+        opacity: 0.45;
+        cursor: default;
+      }
+
+      &.advantage,
+      &.disadvantage {
+        padding: calc(var(--ghs-unit) * 0.3 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+        img {
+          width: calc(var(--ghs-unit) * 2.2 * var(--ghs-text-factor) * var(--ghs-barsize));
+          display: block;
+          filter: var(--ghs-filter-white);
+        }
+      }
+    }
+  }
+
+  .result {
+    margin-bottom: calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+    .calc-line {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+      font-size: calc(var(--ghs-unit) * 2.1 * var(--ghs-text-factor) * var(--ghs-dialog-factor));
+
+      .calc-icon {
+        width: calc(var(--ghs-unit) * 3 * var(--ghs-text-factor) * var(--ghs-barsize));
+        height: calc(var(--ghs-unit) * 3 * var(--ghs-text-factor) * var(--ghs-barsize));
+        filter: var(--ghs-filter-white);
+        flex-shrink: 0;
+
+        &.shield-icon {
+          width: calc(var(--ghs-unit) * 3.4 * var(--ghs-text-factor) * var(--ghs-barsize));
+          height: calc(var(--ghs-unit) * 3.4 * var(--ghs-text-factor) * var(--ghs-barsize));
+        }
+      }
+
+      .calc-value {
+        font-weight: 700;
+      }
+
+      .calc-modifier {
+        opacity: 0.85;
+      }
+
+      .calc-op {
+        opacity: 0.75;
+        margin: 0 0.1em;
+      }
+
+      .damage-inline {
+        display: inline-flex;
+        align-items: center;
+        gap: calc(var(--ghs-unit) * 0.3 * var(--ghs-text-factor) * var(--ghs-barsize));
+        cursor: pointer;
+        color: inherit;
+        background: rgba(232, 168, 56, 0.15);
+        border: 2px dashed #e8a838;
+        border-radius: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+        padding: 0.2em 0.55em;
+        font: inherit;
+        font-weight: 700;
+
+        &:hover {
+          background: rgba(232, 168, 56, 0.18);
+          border-color: #e8a838;
+        }
+
+        &.active {
+          border-style: solid;
+          border-color: #e8a838;
+          box-shadow: 0 0 0 1px rgba(232, 168, 56, 0.45);
+          background: rgba(232, 168, 56, 0.22);
+        }
+
+        &.manual:not(.active) {
+          border-style: solid;
+          border-color: rgba(232, 168, 56, 0.85);
+        }
+      }
+    }
+
+    .edit-damage-hint {
+      margin: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize)) 0 0;
+      font-size: calc(var(--ghs-unit) * 1.6 * var(--ghs-text-factor) * var(--ghs-dialog-factor));
+      color: #e8c878;
+      opacity: 1;
+      font-weight: 600;
+    }
+
+    .choose {
+      display: flex;
+      gap: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+      margin-top: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+
+      ghs-attackmodifier {
+        display: block;
+        width: calc(var(--ghs-unit) * 8 * var(--ghs-text-factor) * var(--ghs-barsize));
+        cursor: pointer;
+      }
+    }
+  }
+
+  .apply {
+    width: 100%;
+    cursor: pointer;
+    color: var(--ghs-color-white);
+    background: rgba(0, 0, 0, 0.5);
+    border: 1px solid var(--ghs-color-gold, #d4af37);
+    border-radius: calc(var(--ghs-unit) * 0.25 * var(--ghs-text-factor) * var(--ghs-barsize));
+    padding: calc(var(--ghs-unit) * 0.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+    font-weight: 600;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: default;
+      border-color: var(--ghs-color-gray);
+    }
+  }
+
+  .deck-hint {
+    margin: calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize)) 0 0;
+    font-size: 0.85em;
+    opacity: 0.85;
+    text-align: center;
+  }
+}
+
+:host:has(.attack-resolve-pick-overlay),
+:host:has(.attack-resolve-panel) {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  pointer-events: none;
+}
+
+:host:has(.attack-resolve-panel) .attack-resolve-panel {
+  pointer-events: auto;
+}
+
+.attack-resolve-pick-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.35);
+}

--- a/src/app/ui/figures/attackmodifier/attack-resolve-panel.ts
+++ b/src/app/ui/figures/attackmodifier/attack-resolve-panel.ts
@@ -1,0 +1,190 @@
+import { NgClass } from '@angular/common';
+import { ChangeDetectionStrategy, Component, HostListener, inject } from '@angular/core';
+import { AttackResolveInputField } from 'src/app/game/businesslogic/AttackResolveManager';
+import { GameManager, gameManager } from 'src/app/game/businesslogic/GameManager';
+import { GhsManager } from 'src/app/game/businesslogic/GhsManager';
+import { SettingsManager, settingsManager } from 'src/app/game/businesslogic/SettingsManager';
+import { AttackModifierComponent } from 'src/app/ui/figures/attackmodifier/attackmodifier';
+import { ConditionsComponent } from 'src/app/ui/figures/conditions/conditions';
+import { GhsLabelDirective } from 'src/app/ui/helper/label';
+
+@Component({
+  imports: [NgClass, GhsLabelDirective, ConditionsComponent, AttackModifierComponent],
+  selector: 'ghs-attack-resolve-panel',
+  templateUrl: './attack-resolve-panel.html',
+  styleUrls: ['./attack-resolve-panel.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AttackResolvePanelComponent {
+  private ghsManager = inject(GhsManager);
+
+  settingsManager: SettingsManager = settingsManager;
+  gameManager: GameManager = gameManager;
+  numpadKeys = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+  constructor() {
+    this.ghsManager.uiChangeEffect(() => {});
+  }
+
+  get manager() {
+    return gameManager.attackResolveManager;
+  }
+
+  get visible(): boolean {
+    return this.manager.phase === 'configure' && this.manager.hasAttacker && !!this.manager.target;
+  }
+
+  get target() {
+    return this.manager.target!;
+  }
+
+  get attackDeck() {
+    return this.manager.attackModifierDeck;
+  }
+
+  get deckNumeration(): string {
+    return this.manager.deckNumeration;
+  }
+
+  get deckIconUrl(): string {
+    return this.manager.deckIconUrl;
+  }
+
+  get newStyle(): boolean {
+    if (this.manager.character) {
+      return gameManager.newAmStyle(this.manager.character.edition) || settingsManager.settings.fhStyle;
+    }
+    return settingsManager.settings.fhStyle;
+  }
+
+  get attackerEntity() {
+    return this.manager.attackerEntity;
+  }
+
+  get attackerFigure() {
+    return this.manager.attackerFigure;
+  }
+
+  get activeInputDisplay(): string {
+    if (this.manager.inputField === 'damage') {
+      return '' + this.manager.finalDamage;
+    }
+    if (this.manager.inputField === 'pierce') {
+      return '' + this.manager.pierce;
+    }
+    return '' + this.manager.baseAttack;
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent) {
+    if (!this.visible || !settingsManager.settings.keyboardShortcuts) {
+      return;
+    }
+    if (event.ctrlKey || event.altKey || event.metaKey) {
+      return;
+    }
+    if (event.key >= '0' && event.key <= '9') {
+      this.manager.appendDigit(+event.key);
+      event.preventDefault();
+      event.stopPropagation();
+    } else if (event.key === 'Backspace') {
+      this.manager.backspaceDigit();
+      event.preventDefault();
+      event.stopPropagation();
+    } else if (event.key === 'Escape') {
+      if (this.manager.inputField === 'damage' && this.manager.numpadOpen) {
+        this.manager.cancelDamageEdit();
+      } else {
+        this.manager.closeNumpad();
+      }
+      event.preventDefault();
+      event.stopPropagation();
+    } else if (event.key === 'Enter' && this.manager.numpadOpen) {
+      this.manager.closeNumpad();
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  acceptNumpad(): void {
+    this.manager.closeNumpad();
+  }
+
+  openInputField(field: AttackResolveInputField, event: Event): void {
+    event.stopPropagation();
+    this.manager.setInputField(field);
+  }
+
+  inputFieldLabel(field: AttackResolveInputField): string {
+    const value =
+      field === 'damage' ? this.manager.finalDamage : field === 'pierce' ? this.manager.pierce : this.manager.baseAttack;
+    const key =
+      field === 'damage'
+        ? 'game.attackResolve.inputDamageValue'
+        : field === 'pierce'
+          ? 'game.attackResolve.inputPierceValue'
+          : 'game.attackResolve.inputAttackValue';
+    return settingsManager.getLabel(key, ['' + value]);
+  }
+
+  numpadDigitLabel(digit: number): string {
+    return settingsManager.getLabel('game.attackResolve.numpadDigit', ['' + digit]);
+  }
+
+  get clearButtonLabel(): string {
+    return settingsManager.getLabel('game.attackResolve.clear');
+  }
+
+  get backspaceButtonLabel(): string {
+    return settingsManager.getLabel('game.attackResolve.backspace');
+  }
+
+  actionAltLabel(action: 'attack' | 'pierce' | 'damage' | 'shield'): string {
+    const keys: Record<typeof action, string> = {
+      attack: 'game.attackResolve.inputAttack',
+      pierce: 'game.attackResolve.inputPierce',
+      damage: 'game.attackResolve.inputDamage',
+      shield: 'game.action.shield'
+    };
+    return settingsManager.getLabel(keys[action]);
+  }
+
+  get drawAdvantageAltLabel(): string {
+    return settingsManager.getLabel('game.cards.drawAdvantage');
+  }
+
+  get drawDisadvantageAltLabel(): string {
+    return settingsManager.getLabel('game.cards.drawDisadvantage');
+  }
+
+  actionIconUrl(action: 'attack' | 'pierce' | 'damage' | 'shield'): string {
+    const prefix = settingsManager.settings.fhStyle ? '/fh' : '';
+    if (action === 'shield') {
+      return './assets/images' + prefix + '/action/hint/shield.svg';
+    }
+    if (action === 'damage') {
+      return './assets/images' + prefix + '/action/damage.svg';
+    }
+    return './assets/images' + prefix + '/action/' + action + '.svg';
+  }
+
+  get numpadDoneLabel(): string {
+    return settingsManager.getLabel('game.attackResolve.numpadDone');
+  }
+
+  get undoButtonLabel(): string {
+    return settingsManager.getLabel('game.attackResolve.undo');
+  }
+
+  get cancelDamageLabel(): string {
+    return settingsManager.getLabel('cancel');
+  }
+
+  get applyButtonLabel(): string {
+    return settingsManager.getLabel(this.manager.applied ? 'game.attackResolve.applied' : 'game.attackResolve.apply');
+  }
+
+  get closeButtonLabel(): string {
+    return settingsManager.getLabel('close');
+  }
+}

--- a/src/app/ui/figures/attackmodifier/attackmodifierdeck.html
+++ b/src/app/ui/figures/attackmodifier/attackmodifierdeck.html
@@ -43,10 +43,14 @@
       class="am"
       (click)="draw($event)"
       [ghs-label]="
-        compact && fullscreen() ? 'game.cards.fullscreen' : deck.current >= deckLength - 1 ? 'game.cards.shuffle' : 'game.cards.draw'
+        compact && fullscreen()
+          ? 'game.cards.fullscreen'
+          : deck.current >= deckLength - 1
+            ? 'game.cards.shuffle'
+            : 'game.cards.draw'
       "
       [ghs-label-attribute]="'title'"
-      [ngClass]="{ 'town-guard': townGuard(), disabled: disabled }"
+        [ngClass]="{ 'town-guard': townGuard(), disabled: disabled || attackResolveBlocksDeckDraw() }"
     >
       <span class="number" [ngClass]="{ 'has-shuffle': deck.current >= deckLength + (deck.bb ? -3 : -1) }">
         @if (!deck.bb) {
@@ -94,7 +98,7 @@
       </span>
     }
 
-    @if ((deck.bb || settingsManager.settings.amAdvantage) && (!compact || vertical())) {
+    @if ((deck.bb || settingsManager.settings.amAdvantage) && (!compact || vertical()) && !attackResolveGuided()) {
       <span
         class="advantage"
         [ghs-label]="'game.cards.drawAdvantage'"
@@ -111,7 +115,7 @@
       </span>
     }
 
-    @if ((deck.bb || settingsManager.settings.amAdvantage) && (!compact || vertical())) {
+    @if ((deck.bb || settingsManager.settings.amAdvantage) && (!compact || vertical()) && !attackResolveGuided()) {
       <span
         class="disadvantage"
         [ghs-label]="'game.cards.drawDisadvantage'"

--- a/src/app/ui/figures/attackmodifier/attackmodifierdeck.ts
+++ b/src/app/ui/figures/attackmodifier/attackmodifierdeck.ts
@@ -315,7 +315,50 @@ export class AttackModifierDeckComponent implements OnInit, OnChanges {
     );
   }
 
+  attackResolveBlocksDeckDraw(): boolean {
+    if (!settingsManager.settings.attackResolveGuided || !gameManager.game.scenario || gameManager.game.state !== GameState.next) {
+      return false;
+    }
+    if (this.townGuard() || this.standalone()) {
+      return false;
+    }
+
+    const mgr = gameManager.attackResolveManager;
+    const character = this.character;
+
+    if (character) {
+      return (
+        !this.ally() &&
+        character.active &&
+        (mgr.phase === 'idle' || mgr.character === character)
+      );
+    }
+
+    const monster = mgr.footerAttackMonster();
+    if (!monster || !monster.active) {
+      return false;
+    }
+
+    const usesAllyDeck = mgr.monsterUsesAllyDeck(monster);
+    if (this.ally() !== usesAllyDeck) {
+      return false;
+    }
+
+    return mgr.phase === 'idle' || mgr.monster === monster;
+  }
+
+  attackResolveGuided(): boolean {
+    return this.attackResolveBlocksDeckDraw() && gameManager.attackResolveManager.phase === 'idle';
+  }
+
   draw(event: any, state: 'advantage' | 'disadvantage' | undefined = undefined) {
+    if (this.attackResolveBlocksDeckDraw()) {
+      if (event) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+      return;
+    }
     if (this.compact && this.fullscreen()) {
       this.openFullscreen(event);
     } else if (!this.disabled) {

--- a/src/app/ui/figures/character/character.ts
+++ b/src/app/ui/figures/character/character.ts
@@ -230,6 +230,9 @@ export class CharacterComponent implements OnInit {
   }
 
   toggleFigure(event: any): void {
+    if (this.tryAttackResolveTarget()) {
+      return;
+    }
     if (!this.character.absent) {
       if (
         gameManager.game.state === GameState.next &&
@@ -466,6 +469,9 @@ export class CharacterComponent implements OnInit {
   }
 
   openEntityMenu(): void {
+    if (this.tryAttackResolveTarget()) {
+      return;
+    }
     this.dialog.open(EntitiesMenuDialogComponent, {
       panelClass: ['dialog'],
       data: {
@@ -741,5 +747,9 @@ export class CharacterComponent implements OnInit {
         data: { character: this.character }
       });
     }
+  }
+
+  private tryAttackResolveTarget(): boolean {
+    return gameManager.attackResolveManager.handleStandeeClick(this.character, this.character);
   }
 }

--- a/src/app/ui/figures/character/sheet/character-sheet.ts
+++ b/src/app/ui/figures/character/sheet/character-sheet.ts
@@ -494,6 +494,9 @@ export class CharacterSheetComponent implements OnInit, AfterViewInit {
           this.character.progress.retired ? 'setRetired' : 'unsetRetired',
           gameManager.characterManager.characterName(this.character, true, true)
         );
+        if (gameManager.fhRules()) {
+          gameManager.characterManager.moveResourcesToSupply(this.character);
+        }
         this.character.progress.retired = true;
         if (gameManager.game.party.campaignMode) {
           gameManager.game.party.retirements.push(this.character.toModel());

--- a/src/app/ui/figures/conditions/conditions.html
+++ b/src/app/ui/figures/conditions/conditions.html
@@ -12,7 +12,15 @@
         }"
       >
         @if (condition.types.includes(ConditionType.stack) || condition.types.includes(ConditionType.upgrade)) {
-          <img tabclick (click)="dec(condition)" class="ghs-svg dec" src="./assets/images/left.svg" />
+          <img
+            tabclick
+            (click)="dec(condition)"
+            class="ghs-svg dec"
+            src="./assets/images/left.svg"
+            title="Decrease"
+            alt="Decrease"
+            aria-hidden="true"
+          />
         }
         <span
           class="condition"
@@ -28,7 +36,12 @@
             immunity: isImmune(condition.name)
           }"
         >
-          <img [src]="'./assets/images' + (settingsManager.settings.fhStyle ? '/fh' : '') + '/condition/' + condition.name + '.svg'" />
+          <img
+            [src]="'./assets/images' + (settingsManager.settings.fhStyle ? '/fh' : '') + '/condition/' + condition.name + '.svg'"
+            [attr.title]="conditionLabel(condition)"
+            [attr.alt]="conditionLabel(condition)"
+            aria-hidden="true"
+          />
           @if (condition.types.includes(ConditionType.stack) || condition.types.includes(ConditionType.upgrade)) {
             <span [ngClass]="{ stack: condition.types.includes(ConditionType.stack) }" class="value">{{
               getValue(condition) | ghsValueSign
@@ -45,7 +58,15 @@
           <span class="condition expire expire-overlay"></span>
         }
         @if (condition.types.includes(ConditionType.stack) || condition.types.includes(ConditionType.upgrade)) {
-          <img tabclick (click)="inc(condition)" class="ghs-svg inc" src="./assets/images/right.svg" />
+          <img
+            tabclick
+            (click)="inc(condition)"
+            class="ghs-svg inc"
+            src="./assets/images/right.svg"
+            title="Increase"
+            alt="Increase"
+            aria-hidden="true"
+          />
         }
       </a>
       @if (conditionSeparator.includes(i)) {
@@ -53,7 +74,7 @@
       }
     }
 
-    @if (conditions.length) {
+    @if (conditions.length && !hideToggles()) {
       <div class="separator"></div>
       <a class="item">
         <span
@@ -67,7 +88,12 @@
           [originY]="'top'"
           [overlayY]="'bottom'"
         >
-          <img src="./assets/images/condition/permanent.svg" />
+          <img
+            src="./assets/images/condition/permanent.svg"
+            [attr.title]="permanentToggleLabel"
+            [attr.alt]="permanentToggleLabel"
+            aria-hidden="true"
+          />
         </span>
       </a>
       <a class="item">
@@ -82,7 +108,12 @@
           [originY]="'top'"
           [overlayY]="'bottom'"
         >
-          <img src="./assets/images/condition/round.svg" />
+          <img
+            src="./assets/images/condition/round.svg"
+            [attr.title]="roundExpireToggleLabel"
+            [attr.alt]="roundExpireToggleLabel"
+            aria-hidden="true"
+          />
         </span>
       </a>
       <!--
@@ -106,8 +137,12 @@
           [originY]="'top'"
           [overlayY]="'bottom'"
         >
-          <img [src]="'./assets/images' + (settingsManager.settings.fhStyle ? '/fh/condition/immune.svg' : '/condition/immunity.svg')"
-        /></span>
+          <img
+            [src]="'./assets/images' + (settingsManager.settings.fhStyle ? '/fh/condition/immune.svg' : '/condition/immunity.svg')"
+            [attr.title]="immuneToggleLabel"
+            [attr.alt]="immuneToggleLabel"
+            aria-hidden="true"
+          /></span>
       </a>
     }
   </div>

--- a/src/app/ui/figures/conditions/conditions.ts
+++ b/src/app/ui/figures/conditions/conditions.ts
@@ -56,6 +56,9 @@ export class ConditionsComponent implements OnInit {
   readonly inputType = input<string>('', { alias: 'type' });
 
   readonly columns = input<number>(3);
+  readonly positiveOnly = input<boolean>(false);
+  readonly negativeOnly = input<boolean>(false);
+  readonly hideToggles = input<boolean>(false);
   readonly empower = input<boolean>(false);
   readonly enfeeble = input<boolean>(false);
   readonly conditionChange = output<EntityCondition[]>({ alias: 'conditionChange' });
@@ -79,6 +82,22 @@ export class ConditionsComponent implements OnInit {
 
   constructor() {
     this.ghsManager.uiChangeEffect(() => this.initializeConditions());
+  }
+
+  conditionLabel(condition: Condition): string {
+    return settingsManager.getLabel('game.condition.' + condition.name);
+  }
+
+  get permanentToggleLabel(): string {
+    return settingsManager.getLabel('game.condition.permanent');
+  }
+
+  get roundExpireToggleLabel(): string {
+    return settingsManager.getLabel('game.condition.roundExpire');
+  }
+
+  get immuneToggleLabel(): string {
+    return settingsManager.getLabel('game.condition.immune');
   }
 
   ngOnInit(): void {
@@ -106,6 +125,9 @@ export class ConditionsComponent implements OnInit {
 
   @HostListener('document:keydown', ['$event'])
   onKeyPress(event: KeyboardEvent) {
+    if (gameManager.attackResolveManager.phase === 'configure') {
+      return;
+    }
     if (settingsManager.settings.keyboardShortcuts && event.key in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']) {
       const keyNumber = +event.key;
       if (this.timeout) {
@@ -166,19 +188,11 @@ export class ConditionsComponent implements OnInit {
     negativeConditions.push(...gameManager.conditionsForTypes('stack', 'negative', this.type));
     negativeConditions = negativeConditions.filter((c, i, s) => s.map((co) => co.name).indexOf(c.name) === i);
 
-    if (negativeConditions.length) {
-      this.conditions.push(...negativeConditions);
-    }
     let positiveConditions: Condition[] = [];
     positiveConditions.push(...gameManager.conditionsForTypes('standard', 'positive', this.type));
     positiveConditions.push(...gameManager.conditionsForTypes('upgrade', 'positive', this.type));
     positiveConditions.push(...gameManager.conditionsForTypes('stack', 'positive', this.type));
     positiveConditions = positiveConditions.filter((c, i, s) => s.map((co) => co.name).indexOf(c.name) === i);
-
-    if (positiveConditions.length) {
-      this.conditionSeparator.push(this.conditions.length - 1);
-      this.conditions.push(...positiveConditions);
-    }
 
     let neutralConditions: Condition[] = [];
     neutralConditions.push(...gameManager.conditionsForTypes('standard', 'neutral', this.type));
@@ -186,9 +200,30 @@ export class ConditionsComponent implements OnInit {
     neutralConditions.push(...gameManager.conditionsForTypes('stack', 'neutral', this.type));
     neutralConditions = neutralConditions.filter((c, i, s) => s.map((co) => co.name).indexOf(c.name) === i);
 
-    if (neutralConditions.length) {
-      this.conditionSeparator.push(this.conditions.length - 1);
-      this.conditions.push(...neutralConditions);
+    if (this.positiveOnly()) {
+      this.conditions.push(...positiveConditions);
+    } else if (this.negativeOnly()) {
+      if (negativeConditions.length) {
+        this.conditions.push(...negativeConditions);
+      }
+      if (neutralConditions.length) {
+        if (this.conditions.length) {
+          this.conditionSeparator.push(this.conditions.length - 1);
+        }
+        this.conditions.push(...neutralConditions);
+      }
+    } else {
+      if (negativeConditions.length) {
+        this.conditions.push(...negativeConditions);
+      }
+      if (positiveConditions.length) {
+        this.conditionSeparator.push(this.conditions.length - 1);
+        this.conditions.push(...positiveConditions);
+      }
+      if (neutralConditions.length) {
+        this.conditionSeparator.push(this.conditions.length - 1);
+        this.conditions.push(...neutralConditions);
+      }
     }
 
     if (this.immunityEnabled) {

--- a/src/app/ui/figures/monster/cards/image.ts
+++ b/src/app/ui/figures/monster/cards/image.ts
@@ -43,6 +43,14 @@ export class MonsterImageComponent {
   }
 
   toggleFigure() {
+    const mgr = gameManager.attackResolveManager;
+    if (mgr.phase === 'pickTarget' && mgr.hasAttacker) {
+      const entity =
+        this.monster.entities.find((e) => e.active && !e.dead) || this.monster.entities.find((e) => !e.dead);
+      if (entity && mgr.handleStandeeClick(entity, this.monster)) {
+        return;
+      }
+    }
     if (gameManager.game.state === GameState.next && gameManager.monsterManager.monsterEntityCount(this.monster)) {
       gameManager.stateManager.before(this.monster.active ? 'unsetActive' : 'setActive', 'data.monster.' + this.monster.name);
       gameManager.roundManager.toggleFigure(this.monster);

--- a/src/app/ui/figures/objective-container/objective-container.ts
+++ b/src/app/ui/figures/objective-container/objective-container.ts
@@ -123,6 +123,10 @@ export class ObjectiveContainerComponent implements OnInit {
   }
 
   toggleFigure(event: any): void {
+    const pickEntity = this.entity ?? this.objective.entities.find((entity) => gameManager.entityManager.isAlive(entity));
+    if (pickEntity && gameManager.attackResolveManager.handleStandeeClick(pickEntity, this.objective)) {
+      return;
+    }
     if (gameManager.game.state === GameState.draw || (settingsManager.settings.initiativeRequired && this.objective.initiative <= 0)) {
       this.openInitiativeDialog(event);
     } else {
@@ -209,6 +213,10 @@ export class ObjectiveContainerComponent implements OnInit {
   }
 
   openEntityMenu(): void {
+    const pickEntity = this.entity ?? this.objective.entities.find((entity) => gameManager.entityManager.isAlive(entity));
+    if (pickEntity && gameManager.attackResolveManager.handleStandeeClick(pickEntity, this.objective)) {
+      return;
+    }
     this.dialog.open(EntitiesMenuDialogComponent, {
       panelClass: ['dialog'],
       data: {

--- a/src/app/ui/figures/standee/standee.scss
+++ b/src/app/ui/figures/standee/standee.scss
@@ -1,3 +1,13 @@
+.entity-border.attack-target-pick {
+  cursor: crosshair;
+  z-index: 500;
+
+  &::before {
+    border-color: var(--ghs-color-gold, #d4af37);
+    box-shadow: 0 0 calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize)) rgba(212, 175, 55, 0.65);
+  }
+}
+
 .entity-border {
   position: relative;
   touch-action: none;

--- a/src/app/ui/figures/standee/standee.ts
+++ b/src/app/ui/figures/standee/standee.ts
@@ -188,6 +188,7 @@ export class StandeeComponent implements OnInit {
     const isMonster = gameManager.isMonster(this.figure);
 
     this.entityBorderClasses = {
+      'attack-target-pick': gameManager.attackResolveManager.phase === 'pickTarget',
       dead: this.entity.dead,
       off: !this.entity.dormant && this.entity.off,
       dormant: this.entity.dormant,
@@ -197,12 +198,18 @@ export class StandeeComponent implements OnInit {
         !this.entity.dormant &&
         this.entity.revealed &&
         settingsManager.settings.scenarioRooms &&
-        settingsManager.settings.activeStandees,
+        (settingsManager.settings.activeStandees || settingsManager.settings.monsterStandeeTurns),
       active:
         !this.entity.dormant &&
-        ((isMonsterEntity && this.entity.active && settingsManager.settings.activeStandees) ||
+        ((isMonsterEntity &&
+          this.entity.active &&
+          (settingsManager.settings.activeStandees || settingsManager.settings.monsterStandeeTurns)) ||
           (isSummon && this.entity.active && settingsManager.settings.activeSummons)),
-      'active-focus': !this.entity.dormant && this.entity.active && settingsManager.settings.activeStandees && !this.figure.active,
+      'active-focus':
+        !this.entity.dormant &&
+        this.entity.active &&
+        (settingsManager.settings.activeStandees || settingsManager.settings.monsterStandeeTurns) &&
+        !this.figure.active,
       'active-turn': this.activeTurn,
       monster: isMonsterEntity,
       objective: isObjectiveEntity,
@@ -439,9 +446,16 @@ export class StandeeComponent implements OnInit {
   }
 
   doubleClick(): void {
+    if (gameManager.attackResolveManager.phase === 'pickTarget') {
+      return;
+    }
     if (this.entity.revealed) {
       this.entity.revealed = false;
-    } else if (settingsManager.settings.activeStandees && this.entity instanceof MonsterEntity) {
+    } else if (
+      settingsManager.settings.activeStandees &&
+      !settingsManager.settings.monsterStandeeTurns &&
+      this.entity instanceof MonsterEntity
+    ) {
       gameManager.stateManager.before(
         this.figure.type + (this.entity.active ? 'UnsetEntityActive' : 'SetEntityActive'),
         this.figure.name,
@@ -495,6 +509,9 @@ export class StandeeComponent implements OnInit {
   }
 
   openEntityMenu(): void {
+    if (gameManager.attackResolveManager.handleStandeeClick(this.entity, this.figure)) {
+      return;
+    }
     if (this.entity.number < 0 && this.figure instanceof Monster && this.entity instanceof MonsterEntity) {
       if (settingsManager.settings.randomStandees) {
         const number = gameManager.monsterManager.monsterRandomStandee(this.figure);

--- a/src/app/ui/footer/footer.html
+++ b/src/app/ui/footer/footer.html
@@ -30,7 +30,13 @@
         [originY]="'top'"
         [overlayY]="'bottom'"
       >
-        <img class="ghs-svg" src="./assets/images/entities.svg" />
+        <img
+          class="ghs-svg"
+          src="./assets/images/entities.svg"
+          alt="Entities Menu"
+          [ghs-label]="'entities.event.entities'"
+          [ghs-label-attribute]="'alt'"
+        />
       </div>
     }
     <ghs-scenario #ghsScenario></ghs-scenario>
@@ -91,15 +97,27 @@
         [bottom]="true"
         [battleGoals]="false"
       ></ghs-attackmodifier-deck>
+      @if (gameManager.attackResolveManager.isPickingTarget(activeCharacter)) {
+        <div class="attack-resolve-footer-hint" role="status">
+          <span [ghs-label]="'game.attackResolve.pickTargetShort'"></span>
+        </div>
+      }
       <div
         class="active-toggle"
+        (click)="onCharacterAttackModifierIconClick($event)"
         [ngClass]="{
           inactive: !activeCharacter.attackModifierDeck.active,
-          denied: gameManager.stateManager.permissions && !gameManager.stateManager.permissions.character
+          denied: gameManager.stateManager.permissions && !gameManager.stateManager.permissions.character,
+          'attack-pick': gameManager.attackResolveManager.isPickingTarget(activeCharacter),
+          'attack-configure': gameManager.attackResolveManager.isConfiguring(activeCharacter)
         }"
       >
-        <span class="numeration" (click)="toggleActiveCharacterAttackModifierDeck()">
-          <img [src]="gameManager.characterManager.characterIcon(activeCharacter)" />
+        <span class="numeration">
+          <img
+            [src]="gameManager.characterManager.characterIcon(activeCharacter)"
+            alt="Character attack modifier deck"
+            [attr.alt]="gameManager.characterManager.characterName(activeCharacter, true)"
+          />
         </span>
       </div>
     </div>
@@ -133,14 +151,21 @@
         numeration="A"
         [bottom]="true"
       ></ghs-attackmodifier-deck>
+      @if (gameManager.attackResolveManager.isPickingTargetMonster(gameManager.attackResolveManager.footerAttackMonster())) {
+        <div class="attack-resolve-footer-hint" role="status">
+          <span [ghs-label]="'game.attackResolve.pickTargetShort'"></span>
+        </div>
+      }
       <div
         class="active-toggle"
+        (click)="onAllyAttackModifierIconClick($event)"
         [ngClass]="{
           inactive: !gameManager.game.allyAttackModifierDeck.active,
-          denied: gameManager.stateManager.permissions && !gameManager.stateManager.permissions.attackModifiers
+          denied: gameManager.stateManager.permissions && !gameManager.stateManager.permissions.attackModifiers,
+          'attack-pick': gameManager.attackResolveManager.isPickingTargetMonster(gameManager.attackResolveManager.footerAttackMonster())
         }"
       >
-        <span class="numeration" (click)="toggleActiveAllyAttackModifierDeck()">A</span>
+        <span class="numeration">A</span>
       </div>
     </div>
   }
@@ -177,14 +202,25 @@
         numeration="m"
         [bottom]="true"
       ></ghs-attackmodifier-deck>
+      @if (
+        gameManager.attackResolveManager.isPickingTargetMonster(gameManager.attackResolveManager.footerAttackMonster()) &&
+        !gameManager.attackResolveManager.footerAttackMonster()?.isAlly &&
+        !gameManager.attackResolveManager.footerAttackMonster()?.isAllied
+      ) {
+        <div class="attack-resolve-footer-hint" role="status">
+          <span [ghs-label]="'game.attackResolve.pickTargetShort'"></span>
+        </div>
+      }
       <div
         class="active-toggle"
+        (click)="onMonsterAttackModifierIconClick($event)"
         [ngClass]="{
           inactive: !gameManager.game.monsterAttackModifierDeck.active,
-          denied: gameManager.stateManager.permissions && !gameManager.stateManager.permissions.attackModifiers
+          denied: gameManager.stateManager.permissions && !gameManager.stateManager.permissions.attackModifiers,
+          'attack-pick': gameManager.attackResolveManager.isPickingTargetMonster(gameManager.attackResolveManager.footerAttackMonster())
         }"
       >
-        <span class="numeration" (click)="toggleActiveMonsterAttackModifierDeck()">m</span>
+        <span class="numeration">m</span>
       </div>
     </div>
   }
@@ -214,7 +250,13 @@
         }"
       >
         <span class="numeration" (click)="toggleLootDeck()">
-          <img src="./assets/images/fh/loot-token.png" />
+          <img
+            src="./assets/images/fh/loot-token.png"
+            alt="Loot deck"
+            [attr.alt]="
+              settingsManager.getLabel(gameManager.game.lootDeck.active ? 'state.info.lootDeckHide' : 'state.info.lootDeckShow')
+            "
+          />
         </span>
       </div>
     </div>
@@ -245,7 +287,15 @@
         }"
       >
         <span class="numeration" (click)="toggleChallengeDeck()">
-          <img src="./assets/images/fh/challenges/challenge.png" />
+          <img
+            src="./assets/images/fh/challenges/challenge.png"
+            alt="Challenge deck"
+            [attr.alt]="
+              settingsManager.getLabel(
+                gameManager.game.challengeDeck.active ? 'state.info.challengeDeck.hide' : 'state.info.challengeDeck.show'
+              )
+            "
+          />
         </span>
       </div>
     </div>

--- a/src/app/ui/footer/footer.scss
+++ b/src/app/ui/footer/footer.scss
@@ -76,6 +76,22 @@ footer {
         transform: scale(1.3);
       }
 
+      &.attack-pick,
+      &.attack-configure {
+        &::after {
+          content: '';
+          position: absolute;
+          inset: calc(var(--ghs-unit) * -0.25 * var(--ghs-text-factor) * var(--ghs-barsize));
+          border: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize)) solid var(--ghs-color-gold, #d4af37);
+          border-radius: 50%;
+          pointer-events: none;
+        }
+      }
+
+      &.attack-pick {
+        animation: attack-pick-pulse calc(var(--ghs-animation-speed) * 1200ms) ease-in-out infinite;
+      }
+
       &:hover {
         filter: brightness(0.7) grayscale(0.3);
       }
@@ -421,5 +437,34 @@ footer.compact {
 
   .flex-shrink {
     flex-basis: 0;
+  }
+}
+
+.character-deck .attack-resolve-footer-hint,
+.monster-deck .attack-resolve-footer-hint,
+.ally-deck .attack-resolve-footer-hint {
+  position: absolute;
+  right: calc(var(--ghs-unit) * 6.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+  top: calc(var(--ghs-unit) * 3.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+  z-index: 4;
+  padding: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize)) calc(var(--ghs-unit) * 0.6 * var(--ghs-text-factor) * var(--ghs-barsize));
+  color: var(--ghs-color-white);
+  font-size: calc(var(--ghs-unit) * 1.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+  font-weight: 600;
+  white-space: nowrap;
+  background: rgba(0, 0, 0, 0.88);
+  border: calc(var(--ghs-unit) * 0.25 * var(--ghs-text-factor) * var(--ghs-barsize)) solid var(--ghs-color-gold, #d4af37);
+  border-radius: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+  pointer-events: none;
+  animation: attack-pick-pulse calc(var(--ghs-animation-speed) * 1200ms) ease-in-out infinite;
+}
+
+@keyframes attack-pick-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 rgba(212, 175, 55, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 calc(var(--ghs-unit) * 1.25 * var(--ghs-text-factor) * var(--ghs-barsize)) rgba(212, 175, 55, 0.85);
   }
 }

--- a/src/app/ui/footer/footer.ts
+++ b/src/app/ui/footer/footer.ts
@@ -150,6 +150,7 @@ export class FooterComponent implements OnInit {
     window.addEventListener('resize', () => {
       const monsterDeck = this.monsterDeck();
       this.compact = !!monsterDeck && monsterDeck.nativeElement.clientWidth > this.elementRef.nativeElement.clientWidth * 0.3;
+      this.cdr.markForCheck();
     });
   }
 
@@ -168,11 +169,7 @@ export class FooterComponent implements OnInit {
           (gameManager.game.scenario && gameManager.game.scenario.allyDeck))) ||
       false;
     this.lootDeckEnabeld = settingsManager.settings.lootDeck && Object.keys(gameManager.game.lootDeck.cards).length > 0;
-    const activeCharacter = settingsManager.settings.characterAttackModifierDeckActiveBottom
-      ? (gameManager.game.figures.find(
-          (figure) => figure instanceof Character && (figure.attackModifierDeckVisible || gameManager.bbRules())
-        ) as Character)
-      : undefined;
+    const activeCharacter = gameManager.attackResolveManager.footerAttackCharacter();
     if (settingsManager.settings.animations && ((this.activeCharacter && !activeCharacter) || (!this.activeCharacter && activeCharacter))) {
       this.activeCharacterFade = true;
       if (activeCharacter) {
@@ -504,6 +501,65 @@ export class FooterComponent implements OnInit {
 
   nextDisabled(): boolean {
     return this.activeHint() || this.finish() || this.failed();
+  }
+
+  onMonsterAttackModifierIconClick(event: Event): void {
+    this.onAttackModifierDeckIconClick(event, false);
+  }
+
+  onAllyAttackModifierIconClick(event: Event): void {
+    this.onAttackModifierDeckIconClick(event, true);
+  }
+
+  private onAttackModifierDeckIconClick(event: Event, allyDeck: boolean): void {
+    event.stopPropagation();
+    const monster = gameManager.attackResolveManager.footerAttackMonster();
+    if (!monster || gameManager.attackResolveManager.monsterUsesAllyDeck(monster) !== allyDeck) {
+      if (allyDeck) {
+        this.toggleActiveAllyAttackModifierDeck();
+      } else {
+        this.toggleActiveMonsterAttackModifierDeck();
+      }
+      return;
+    }
+    const mgr = gameManager.attackResolveManager;
+    if (mgr.enabledForMonster(monster)) {
+      if (mgr.phase !== 'idle') {
+        mgr.finish();
+      } else {
+        mgr.startMonsterAttack(monster);
+      }
+      gameManager.triggerUiChange(false);
+      this.cdr.markForCheck();
+      return;
+    }
+    if (allyDeck) {
+      this.toggleActiveAllyAttackModifierDeck();
+    } else {
+      this.toggleActiveMonsterAttackModifierDeck();
+    }
+  }
+
+  onCharacterAttackModifierIconClick(event: Event): void {
+    event.stopPropagation();
+    const activeCharacter = gameManager.attackResolveManager.footerAttackCharacter();
+    if (!activeCharacter) {
+      return;
+    }
+    const mgr = gameManager.attackResolveManager;
+    if (mgr.enabledFor(activeCharacter)) {
+      if (mgr.phase !== 'idle') {
+        mgr.finish();
+      } else {
+        mgr.startAttack(activeCharacter);
+      }
+      gameManager.triggerUiChange(false);
+      this.cdr.markForCheck();
+      return;
+    }
+    if (this.activeCharacter) {
+      this.toggleActiveCharacterAttackModifierDeck();
+    }
   }
 
   toggleActiveCharacterAttackModifierDeck() {

--- a/src/app/ui/header/header.html
+++ b/src/app/ui/header/header.html
@@ -1,17 +1,24 @@
 <header [ngClass]="settingsManager.settings.theme">
   <div class="main-menu">
-    <a #mainMenuButton class="menu-button active-outline" [ghs-label]="'menu.main'" [ghs-label-attribute]="'title'" (click)="openMenu()">
-      <img class="ghs-svg" src="./assets/images/menu.svg" />
+    <a
+      #mainMenuButton
+      class="menu-button active-outline"
+      [ghs-label]="'menu.main'"
+      [ghs-label-attribute]="'aria-label'"
+      (click)="openMenu()"
+    >
+      <img class="ghs-svg" src="./assets/images/menu.svg" alt="" />
     </a>
   </div>
   @if (!standalone() || connection()) {
     @if (gameManager.stateManager.serverError) {
       <img
         src="./assets/images/warning.svg"
+        alt="Server error"
         [ghs-tooltip]="gameManager.stateManager.serverError"
         class="ghs-svg server-connection closed"
         [ghs-label]="'server.error'"
-        [ghs-label-attribute]="'title'"
+        [ghs-label-attribute]="'alt'"
       />
     }
     @switch (wsState) {
@@ -19,67 +26,49 @@
         <a
           (click)="openMenu(SubMenu.server)"
           [ghs-label]="'server.connected'"
-          [ghs-label-attribute]="'title'"
+          [ghs-label-attribute]="'aria-label'"
           class="server-connection-status"
         >
-          <img
-            src="./assets/images/server-connection.svg"
-            class="ghs-svg server-connection connected"
-            [ghs-label]="'server.connected'"
-            [ghs-label-attribute]="'title'"
-          />
+          <img src="./assets/images/server-connection.svg" class="ghs-svg server-connection connected" alt="" />
         </a>
       }
       @case (WebSocket.CONNECTING) {
         <img
           src="./assets/images/server-connection.svg"
+          alt="Connecting"
           class="ghs-svg server-connection connecting"
           [ghs-label]="'server.connecting'"
-          [ghs-label-attribute]="'title'"
+          [ghs-label-attribute]="'alt'"
         />
       }
       @case (WebSocket.CLOSING) {
         <img
           src="./assets/images/server-connection.svg"
+          alt="Closing"
           class="ghs-svg server-connection closing"
           [ghs-label]="'server.closing'"
-          [ghs-label-attribute]="'title'"
+          [ghs-label-attribute]="'alt'"
         />
       }
       @case (WebSocket.CLOSED) {
         <a
           (click)="settingsManager.settings.serverAutoconnect ? gameManager.stateManager.connect() : openMenu(SubMenu.server)"
-          [ghs-label]="'server.reconnected'"
-          [ghs-label-attribute]="'title'"
+          [ghs-label]="'server.closed'"
+          [ghs-label-attribute]="'aria-label'"
           class="server-connection-status"
         >
-          <img
-            src="./assets/images/warning.svg"
-            class="ghs-svg server-connection closed"
-            [ghs-label]="'server.closed'"
-            [ghs-label-attribute]="'title'"
-          />
-          <img
-            src="./assets/images/server-connection.svg"
-            class="ghs-svg server-connection closed"
-            [ghs-label]="'server.closed'"
-            [ghs-label-attribute]="'title'"
-          />
+          <img src="./assets/images/warning.svg" class="ghs-svg server-connection closed" alt="" />
+          <img src="./assets/images/server-connection.svg" class="ghs-svg server-connection closed" alt="" />
         </a>
       }
       @case (-1) {
         <a
           (click)="settingsManager.settings.serverAutoconnect ? gameManager.stateManager.connect() : openMenu(SubMenu.server)"
-          [ghs-label]="'server.reconnected'"
-          [ghs-label-attribute]="'title'"
+          [ghs-label]="'server.disconnected'"
+          [ghs-label-attribute]="'aria-label'"
           class="server-connection-status"
         >
-          <img
-            src="./assets/images/server-connection.svg"
-            class="ghs-svg server-connection disconnected"
-            [ghs-label]="'server.disconnected'"
-            [ghs-label-attribute]="'title'"
-          />
+          <img src="./assets/images/server-connection.svg" class="ghs-svg server-connection disconnected" alt="" />
         </a>
       }
     }
@@ -87,7 +76,13 @@
 
   @if (!standalone()) {
     @if (syncing) {
-      <img src="./assets/images/shuffle.svg" class="server-connection syncing" />
+      <img
+        src="./assets/images/shuffle.svg"
+        alt="Server Sync"
+        class="server-connection syncing"
+        [ghs-label]="'state.info.serverSyncEmpty'"
+        [ghs-label-attribute]="'alt'"
+      />
     }
     @if (!syncing && gameManager.stateManager.wsState() !== -99 && gameManager.game.server) {
       <span class="game-server">°</span>
@@ -154,9 +149,12 @@
       >
         <img
           class="ghs-svg"
+          alt="Event Effects Menu"
           [src]="
             './assets/images/event' + (gameManager.game.round > 0 || gameManager.game.state === GameState.next ? '-effects' : '') + '.svg'
           "
+          [ghs-label]="'entities.event.menu'"
+          [ghs-label-attribute]="'alt'"
         />
       </div>
     }
@@ -165,7 +163,13 @@
     }
     @if (gameManager.buildingsManager.petsEnabled) {
       <div class="pets" (click)="openPets()">
-        <img class="ghs-svg" src="./assets/images/fh/catching.svg" />
+        <img
+          class="ghs-svg"
+          src="./assets/images/fh/catching.svg"
+          alt="Pets"
+          [ghs-label]="'settings.fhPets'"
+          [ghs-label-attribute]="'alt'"
+        />
       </div>
     }
     @if (settingsManager.settings.gameClock) {
@@ -192,11 +196,36 @@
       >
         <img
           class="ghs-svg"
+          alt="Game clock"
           [src]="'./assets/images/' + (lastGameClockTimestamp && !lastGameClockTimestamp.clockOut ? 'clock-out' : 'clock-in') + '.svg'"
+          [ghs-label]="lastGameClockTimestamp && !lastGameClockTimestamp.clockOut ? 'duration.gameClock.clockOut' : 'duration.gameClock.clockIn'"
+          [ghs-label-attribute]="'alt'"
         />
       </div>
     }
     <span class="spacer"></span>
+    @if (gameManager.attackResolveManager.phase === 'pickTarget' && gameManager.attackResolveManager.hasAttacker) {
+      <div class="attack-resolve-pick-banner" role="status">
+        <div class="pick-text">
+          <span class="pick-title" [ghs-label]="'game.attackResolve.pickTargetTitle'"></span>
+          <span
+            class="pick-detail"
+            [ghs-label]="'game.attackResolve.pickTargetDetail'"
+            [ghs-label-args]="[gameManager.attackResolveManager.attackerLabel]"
+          ></span>
+        </div>
+        <button
+          type="button"
+          class="pick-cancel"
+          title="Cancel attack"
+          (click)="cancelAttackResolvePick()"
+          [ghs-label]="'game.attackResolve.pickTargetCancel'"
+          [ghs-label-attribute]="'aria-label'"
+        >
+          <span [ghs-label]="'cancel'"></span>
+        </button>
+      </div>
+    }
     <div class="elements" [ngClass]="{ denied: gameManager.stateManager.permissions && !gameManager.stateManager.permissions.elements }">
       @for (element of gameManager.game.elementBoard | trackUUID; track element._trackUUID) {
         <ghs-element [element]="element"></ghs-element>

--- a/src/app/ui/header/header.scss
+++ b/src/app/ui/header/header.scss
@@ -191,15 +191,90 @@ header {
     }
   }
 
+  .attack-resolve-pick-banner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-end;
+    flex-shrink: 1;
+    min-width: 0;
+    max-width: min(40vw, calc(var(--ghs-unit) * 42 * var(--ghs-text-factor) * var(--ghs-barsize)));
+    margin-right: calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize));
+    padding: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize)) calc(var(--ghs-unit) * 0.85 * var(--ghs-text-factor) * var(--ghs-barsize));
+    color: var(--ghs-color-white);
+    text-align: right;
+    text-shadow: var(--ghs-outline);
+    background: rgba(0, 0, 0, 0.82);
+    border: calc(var(--ghs-unit) * 0.25 * var(--ghs-text-factor) * var(--ghs-barsize)) solid var(--ghs-color-gold, #d4af37);
+    border-radius: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+    box-shadow: 0 0 calc(var(--ghs-unit) * 1.25 * var(--ghs-text-factor) * var(--ghs-barsize)) rgba(212, 175, 55, 0.5);
+    pointer-events: auto;
+    flex-direction: row;
+    align-items: center;
+    gap: calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize));
+    animation: attack-resolve-pick-banner-pulse calc(var(--ghs-animation-speed) * 1400ms) ease-in-out infinite;
+
+    .pick-text {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      min-width: 0;
+    }
+
+    .pick-title {
+      font-family: var(--ghs-font-title);
+      font-size: calc(var(--ghs-unit) * 1.85 * var(--ghs-text-factor) * var(--ghs-barsize));
+      font-weight: 700;
+      line-height: 1.15;
+      white-space: normal;
+    }
+
+    .pick-detail {
+      font-size: calc(var(--ghs-unit) * 1.45 * var(--ghs-text-factor) * var(--ghs-barsize));
+      line-height: 1.15;
+      opacity: 0.95;
+      white-space: normal;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 100%;
+    }
+
+    .pick-cancel {
+      flex-shrink: 0;
+      cursor: pointer;
+      border: calc(var(--ghs-unit) * 0.2 * var(--ghs-text-factor) * var(--ghs-barsize)) solid var(--ghs-color-gold, #d4af37);
+      border-radius: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize));
+      background: rgba(0, 0, 0, 0.5);
+      color: var(--ghs-color-white);
+      font-size: calc(var(--ghs-unit) * 1.5 * var(--ghs-text-factor) * var(--ghs-barsize));
+      padding: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-barsize)) calc(var(--ghs-unit) * 0.65 * var(--ghs-text-factor) * var(--ghs-barsize));
+      min-height: calc(var(--ghs-unit) * 4 * var(--ghs-text-factor) * var(--ghs-barsize));
+      touch-action: manipulation;
+    }
+  }
+
   .elements {
     display: flex;
     height: 100%;
     align-items: center;
+    flex-shrink: 0;
 
     ghs-element {
       margin: 0 calc(var(--ghs-unit) * 0.25 * var(--ghs-barsize));
       width: calc(var(--ghs-unit) * 7.4 * var(--ghs-barsize));
       height: calc(var(--ghs-unit) * 7.4 * var(--ghs-barsize));
     }
+  }
+}
+
+@keyframes attack-resolve-pick-banner-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-barsize)) rgba(212, 175, 55, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 calc(var(--ghs-unit) * 1.75 * var(--ghs-text-factor) * var(--ghs-barsize)) rgba(212, 175, 55, 0.8);
   }
 }

--- a/src/app/ui/header/header.ts
+++ b/src/app/ui/header/header.ts
@@ -84,6 +84,7 @@ export class HeaderComponent implements OnInit {
       }
       this.updateClock();
       this.syncing = window.document.body.classList.contains('server-sync');
+      this.cdr.markForCheck();
     });
   }
 
@@ -202,5 +203,9 @@ export class HeaderComponent implements OnInit {
     );
     gameManager.toggleGameClock();
     gameManager.stateManager.after();
+  }
+
+  cancelAttackResolvePick(): void {
+    gameManager.attackResolveManager.cancel();
   }
 }

--- a/src/app/ui/header/menu/keyboard-shortcuts/keyboard-shortcuts.html
+++ b/src/app/ui/header/menu/keyboard-shortcuts/keyboard-shortcuts.html
@@ -1,9 +1,14 @@
 <div class="scroll-container">
-  <h1 ghs-label="tools.keyboard"></h1>
+  <div class="toolbar">
+    <h1 ghs-label="tools.keyboard"></h1>
+    <button type="button" class="print" title="Print" ghs-label="tools.keyboard.print" (click)="printReference()">
+      <span ghs-label="tools.keyboard.print"></span>
+    </button>
+  </div>
 
   <p ghs-label="tools.keyboard.global"></p>
 
-  <div class="line" ghs-setting-menu="keyboardShortcuts"></div>
+  <div class="line no-print" ghs-setting-menu="keyboardShortcuts"></div>
 
   <ul>
     <li>
@@ -56,7 +61,7 @@
       ></span>
     </li>
     <li>
-      <kbd><span ghs-label="tools.keyboard.shift"></span></kbd>&nbsp;+&nbsp;<kbd><span>X</span></kbd>
+      <kbd><span ghs-label="tools.keyboard.shift"></span></kbd>&nbsp;+&nbsp;<kbd><span>L</span></kbd>
       <span ghs-label="tools.keyboard.activeCharacter.lootDec"></span>
     </li>
     <li>

--- a/src/app/ui/header/menu/keyboard-shortcuts/keyboard-shortcuts.scss
+++ b/src/app/ui/header/menu/keyboard-shortcuts/keyboard-shortcuts.scss
@@ -1,6 +1,34 @@
 .scroll-container {
   color: var(--ghs-color-white);
   font-size: calc(var(--ghs-unit) * 2.5 * var(--ghs-dialog-factor));
+
+  .toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: calc(var(--ghs-unit) * 1 * var(--ghs-dialog-factor));
+    margin-bottom: calc(var(--ghs-unit) * 0.5 * var(--ghs-dialog-factor));
+
+    h1 {
+      margin: 0;
+    }
+
+    .print {
+      cursor: pointer;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      border-radius: calc(var(--ghs-unit) * 0.35 * var(--ghs-dialog-factor));
+      padding: calc(var(--ghs-unit) * 0.35 * var(--ghs-text-factor) * var(--ghs-dialog-factor))
+        calc(var(--ghs-unit) * 0.75 * var(--ghs-text-factor) * var(--ghs-dialog-factor));
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--ghs-color-white);
+      font: inherit;
+      white-space: nowrap;
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.15);
+      }
+    }
+  }
 }
 
 li {

--- a/src/app/ui/header/menu/keyboard-shortcuts/keyboard-shortcuts.ts
+++ b/src/app/ui/header/menu/keyboard-shortcuts/keyboard-shortcuts.ts
@@ -12,4 +12,10 @@ import { GhsLabelDirective } from 'src/app/ui/helper/label';
 export class KeyboardShortcutsComponent {
   settinsManager: SettingsManager = settingsManager;
   isMac: boolean = navigator.userAgent.includes('Mac');
+
+  printReference(): void {
+    const url = new URL('assets/keyboard-shortcuts-print.html', window.location.origin);
+    url.searchParams.set('print', '1');
+    window.open(url.toString(), '_blank', 'noopener');
+  }
 }

--- a/src/app/ui/header/menu/settings/settings.html
+++ b/src/app/ui/header/menu/settings/settings.html
@@ -1,8 +1,11 @@
 <div class="settings-layout" [ngClass]="{ connected: gameManager.stateManager.wsState() === WebSocket.OPEN, filtering: !!filter }">
   <div class="line filter-line">
     <input
+      id="settings-filter"
       [(ngModel)]="filter"
       type="text"
+      title="Search settings"
+      aria-label="Search settings"
       [ghs-label]="'settings.filter'"
       [ghs-label-attribute]="'placeholder'"
       (change)="updateFilter()"
@@ -69,6 +72,7 @@
           [checked]="settingsManager.settings.initiativeRequired"
         ></div>
         <div class="line" ghs-setting-menu="automaticEndRound"></div>
+        <div class="line" ghs-setting-menu="attackResolveGuided" [requires]="['characterAttackModifierDeck']"></div>
       </div>
 
       <div class="line title span" ghs-setting-title-menu="conditions" [sync]="true"></div>
@@ -89,13 +93,14 @@
                     (click)="toggleApplyConditionsExclude(condition.name)"
                   >
                     <img
+                      alt="Condition icon"
                       [src]="'./assets/images' + (settingsManager.settings.fhStyle ? '/fh' : '') + '/condition/' + condition.name + '.svg'"
                     />
                     @if (condition.types.includes(ConditionType.value)) {
                       <span class="value">X</span>
                     }
                   </div>
-                  <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" />
+                  <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" alt="Hint" title="Show hint" />
                   <span class="hint above" [ngClass]="{ right: i > 2 }">
                     <span class="text" [ghs-label]="'settings.applyConditions.hint.' + condition.name"></span>
                   </span>
@@ -125,13 +130,14 @@
                     (click)="toggleActiveApplyConditionsExclude(condition.name)"
                   >
                     <img
+                      alt="Condition icon"
                       [src]="'./assets/images' + (settingsManager.settings.fhStyle ? '/fh' : '') + '/condition/' + condition.name + '.svg'"
                     />
                     @if (condition.types.includes(ConditionType.value)) {
                       <span class="value">X</span>
                     }
                   </div>
-                  <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" />
+                  <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" alt="Hint" title="Show hint" />
                   <span class="hint above" [ngClass]="{ right: i > 2 }">
                     <span class="text" [ghs-label]="'settings.activeApplyConditions.hint.' + condition.name"></span>
                   </span>
@@ -148,7 +154,7 @@
           >
             <div class="hint-container inline">
               <label [ghs-label]="'settings.activeApplyConditions.auto'"></label>
-              <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" />
+              <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" alt="Hint" title="Show hint" />
               <span class="hint above">
                 <span class="text" [ghs-label]="'settings.activeApplyConditions.auto.hint'"></span>
               </span>
@@ -169,6 +175,7 @@
                       (click)="toggleActiveApplyConditionsAuto(condition.name)"
                     >
                       <img
+                        alt="Condition icon"
                         [src]="
                           './assets/images' + (settingsManager.settings.fhStyle ? '/fh' : '') + '/condition/' + condition.name + '.svg'
                         "
@@ -177,7 +184,7 @@
                         <span class="value">X</span>
                       }
                     </div>
-                    <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" />
+                    <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" alt="Hint" title="Show hint" />
                     <span class="hint above" [ngClass]="{ right: i > 2 }">
                       <span class="text" [ghs-label]="'settings.activeApplyConditions.auto.hint.' + condition.name"></span>
                     </span>
@@ -275,6 +282,7 @@
           [requires]="['monsters', 'standees', 'scenarioRooms', 'automaticStandees', '!randomStandees']"
         ></div>
         <div class="line" ghs-setting-menu="activeStandees" [requires]="['standees']"></div>
+        <div class="line" ghs-setting-menu="monsterStandeeTurns" [requires]="['standees']"></div>
       </div>
     </div>
 
@@ -420,14 +428,16 @@
           <div class="line" ghs-setting-menu="wakeLock"></div>
         }
         <div class="line" ghs-setting-menu="portraitMode"></div>
+        <div class="line" ghs-setting-menu="presentationMode"></div>
         <div class="line" ghs-setting-menu="barsize" type="range" [min]="0.1" [max]="2"></div>
+        <div class="line" ghs-setting-menu="globalFontsize" type="range" [min]="0.75" [max]="1.5" [step]="0.05"></div>
         <div class="line" ghs-setting-menu="fontsize" type="range" [min]="0.1" [max]="2"></div>
       </div>
 
       <div class="line title span">
         <div class="hint-container">
-          <label [ghs-label]="'settings.customCss'"></label>
-          <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" />
+          <label for="settings-custom-css" [ghs-label]="'settings.customCss'"></label>
+          <img src="./assets/images/hint.svg" class="hint-trigger ghs-svg" alt="Hint" title="Show hint" />
           <span class="hint">
             <span class="text" [ghs-label]="'settings.customCss.hint'"></span>
           </span>
@@ -435,7 +445,10 @@
       </div>
       <div class="span">
         <textarea
+          id="settings-custom-css"
           class="custom-css-input"
+          title="Custom CSS"
+          aria-label="Custom CSS"
           [value]="settingsManager.settings.customCss"
           (change)="settingsManager.set('customCss', $any($event.target).value)"
           [placeholder]="settingsManager.getLabel('settings.customCss.placeholder')"
@@ -528,11 +541,13 @@
             <a
               href="https://i18n.gloomhaven-secretariat.de/engage/gloomhavensecretariat/"
               target="_blank"
+              rel="noopener noreferrer"
+              title="Translation help"
               [ghs-tooltip]="'settings.locale.help.hint'"
               [originY]="'top'"
               [overlayY]="'bottom'"
             >
-              <img class="ghs-svg" src="./assets/images/hint.svg" />&nbsp;
+              <img class="ghs-svg" src="./assets/images/hint.svg" alt="" />&nbsp;
               <span [ghs-label]="'settings.locale.help'"></span>
             </a>
           </div>

--- a/src/app/ui/helper/keyboard-shortcuts.ts
+++ b/src/app/ui/helper/keyboard-shortcuts.ts
@@ -690,10 +690,28 @@ export class KeyboardShortcuts implements OnInit {
         gameManager.stateManager.after();
       } else if (activeFigure instanceof Monster) {
         let toggleFigure = true;
-        const entities = activeFigure.entities
-          .filter((entity) => gameManager.entityManager.isAlive(entity) && entity.summon !== SummonState.new)
-          .sort(gameManager.monsterManager.sortEntities);
-        if (settingsManager.settings.activeStandees) {
+        const entities = settingsManager.settings.monsterStandeeTurns
+          ? gameManager.monsterManager.aliveStandeeEntities(activeFigure)
+          : activeFigure.entities
+              .filter((entity) => gameManager.entityManager.isAlive(entity) && entity.summon !== SummonState.new)
+              .sort(gameManager.monsterManager.sortEntities);
+        if (settingsManager.settings.monsterStandeeTurns && !reverse) {
+          const activeEntity = entities.find((entity) => entity.active);
+          if (activeEntity) {
+            gameManager.stateManager.before(
+              'unsetEntityActive',
+              'data.monster.' + activeFigure.name,
+              'monster.' + activeEntity.type,
+              activeEntity.number
+            );
+          }
+          if (gameManager.monsterManager.advanceStandeeTurn(activeFigure)) {
+            toggleFigure = false;
+          }
+          if (activeEntity) {
+            gameManager.stateManager.after();
+          }
+        } else if (settingsManager.settings.activeStandees) {
           let activeEntity = entities.find((entity) => entity.active);
           if (!activeEntity && entities.length > 0 && reverse && activeFigure.active) {
             activeEntity = entities[entities.length - 1];

--- a/src/app/ui/main.html
+++ b/src/app/ui/main.html
@@ -293,5 +293,6 @@
   @if (fullviewChar) {
     <ghs-character-fullview [character]="fullviewChar"></ghs-character-fullview>
   }
+  <ghs-attack-resolve-panel></ghs-attack-resolve-panel>
 </main>
 <ghs-footer #footer></ghs-footer>

--- a/src/app/ui/main.ts
+++ b/src/app/ui/main.ts
@@ -20,6 +20,7 @@ import { CharacterFullViewComponent } from 'src/app/ui/figures/character/fullvie
 import { MonsterNumberPickerDialog } from 'src/app/ui/figures/monster/dialogs/numberpicker-dialog';
 import { MonsterComponent } from 'src/app/ui/figures/monster/monster';
 import { ObjectiveContainerComponent } from 'src/app/ui/figures/objective-container/objective-container';
+import { AttackResolvePanelComponent } from 'src/app/ui/figures/attackmodifier/attack-resolve-panel';
 import { FooterComponent } from 'src/app/ui/footer/footer';
 import { HeaderComponent } from 'src/app/ui/header/header';
 import { SubMenu } from 'src/app/ui/header/menu/menu';
@@ -40,6 +41,7 @@ import { environment } from 'src/environments/environment';
     CharacterFullViewComponent,
     MonsterComponent,
     ObjectiveContainerComponent,
+    AttackResolvePanelComponent,
     FooterComponent,
     HeaderComponent,
     FigureAutoscrollDirective,

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -41,6 +41,35 @@
     },
     "character": "Character Sheets",
     "enhancements": "Enhancement Calculator",
+    "history": {
+      "category": {
+        "buildings": "Buildings",
+        "calendar": "Calendar",
+        "campaign": "Campaign",
+        "characters": "Characters",
+        "events": "Events",
+        "items": "Items",
+        "other": "Other",
+        "party": "Party",
+        "resources": "Resources",
+        "scenario": "Scenarios",
+        "undo": "Undo"
+      },
+      "clear": "Clear History",
+      "columns": {
+        "category": "Category",
+        "change": "Change",
+        "date": "Date",
+        "record": "Record",
+        "revision": "#"
+      },
+      "empty": "No campaign changes recorded yet.",
+      "filter": "Search history…",
+      "filterAll": "All categories",
+      "menu": "Campaign History",
+      "noResults": "No entries match your filters.",
+      "title": "Campaign History"
+    },
     "items": "Itemcards Overview",
     "map": {
       "": "Global Map",
@@ -261,6 +290,7 @@
         "event": "Add %game.events.type.{0}% Event {1} to the deck",
         "events": "Add City Event {0} and Road Event {0} to the deck",
         "moveSupply": "Move resources to Frosthaven supply",
+        "moveSupplyInfo": "The following resources will be moved to Frosthaven supply:",
         "prosperity": "+{0} prosperity"
       },
       "retirements": "Retirements",
@@ -616,6 +646,50 @@
         "normal": "Spawn Normal Ally"
       }
     },
+    "attackResolve": {
+      "apply": "Apply damage & conditions",
+      "applied": "Applied",
+      "baseAttack": "Base attack value",
+      "conditionBonus": "+{0} from target poison",
+      "conditionsAttacker": "Attacker buffs",
+      "conditionsTarget": "Target effects",
+      "damageDetail": "Attack {0}, shield −{1}",
+      "editDamageHint": "Click damage to adjust",
+      "effectiveAttack": "Effective base: {0}",
+      "numpadDone": "Done",
+      "finalDamage": "Damage: {0}",
+      "inputAttack": "Attack",
+      "inputAttackValue": "Attack: {0}",
+      "inputDamage": "Damage",
+      "inputDamageValue": "Damage: {0}",
+      "inputPierce": "Pierce",
+      "inputPierceValue": "Pierce: {0}",
+      "numpadDigit": "{0}",
+      "pierce": "Pierce value",
+      "shieldAfterPierce": "Shield {0} (−{1} after pierce)",
+      "draw": "Draw attack modifier",
+      "drawHint": "Choose a target and enter base attack first.",
+      "chooseCard": "Click the other card to use it for advantage/disadvantage.",
+      "clear": "Clear",
+      "backspace": "Del",
+      "deckHint": "Drawn modifiers appear in your character deck on the right.",
+      "deckHintMonster": "Drawn modifiers appear in the monster deck on the right.",
+      "deckHintAlly": "Drawn modifiers appear in the ally deck on the right.",
+      "pickTarget": "Click a standee on the board to choose your attack target.",
+      "pickTargetTitle": "Select attack target",
+      "pickTargetDetail": "Click a standee for {0}'s attack.",
+      "pickTargetShort": "Click target",
+      "pickTargetCancel": "Cancel attack",
+      "noTargets": "No figures on the board. Add monsters, objectives, or allies first.",
+      "open": "Resolve attack",
+      "result": "Attack value: {0} ({1})",
+      "retaliate": "Retaliate {0}",
+      "shield": "Shield {0}",
+      "target": "Target",
+      "targetPlaceholder": "Select target…",
+      "undo": "Undo attack",
+      "title": "Attack — {0}"
+    },
     "attackModifiers": {
       "": "Attack Modifier Deck",
       "additional": {
@@ -892,6 +966,13 @@
         "notApply": "Resolve, not Apply"
       },
       "applyManually": "Apply the following manually:",
+      "distribution": {
+        "apply": "Apply assignments",
+        "assign": "Assign",
+        "done": "Resources distributed",
+        "open": "Distribute resources…",
+        "title": "Event Resource Distribution"
+      },
       "conditions": {
         "and": "and",
         "building": "{0}",
@@ -957,6 +1038,7 @@
         "collectiveGoldOther": "All other characters gain {0} collective gold.",
         "collectiveItem": "Gain {2} collective \"%data.items.{1}-{0}%\" (Item {0}).",
         "collectiveResource": "Gain {0} collective %game.resource.{1}%.",
+        "collectiveResourceAny": "Gain {0} collective material resources of any kind.",
         "collectiveResourceType": "Gain any {0} collective %game.loot.{1}%s.",
         "consumeCollectiveItem": "Consume {0} collective %game.itemSlot:{1}% item.",
         "consumeItem": "Consume {0} %game.itemSlot:{1}% item each.",
@@ -2429,6 +2511,10 @@
       "": "Active standees",
       "hint": "On monsters turn, every standee has an active state, double click on standee to mark as done"
     },
+    "monsterStandeeTurns": {
+      "": "Monster turns by standee",
+      "hint": "During a monster figure's turn, activate standees one at a time in order. End turn advances to the next standee. Attack Resolver uses the active standee's attack and effect values."
+    },
     "activeSummons": {
       "": "Active summons",
       "hint": "At start of the characters turn, summons will be activated in its order, double click to toggle active state."
@@ -2481,6 +2567,10 @@
     "amAdvantageHouseRule": {
       "": "Advantage/Disadvantage Rolling House Rule",
       "hint": "Instead of ignore rolling on second draw, also draw additional modifiers until non-rolling drawn."
+    },
+    "attackResolveGuided": {
+      "": "Attack Resolver",
+      "hint": "On a figure's turn in a scenario, clicking their attack modifier deck opens a panel to choose a target, enter base attack and status effects, draw modifiers (including advantage/disadvantage), then apply damage. For monsters with standee turns enabled, uses the currently active standee's stats."
     },
     "animationSpeed": {
       "": "Animation Speed",
@@ -3016,6 +3106,17 @@
     "playerNumber": {
       "": "Display player number",
       "hint": "Display the player number on the character's board."
+    },
+    "globalFontsize": {
+      "": "Display scale",
+      "dec": "Decrease display scale",
+      "hint": "Scale the whole interface (useful for TV projection or large monitors).",
+      "inc": "Increase display scale",
+      "reset": "Reset display scale"
+    },
+    "presentationMode": {
+      "": "Presentation mode (TV)",
+      "hint": "Use a wider layout on large landscape screens instead of a narrow centered column."
     },
     "portraitMode": {
       "": "Portrait-Mode Optimization",
@@ -3676,7 +3777,19 @@
         "cancel": "Cancel drawing %game.events.type.{1}% event",
         "new": "Draw a new %game.events.type.{1}% event"
       },
+      "events": {
+        "deck": {
+          "addEvent": "Add %game.events.type.{0}% event {1} to deck",
+          "changeSelection": "Change selection for %game.events.type.{0}% event {1}",
+          "markDrawn": "Mark %game.events.type.{0}% event {1} as drawn",
+          "removeDrawn": "Remove drawn %game.events.type.{0}% event {1}",
+          "removeEvent": "Remove %game.events.type.{0}% event {1} from deck",
+          "reorder": "Reorder %game.events.type.{0}% event deck",
+          "shuffle": "Shuffle %game.events.type.{0}% event deck"
+        }
+      },
       "eventEffect": {
+        "applyManualDistribution": "Apply manual event resource distribution",
         "addCondition": "%game.condition.{0}% to {1}",
         "addImmunity": "%game.immunity.{0}% to {1}",
         "changeCharacterBattleGoals": "{0} %game.checkmark% for {1}",
@@ -3684,9 +3797,10 @@
         "changeCharacterCurse": "{0} %game.condition.curse% for {1}",
         "changeCharacterGold": "{0} Gold for {1}",
         "changeCharacterHP": "{0} HP for {1}",
-        "changeCharacterResource": "{1} %game.resource.{0}% for {2}",
+        "changeCharacterResource": "{1} {0} for {2}",
         "changeCharacterXP": "{0} XP for {1}",
         "drawRandomItem": "Draw Random Item Design {0} \"{2}\" (%data.edition.{1}%)",
+        "resourcesDistributed": "Resources distributed from %game.events.type.{0}% event {1}: {2}",
         "drawRandomItemBlueprint": "Draw Random Item Blueprint {0} \"{2}\" (%data.edition.{1}%)",
         "drawRandomScenario": "Draw Random Scenario {2} %data.scenarioNumber:{0}%",
         "drawRandomScenarioSection": "Draw Random Scenario Section %data.section:{0}%, unlock {3}",
@@ -3699,7 +3813,27 @@
         "reputation": "{0} Reputation",
         "setConditionValue": "%game.condition.{0}% to {1} for {2}"
       },
+      "campaignHistory": {
+        "undo": "Undid {0}: {1}"
+      },
       "finishConclusion": "Finish conclusion #{0} {1} ({2})",
+      "scenarioReward": {
+        "changeCharacterBattleGoals": "{0} %game.checkmark% for {1}",
+        "changeCharacterGold": "{0} Gold for {1}",
+        "changeCharacterResource": "{1} {0} for {2}",
+        "changeCharacterXP": "{0} XP for {1}",
+        "defense": "{0} Defense",
+        "inspiration": "{0} Inspiration",
+        "lockCharacter": "Locked character {0}",
+        "morale": "{0} Morale",
+        "perks": "{0} Perks for {1}",
+        "prosperity": "{0} Prosperity",
+        "reputation": "{0} Reputation",
+        "revertConclusion": "Removed conclusion #{0} {1} ({2})",
+        "revertScenario": "Removed scenario #{0} {1} ({2}) unlock",
+        "soldiers": "{0} Soldiers",
+        "unlockScenario": "Unlocked scenario #{0} {1} ({2})"
+      },
       "finishScenario": {
         "battleGoal": "Set Battle Goal checkmarks for %data.character.{0}.{1}% to {2}",
         "close": "Close Scenario Summary",
@@ -3745,6 +3879,7 @@
       "objectiveEntityDead": "Kill %game.objectiveMarker.{1}% of {0}",
       "openRoom": "Open door for tile '{2}' in #{0} {1}",
       "openRoomMarker": "Open door %game.mapMarker.{3}% for tile '{2}' in #{0} {1}",
+      "passTime": "Advance calendar to week {0}",
       "rebuildBuilding": "Rebuild '%data.buildings.{1}%' ({0})",
       "removeAbility": "Remove ability \"{1}\" from {0}",
       "removeAllChars": "Remove all characters",
@@ -4123,6 +4258,7 @@
       "global": "The following keyboard shortcuts are currently implemented:",
       "globalMap": "Open Global Map",
       "keyboard": "Show keyboard shortcuts",
+      "print": "Print shortcut reference",
       "loot": "Draw from Loot Deck",
       "mainMenu": {
         "": "Open main menu",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -119,7 +119,8 @@ body {
   --ghs-small-text-factor: 1;
   --ghs-barsize: 1;
   --ghs-fontsize: 1;
-  --ghs-unit: calc(var(--ghs-width) / var(--ghs-factor));
+  --ghs-global-fontsize: 1;
+  --ghs-unit: calc(var(--ghs-width) / var(--ghs-factor) * var(--ghs-global-fontsize, 1));
   --ghs-max-width: calc(var(--ghs-unit) * 99.9);
   --form-background: transparent;
   --ghs-color-black: #000;
@@ -194,8 +195,8 @@ body {
   }
 
   &.no-select {
-    user-select: none;
     -webkit-user-select: none;
+    user-select: none;
   }
 
   &.fh,
@@ -326,9 +327,18 @@ body {
     --ghs-text-factor: 1;
   }
 
+  body.presentation-mode {
+    --ghs-width: min(90vw, 1400px);
+    --ghs-dialog-factor: 1.1;
+  }
+
   @media (orientation: landscape) {
     body {
       --ghs-width: 900px;
+    }
+
+    body.presentation-mode {
+      --ghs-width: min(88vw, 1400px);
     }
   }
 
@@ -356,6 +366,26 @@ body {
     body {
       --ghs-width: 70vw;
     }
+  }
+}
+
+body.attack-resolve-picking {
+  ghs-footer,
+  ghs-header .main-menu,
+  ghs-header .server-connection-status,
+  ghs-header .event-effects,
+  ghs-header .pets,
+  ghs-header .game-clock,
+  ghs-header .elements,
+  ghs-header .hints,
+  ghs-party-sheet {
+    pointer-events: none;
+    opacity: 0.45;
+  }
+
+  ghs-header .attack-resolve-pick-banner {
+    pointer-events: auto;
+    opacity: 1;
   }
 }
 
@@ -1034,8 +1064,8 @@ input[type='number'] {
   border-width: calc(var(--ghs-unit) * 0.1);
   border-style: solid;
   border-color: var(--ghs-color-gray);
-  user-select: auto;
   -webkit-user-select: auto;
+  user-select: auto;
   font-family: var(--ghs-font-text);
   font-size: calc(var(--ghs-unit) * 3 * var(--ghs-dialog-factor));
 }
@@ -1956,6 +1986,10 @@ input[type='radio'] {
     filter: var(--ghs-filter-white) var(--ghs-filter-shadow);
   }
 
+  .placeholder-resource .icon.ghs-svg {
+    filter: var(--ghs-filter-white) var(--ghs-filter-shadow) !important;
+  }
+
   .autocomplete {
     color: var(--ghs-color-white);
     background: var(--ghs-color-black);
@@ -2071,6 +2105,7 @@ input[type='radio'] {
       height: 100%;
       display: flex;
       align-items: center;
+      -webkit-mask-size: 100% 100%;
       mask-size: 100% 100%;
       overflow: visible;
       width: 100%;
@@ -2083,11 +2118,13 @@ input[type='radio'] {
 
       &:nth-child(1) {
         justify-content: flex-start;
+        -webkit-mask-image: url('assets/images/fh/element/half-mask-left.svg');
         mask-image: url('assets/images/fh/element/half-mask-left.svg');
       }
 
       &:nth-child(2) {
         justify-content: flex-end;
+        -webkit-mask-image: url('assets/images/fh/element/half-mask-right.svg');
         mask-image: url('assets/images/fh/element/half-mask-right.svg');
         right: 0;
 


### PR DESCRIPTION
# Description

Adds a guided attack resolve workflow: pick a target on the board, configure attack modifiers and damage, then apply the result from a single panel.

Changes:
- Add `AttackResolveManager` with phases: idle → pick target → configure.
- Add an attack resolve panel in the footer (modifier deck, attack/pierce/damage input, conditions).
- Integrate with standees, conditions, attack modifier deck, round flow, and monster ability suggestions.
- Add a header banner during target picking and an `attackResolveGuided` setting.
- Add keyboard shortcut and accessibility updates for related UI.
- Add locale strings for attack resolve labels and hints.

Shield is calculated and displayed during resolve; shield conditions are not automatically consumed on the target when damage is applied.

Fixes # (link to related issue here)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)