### PR TITLE
Make GH2E retirement respect Draw Random Item/Scenario settings.

### DIFF
--- a/data/gh2e/label/en.json
+++ b/data/gh2e/label/en.json
@@ -1431,10 +1431,10 @@
       },
       "05": {
         "": "Seeker of Xorn",
-        "1": "\"Crypt Basement\" %game.scenario:57% completed",
+        "1": "\"Crypt Basement\" %game.scenarioNumber:57% completed",
         "2": "Item gained",
         "3": "%game.condition.poison% gained",
-        "4": "\"Palace of Ice\" %game.scenario:58% completed"
+        "4": "\"Palace of Ice\" %game.scenarioNumber:58% completed"
       },
       "06": {
         "": "Zealot of the Blood God",

--- a/src/app/game/businesslogic/ItemManager.ts
+++ b/src/app/game/businesslogic/ItemManager.ts
@@ -10,6 +10,7 @@ import { getLootClass, herbResourceLootTypes, LootClass, LootType } from 'src/ap
 import { EntityValueFunction } from 'src/app/game/model/Entity';
 import { Game } from 'src/app/game/model/Game';
 import { Summon, SummonColor } from 'src/app/game/model/Summon';
+import { ghsShuffleArray } from 'src/app/ui/helper/Static';
 import { v4 as uuidv4 } from 'uuid';
 
 export class ItemManager {
@@ -626,27 +627,29 @@ export class ItemManager {
   }
 
   drawRandomItem(edition: string, blueprint: boolean = false, from: number = -1, to: number = -1): ItemData | undefined {
-    const availableItems = this.getItems(undefined, true).filter(
-      (itemData) =>
-        ((!blueprint && itemData.random) ||
-          (blueprint &&
-            itemData.blueprint &&
-            (!itemData.requiredBuilding ||
-              gameManager.game.party.buildings.find(
-                (buildingModel) => buildingModel.name === itemData.requiredBuilding && buildingModel.level >= itemData.requiredBuildingLevel
-              )))) &&
-        (from === -1 || (typeof itemData.id === 'number' && itemData.id >= from)) &&
-        (to === -1 || (typeof itemData.id === 'number' && itemData.id <= to)) &&
-        !gameManager.game.party.unlockedItems.find(
-          (identifier) => identifier.name === '' + itemData.id && identifier.edition === itemData.edition
-        ) &&
-        gameManager.isEditionRelevant(itemData.edition, edition)
-    );
-    let item: ItemData | undefined = undefined;
-    if (availableItems.length > 0) {
-      item = availableItems[Math.floor(Math.random() * availableItems.length)];
-    }
-    return item;
+    return this.drawRandomItemsBatch(edition, 1, blueprint, from, to)[0];
+  }
+
+  drawRandomItemsBatch(edition: string, count: number, blueprint: boolean = false, from: number = -1, to: number = -1): ItemData[] {
+    return ghsShuffleArray(
+      this.getItems(undefined, true).filter(
+        (itemData) =>
+          ((!blueprint && itemData.random) ||
+            (blueprint &&
+              itemData.blueprint &&
+              (!itemData.requiredBuilding ||
+                gameManager.game.party.buildings.find(
+                  (buildingModel) =>
+                    buildingModel.name === itemData.requiredBuilding && buildingModel.level >= itemData.requiredBuildingLevel
+                )))) &&
+          (from === -1 || (typeof itemData.id === 'number' && itemData.id >= from)) &&
+          (to === -1 || (typeof itemData.id === 'number' && itemData.id <= to)) &&
+          !gameManager.game.party.unlockedItems.find(
+            (identifier) => identifier.name === '' + itemData.id && identifier.edition === itemData.edition
+          ) &&
+          gameManager.isEditionRelevant(itemData.edition, edition)
+      )
+    ).slice(0, count);
   }
 
   applyEquippedItemEffects(character: Character) {

--- a/src/app/game/businesslogic/ScenarioManager.ts
+++ b/src/app/game/businesslogic/ScenarioManager.ts
@@ -15,6 +15,7 @@ import { Game, GameState } from 'src/app/game/model/Game';
 import { Monster } from 'src/app/game/model/Monster';
 import { MonsterEntity } from 'src/app/game/model/MonsterEntity';
 import { GameScenarioModel, Scenario, ScenarioMissingRequirements } from 'src/app/game/model/Scenario';
+import { ghsShuffleArray } from 'src/app/ui/helper/Static';
 
 export class ScenarioManager {
   game: Game;
@@ -1939,54 +1940,56 @@ export class ScenarioManager {
   }
 
   drawRandomScenario(edition: string): ScenarioData | undefined {
-    const availableScenarios = gameManager
-      .scenarioData(edition)
-      .filter(
-        (scenarioData) =>
-          scenarioData.random &&
-          !gameManager.game.party.manualScenarios.find(
-            (scenarioModel) =>
-              scenarioModel.index === scenarioData.index &&
-              scenarioModel.edition === scenarioData.edition &&
-              scenarioModel.group === scenarioData.group &&
-              !scenarioModel.custom
-          ) &&
-          !this.isSuccess(scenarioData)
-      );
-    let scenarioData: ScenarioData | undefined = undefined;
-    if (availableScenarios.length > 0) {
-      scenarioData = availableScenarios[Math.floor(Math.random() * availableScenarios.length)];
-    }
-    return scenarioData;
+    return this.drawRandomScenariosBatch(edition, 1)[0];
+  }
+
+  drawRandomScenariosBatch(edition: string, count: number): ScenarioData[] {
+    return ghsShuffleArray(
+      gameManager
+        .scenarioData(edition)
+        .filter(
+          (scenarioData) =>
+            scenarioData.random &&
+            !gameManager.game.party.manualScenarios.find(
+              (scenarioModel) =>
+                scenarioModel.index === scenarioData.index &&
+                scenarioModel.edition === scenarioData.edition &&
+                scenarioModel.group === scenarioData.group &&
+                !scenarioModel.custom
+            ) &&
+            !this.isSuccess(scenarioData)
+        )
+    ).slice(0, count);
   }
 
   drawRandomScenarioSection(edition: string): ScenarioData | undefined {
-    const availableSections = gameManager
-      .sectionData(edition)
-      .filter(
-        (scenarioData) =>
-          scenarioData.conclusion &&
-          scenarioData.random &&
-          !gameManager.game.party.conclusions.find(
-            (scenarioModel) =>
-              scenarioModel.index === scenarioData.index &&
-              scenarioModel.edition === scenarioData.edition &&
-              scenarioModel.group === scenarioData.group &&
-              !scenarioModel.custom
-          ) &&
-          !gameManager.game.party.scenarios.find(
-            (scenarioModel) =>
-              scenarioModel.index === scenarioData.index &&
-              scenarioModel.edition === scenarioData.edition &&
-              scenarioModel.group === scenarioData.group &&
-              !scenarioModel.custom
-          )
-      );
-    let scenarioData: ScenarioData | undefined = undefined;
-    if (availableSections.length > 0) {
-      scenarioData = availableSections[Math.floor(Math.random() * availableSections.length)];
-    }
-    return scenarioData;
+    return this.drawRandomScenarioSectionsBatch(edition, 1)[0];
+  }
+
+  drawRandomScenarioSectionsBatch(edition: string, count: number): ScenarioData[] {
+    return ghsShuffleArray(
+      gameManager
+        .sectionData(edition)
+        .filter(
+          (scenarioData) =>
+            scenarioData.conclusion &&
+            scenarioData.random &&
+            !gameManager.game.party.conclusions.find(
+              (scenarioModel) =>
+                scenarioModel.index === scenarioData.index &&
+                scenarioModel.edition === scenarioData.edition &&
+                scenarioModel.group === scenarioData.group &&
+                !scenarioModel.custom
+            ) &&
+            !gameManager.game.party.scenarios.find(
+              (scenarioModel) =>
+                scenarioModel.index === scenarioData.index &&
+                scenarioModel.edition === scenarioData.edition &&
+                scenarioModel.group === scenarioData.group &&
+                !scenarioModel.custom
+            )
+        )
+    ).slice(0, count);
   }
 
   scenarioUndoArgs(scenario: Scenario | undefined = undefined): string[] {

--- a/src/app/ui/figures/character/sheet/retirement-dialog.html
+++ b/src/app/ui/figures/character/sheet/retirement-dialog.html
@@ -53,23 +53,29 @@
           [ghs-label-args]="[personalQuest.unlockCharacter]"
         ></div>
       }
-      @if (!!characterScenario) {
+      @if (!!characterScenario && characterScenario !== true) {
         <div
           class="text-white"
           [ghs-label]="'character.progress.personalQuest.unlockCharacter.randomScenario'"
           [ghs-label-args]="[characterScenario.index, characterScenario.name]"
         ></div>
       }
+      @if (characterScenario === true) {
+        <div class="text-white" [ghs-label]="'character.progress.personalQuest.unlockCharacter.randomScenario.info'"></div>
+      }
       @if (characterAlreadyUnlocked && !characterScenario && gameManager.gh2eRules()) {
         <div class="text-white" [ghs-label]="'character.progress.personalQuest.unlockCharacter.randomScenario.gold'"></div>
       }
-      @if (!!characterItemDesign) {
+      @if (!!characterItemDesign && characterItemDesign !== true) {
         <div
           class="text-white link"
           (click)="itemDialog(characterItemDesign)"
           [ghs-label]="'character.progress.personalQuest.unlockCharacter.itemDesign'"
           [ghs-label-args]="[characterItemDesign.id, characterItemDesign.edition]"
         ></div>
+      }
+      @if (characterItemDesign === true) {
+        <div class="text-white" [ghs-label]="'character.progress.personalQuest.unlockCharacter.itemDesign.info'"></div>
       }
       @if (characterAlreadyUnlocked && !characterItemDesign && gameManager.gh2eRules()) {
         <div class="text-white" [ghs-label]="'character.progress.personalQuest.unlockCharacter.itemDesign.gold'"></div>
@@ -196,23 +202,29 @@
           [ngClass]="{ 'already-unlocked': additionalCharacterAlreadyUnlocked }"
         ></div>
       }
-      @if (!!additionalCharacterScenario) {
+      @if (!!additionalCharacterScenario && additionalCharacterScenario !== true) {
         <div
           class="text-white"
           [ghs-label]="'character.progress.personalQuest.unlockCharacter.randomScenario'"
           [ghs-label-args]="[additionalCharacterScenario.index, additionalCharacterScenario.name]"
         ></div>
       }
-      @if (additionalCharacterAlreadyUnlocked && !additionalCharacterScenario && gameManager.gh2eRules()) {
-        <div class="text-white" [ghs-label]="'character.progress.personalQuest.randomScenario.gold'"></div>
+      @if (additionalCharacterScenario === true) {
+        <div class="text-white" [ghs-label]="'character.progress.personalQuest.unlockCharacter.randomScenario.info'"></div>
       }
-      @if (!!additionalCharacterItemDesign) {
+      @if (additionalCharacterAlreadyUnlocked && !additionalCharacterScenario && gameManager.gh2eRules()) {
+        <div class="text-white" [ghs-label]="'character.progress.personalQuest.unlockCharacter.randomScenario.gold'"></div>
+      }
+      @if (!!additionalCharacterItemDesign && additionalCharacterItemDesign !== true) {
         <div
           class="text-white link"
           (click)="itemDialog(additionalCharacterItemDesign)"
           [ghs-label]="'character.progress.personalQuest.unlockCharacter.itemDesign'"
           [ghs-label-args]="[additionalCharacterItemDesign.id, additionalCharacterItemDesign.edition]"
         ></div>
+      }
+      @if (additionalCharacterItemDesign === true) {
+        <div class="text-white" [ghs-label]="'character.progress.personalQuest.unlockCharacter.itemDesign.info'"></div>
       }
       @if (additionalCharacterAlreadyUnlocked && !additionalCharacterItemDesign && gameManager.gh2eRules()) {
         <div class="text-white" [ghs-label]="'character.progress.personalQuest.unlockCharacter.itemDesign.gold'"></div>

--- a/src/app/ui/figures/character/sheet/retirement-dialog.ts
+++ b/src/app/ui/figures/character/sheet/retirement-dialog.ts
@@ -40,22 +40,25 @@ export class CharacterRetirementDialog {
   unlockEvent: string = '';
   alreadyRetired: boolean = false;
   characterAlreadyUnlocked: boolean = false;
-  characterScenario: ScenarioData | undefined;
-  characterItemDesign: ItemData | undefined;
+  characterScenario: ScenarioData | boolean | undefined;
+  characterItemDesign: ItemData | boolean | undefined;
   envelopeAlreadyUnlocked: boolean = false;
-  envelopeSection: ScenarioData | true | undefined;
-  envelopeItemBlueprint: ItemData | true | undefined;
+  envelopeSection: ScenarioData | boolean | undefined;
+  envelopeItemBlueprint: ItemData | boolean | undefined;
+
+  reservedRandomScenario: ScenarioData | undefined = undefined;
+  reservedRandomItem: ItemData | undefined = undefined;
 
   additional: boolean = false;
   additionalPQ: PersonalQuest | undefined;
   additionalPQBuilding: BuildingData | undefined;
   additionalUnlockEvent: string = '';
   additionalCharacterAlreadyUnlocked: boolean = false;
-  additionalCharacterScenario: ScenarioData | undefined;
-  additionalCharacterItemDesign: ItemData | undefined;
+  additionalCharacterScenario: ScenarioData | boolean | undefined;
+  additionalCharacterItemDesign: ItemData | boolean | undefined;
   additionalEnvelopeAlreadyUnlocked: boolean = false;
-  additionalEnvelopeSection: ScenarioData | true | undefined;
-  additionalEnvelopeItemBlueprint: ItemData | true | undefined;
+  additionalEnvelopeSection: ScenarioData | boolean | undefined;
+  additionalEnvelopeItemBlueprint: ItemData | boolean | undefined;
 
   hasResources: boolean = false;
 
@@ -95,6 +98,11 @@ export class CharacterRetirementDialog {
     }
 
     if (this.personalQuest) {
+      const isFhquest = !!this.personalQuest.openEnvelope && gameManager.fhRules();
+      const scenarios = isFhquest
+        ? gameManager.scenarioManager.drawRandomScenarioSectionsBatch(this.personalQuest.edition, 2)
+        : gameManager.scenarioManager.drawRandomScenariosBatch(this.personalQuest.edition, 2);
+      const items = gameManager.itemManager.drawRandomItemsBatch(this.personalQuest.edition, 2, isFhquest);
       if (this.personalQuest.unlockCharacter) {
         this.characterAlreadyUnlocked = gameManager.game.unlockedCharacters.includes(
           this.personalQuest.edition + ':' + this.personalQuest.unlockCharacter
@@ -110,24 +118,23 @@ export class CharacterRetirementDialog {
             );
           this.unlockEvent = (unlockCharacter && unlockCharacter.unlockEvent) || '';
         } else {
-          this.characterScenario = gameManager.scenarioManager.drawRandomScenario(gameManager.currentEdition());
-          this.characterItemDesign = gameManager.itemManager.drawRandomItem(gameManager.currentEdition());
+          this.characterScenario = settingsManager.settings.drawRandomScenario ? scenarios.pop() : !!scenarios.pop();
+          this.characterItemDesign = settingsManager.settings.drawRandomItem ? items.pop() : !!items.pop();
         }
       }
 
-      if (this.personalQuest.openEnvelope && gameManager.fhRules()) {
+      if (isFhquest) {
         this.envelopeAlreadyUnlocked =
           !this.buildingsEnvelopeHelper(this.personalQuest.openEnvelope, false) &&
           !this.buildingsEnvelopeHelper(this.personalQuest.openEnvelope);
         if (this.envelopeAlreadyUnlocked) {
-          this.envelopeSection = settingsManager.settings.drawRandomScenario
-            ? gameManager.scenarioManager.drawRandomScenarioSection(gameManager.currentEdition())
-            : true;
-          this.envelopeItemBlueprint = settingsManager.settings.drawRandomItem
-            ? gameManager.itemManager.drawRandomItem(gameManager.currentEdition(), true)
-            : true;
+          this.envelopeSection = settingsManager.settings.drawRandomScenario ? scenarios.pop() : !!scenarios.pop();
+          this.envelopeItemBlueprint = settingsManager.settings.drawRandomItem ? items.pop() : !!items.pop();
         }
       }
+
+      this.reservedRandomScenario = scenarios.pop();
+      this.reservedRandomItem = items.pop();
     }
 
     this.alreadyRetired =
@@ -237,19 +244,19 @@ export class CharacterRetirementDialog {
     }
 
     if (this.characterAlreadyUnlocked) {
-      if (this.characterScenario) {
+      if (this.characterScenario && this.characterScenario !== true) {
         gameManager.game.party.manualScenarios.push(
           new GameScenarioModel(this.characterScenario.index, this.characterScenario.edition, this.characterScenario.group)
         );
       }
 
-      if (this.characterItemDesign) {
+      if (this.characterItemDesign && this.characterItemDesign !== true) {
         gameManager.game.party.unlockedItems.push(new CountIdentifier(this.characterItemDesign.id, this.characterItemDesign.edition));
       }
     }
 
     if (this.additionalCharacterAlreadyUnlocked) {
-      if (this.additionalCharacterScenario) {
+      if (this.additionalCharacterScenario && this.additionalCharacterScenario !== true) {
         gameManager.game.party.manualScenarios.push(
           new GameScenarioModel(
             this.additionalCharacterScenario.index,
@@ -259,7 +266,7 @@ export class CharacterRetirementDialog {
         );
       }
 
-      if (this.additionalCharacterItemDesign) {
+      if (this.additionalCharacterItemDesign && this.additionalCharacterItemDesign !== true) {
         gameManager.game.party.unlockedItems.push(
           new CountIdentifier(this.additionalCharacterItemDesign.id, this.additionalCharacterItemDesign.edition)
         );
@@ -409,9 +416,15 @@ export class CharacterRetirementDialog {
                 characterData.name === this.additionalPQ.unlockCharacter
             );
           this.additionalUnlockEvent = (unlockCharacter && unlockCharacter.unlockEvent) || '';
+          this.additionalCharacterScenario = undefined;
+          this.additionalCharacterItemDesign = undefined;
         } else {
-          this.additionalCharacterScenario = gameManager.scenarioManager.drawRandomScenario(gameManager.currentEdition());
-          this.additionalCharacterItemDesign = gameManager.itemManager.drawRandomItem(gameManager.currentEdition());
+          this.additionalCharacterScenario = settingsManager.settings.drawRandomScenario
+            ? this.reservedRandomScenario
+            : !!this.reservedRandomScenario;
+          this.additionalCharacterItemDesign = settingsManager.settings.drawRandomItem
+            ? this.reservedRandomItem
+            : !!this.reservedRandomItem;
         }
       }
 
@@ -422,11 +435,14 @@ export class CharacterRetirementDialog {
 
         if (this.additionalEnvelopeAlreadyUnlocked) {
           this.additionalEnvelopeSection = settingsManager.settings.drawRandomScenario
-            ? gameManager.scenarioManager.drawRandomScenarioSection(gameManager.currentEdition())
-            : true;
+            ? this.reservedRandomScenario
+            : !!this.reservedRandomScenario;
           this.additionalEnvelopeItemBlueprint = settingsManager.settings.drawRandomItem
-            ? gameManager.itemManager.drawRandomItem(gameManager.currentEdition(), true)
-            : true;
+            ? this.reservedRandomItem
+            : !!this.reservedRandomItem;
+        } else {
+          this.additionalEnvelopeSection = undefined;
+          this.additionalEnvelopeItemBlueprint = undefined;
         }
       }
     }

--- a/src/app/ui/figures/entities-menu/helpers/campaign.ts
+++ b/src/app/ui/figures/entities-menu/helpers/campaign.ts
@@ -83,10 +83,12 @@ export class CampaignHelper {
         .closed.subscribe({
           next: (result: unknown) => {
             if (result) {
-              if (result == true && gameManager.fhRules()) {
-                gameManager.stateManager.before('eventEffect.inspiration', ghsValueSign(1));
-                gameManager.game.party.inspiration += 1;
-                gameManager.stateManager.after();
+              if (result == true) {
+                if (gameManager.fhRules()) {
+                  gameManager.stateManager.before('eventEffect.inspiration', ghsValueSign(1));
+                  gameManager.game.party.inspiration += 1;
+                  gameManager.stateManager.after();
+                }
               } else {
                 const itemData = result as ItemData;
                 gameManager.stateManager.before(

--- a/src/app/ui/figures/entities-menu/helpers/campaign.ts
+++ b/src/app/ui/figures/entities-menu/helpers/campaign.ts
@@ -83,7 +83,7 @@ export class CampaignHelper {
         .closed.subscribe({
           next: (result: unknown) => {
             if (result) {
-              if (result == true) {
+              if (result == true && gameManager.fhRules()) {
                 gameManager.stateManager.before('eventEffect.inspiration', ghsValueSign(1));
                 gameManager.game.party.inspiration += 1;
                 gameManager.stateManager.after();
@@ -119,9 +119,11 @@ export class CampaignHelper {
           next: (result: unknown) => {
             if (result) {
               if (result == true) {
-                gameManager.stateManager.before('eventEffect.inspiration', ghsValueSign(1));
-                gameManager.game.party.inspiration += 1;
-                gameManager.stateManager.after();
+                if (gameManager.fhRules()) {
+                  gameManager.stateManager.before('eventEffect.inspiration', ghsValueSign(1));
+                  gameManager.game.party.inspiration += 1;
+                  gameManager.stateManager.after();
+                }
               } else {
                 const scenarioData = result as ScenarioData;
                 if (section) {

--- a/src/app/ui/figures/entities-menu/random-item/random-item-dialog.html
+++ b/src/app/ui/figures/entities-menu/random-item/random-item-dialog.html
@@ -9,7 +9,7 @@
       @if (!!item) {
         <ghs-item [item]="item" [flipped]="true" [editionLabel]="gameManager.currentEdition()" (click)="openDialog()"></ghs-item>
       }
-      @if (!item && blueprint) {
+      @if (!item && blueprint && gameManager.fhRules()) {
         <span class="text-white" [ghs-label]="'character.progress.personalQuest.openEnvelope.inspiration'"></span>
       }
     </div>

--- a/src/app/ui/figures/entities-menu/random-scenario/random-scenario-dialog.html
+++ b/src/app/ui/figures/entities-menu/random-scenario/random-scenario-dialog.html
@@ -13,7 +13,7 @@
           [ghs-label-args]="[scenario.index, gameManager.scenarioManager.scenarioTitle(scenario, section), unlocks]"
         ></span>
       }
-      @if (!scenario && section) {
+      @if (!scenario && section && gameManager.fhRules()) {
         <span class="text-white" [ghs-label]="'character.progress.personalQuest.openEnvelope.inspiration'"></span>
       }
     </div>

--- a/src/app/ui/footer/scenario/summary/scenario-summary.html
+++ b/src/app/ui/footer/scenario/summary/scenario-summary.html
@@ -1173,7 +1173,7 @@
                         (click)="openItemDialog(gameManager.itemManager.getItem(itemId, scenario.edition || '', true))"
                       ></span>
                     }
-                    @if (itemId === -1) {
+                    @if (itemId === -1 && gameManager.fhRules()) {
                       <span> <span [ghs-label]="'scenario.rewards.inspiration'" [ghs-label-args]="['+1']"></span> </span>
                     }
                     @if (rewards.hints && rewards.hints.randomItemBlueprint) {
@@ -1205,7 +1205,7 @@
                         (click)="openItemDialog(gameManager.itemManager.getItem(itemId, scenario.edition || '', true))"
                       ></span>
                     }
-                    @if (itemId === -1) {
+                    @if (itemId === -1 && gameManager.fhRules()) {
                       <span> <span [ghs-label]="'scenario.rewards.inspiration'" [ghs-label-args]="['+1']"></span> </span>
                     }
                     @if (rewards.hints && rewards.hints.randomItemDesign) {

--- a/src/app/ui/footer/scenario/summary/scenario-summary.ts
+++ b/src/app/ui/footer/scenario/summary/scenario-summary.ts
@@ -1146,8 +1146,10 @@ export class ScenarioSummaryComponent {
 
       if ((this.gainRewards || this.forceCampaign) && this.randomItemBlueprints.length > 0) {
         this.randomItemBlueprints.forEach((itemId) => {
-          if (itemId === -1 && gameManager.fhRules()) {
-            gameManager.game.party.inspiration += 1;
+          if (itemId === -1) {
+            if (gameManager.fhRules()) {
+              gameManager.game.party.inspiration += 1;
+            }
           } else {
             gameManager.game.party.unlockedItems.push(new CountIdentifier(itemId, this.scenario.edition));
           }
@@ -1156,8 +1158,10 @@ export class ScenarioSummaryComponent {
 
       if ((this.gainRewards || this.forceCampaign) && this.randomItemDesigns.length > 0) {
         this.randomItemDesigns.forEach((itemId) => {
-          if (itemId === -1 && gameManager.fhRules()) {
-            gameManager.game.party.inspiration += 1;
+          if (itemId === -1) {
+            if (gameManager.fhRules()) {
+              gameManager.game.party.inspiration += 1;
+            }
           } else {
             gameManager.game.party.unlockedItems.push(new CountIdentifier(itemId, this.scenario.edition));
           }

--- a/src/app/ui/footer/scenario/summary/scenario-summary.ts
+++ b/src/app/ui/footer/scenario/summary/scenario-summary.ts
@@ -456,8 +456,13 @@ export class ScenarioSummaryComponent {
           this.rewards.randomItemBlueprint &&
           this.randomItemBlueprints.length < this.rewards.randomItemBlueprint
         ) {
+          const blueprints = gameManager.itemManager.drawRandomItemsBatch(
+            this.scenario.edition,
+            this.rewards.randomItemBlueprint - this.randomItemBlueprints.length,
+            true
+          );
           for (let i = this.randomItemBlueprints.length; i < this.rewards.randomItemBlueprint; i++) {
-            const itemData = gameManager.itemManager.drawRandomItem(this.scenario.edition, true);
+            const itemData = blueprints[i];
             const item: Identifier | undefined = itemData ? new Identifier(itemData.id, itemData.edition) : undefined;
             this.randomItemBlueprints[i] = item ? +item.name : -1;
           }
@@ -468,8 +473,13 @@ export class ScenarioSummaryComponent {
           this.rewards.randomItemDesign &&
           this.randomItemDesigns.length < this.rewards.randomItemDesign
         ) {
+          const designs = gameManager.itemManager.drawRandomItemsBatch(
+            this.scenario.edition,
+            this.rewards.randomItemDesign - this.randomItemDesigns.length,
+            false
+          );
           for (let i = this.randomItemDesigns.length; i < this.rewards.randomItemDesign; i++) {
-            const itemData = gameManager.itemManager.drawRandomItem(this.scenario.edition, false);
+            const itemData = designs[i];
             const item: Identifier | undefined = itemData ? new Identifier(itemData.id, itemData.edition) : undefined;
             this.randomItemDesigns[i] = item ? +item.name : -1;
           }
@@ -494,12 +504,13 @@ export class ScenarioSummaryComponent {
             const to = +this.rewards.randomItems.split('-')[1];
             const itemEdition =
               this.rewards.randomItems.split('-').length > 2 ? this.rewards.randomItems.split('-')[2] : this.scenario.edition;
+            const items = gameManager.itemManager.drawRandomItemsBatch(itemEdition, this.characters.length, false, from, to);
             for (let i = this.randomItems.length; i < this.characters.length; i++) {
               const character = this.characters[i];
               if (character.absent) {
                 this.randomItems[i] = undefined;
               } else {
-                let itemData = gameManager.itemManager.drawRandomItem(itemEdition, false, from, to);
+                let itemData = items.pop();
                 if (
                   character.progress.items.find(
                     (owned) => itemData && owned.name === itemData.id + '' && owned.edition === itemData.edition
@@ -1135,7 +1146,7 @@ export class ScenarioSummaryComponent {
 
       if ((this.gainRewards || this.forceCampaign) && this.randomItemBlueprints.length > 0) {
         this.randomItemBlueprints.forEach((itemId) => {
-          if (itemId === -1) {
+          if (itemId === -1 && gameManager.fhRules()) {
             gameManager.game.party.inspiration += 1;
           } else {
             gameManager.game.party.unlockedItems.push(new CountIdentifier(itemId, this.scenario.edition));
@@ -1145,7 +1156,7 @@ export class ScenarioSummaryComponent {
 
       if ((this.gainRewards || this.forceCampaign) && this.randomItemDesigns.length > 0) {
         this.randomItemDesigns.forEach((itemId) => {
-          if (itemId === -1) {
+          if (itemId === -1 && gameManager.fhRules()) {
             gameManager.game.party.inspiration += 1;
           } else {
             gameManager.game.party.unlockedItems.push(new CountIdentifier(itemId, this.scenario.edition));

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -233,11 +233,13 @@
           "": "Open Box %game.characterIcon.{0}%",
           "itemDesign": {
             "": "Gain \"%data.items.{1}-{0}%\" design (Item {0})",
-            "gold": "Item Design Deck deplected, gain 15 collective gold instead"
+            "gold": "Item Design Deck deplected, gain 15 collective gold instead",
+            "info": "Gain one random item design."
           },
           "randomScenario": {
             "": "Unlock \"{1}\" %data.scenarioNumber:{0}%",
-            "gold": "Random Scenario Design Deck deplected, gain 15 collective gold instead"
+            "gold": "Random Scenario Deck deplected, gain 15 collective gold instead",
+            "info": "Gain one random side scenario."
           }
         },
         "unlockPQ": "Unlock Personal Quest {0}"
@@ -1348,7 +1350,7 @@
             "": "Random Side Scenario",
             "alt": "No Random Side Scenarios left",
             "altFh": "No Random Side Scenarios left",
-            "altGh2e": "No Random Side Scenarios left",
+            "altGh2e": "No Random Side Scenarios left, gain 15 collective gold (manual)",
             "result": ": {1} %data.scenarioNumber:{0}%"
           },
           "randomScenarioFh": {


### PR DESCRIPTION
# Description

This makes the GH2E retirement dialog follow the settings for random item/scenario draws like FH does, and make retirements still detect if the decks are depleted to display alternate rewards.

Also improves behavior of completing an additional PQ with inspiration to:
- No longer have a chance to duplicate random draws with primary.
- Properly have depleted deck rewards if primary PQ would draw last card.
- Clear random item/scenario rewards when changing additional PQ to one with its unlock still available (they weren't rewarded before, but still displayed).

Since this required a way to draw batches of random items/scenarios at once, other pieces of code that could use that were updated to do so (like scenario rewards). But this is just future proofing, as there are no real scenarios that grant multiple random things[^1].

Any inspiration gains from drawing random things were given `fhRules()` conditions. I'm not sure all those code paths were even reachable if `fhRules()` were false, but I figured better safe than sorry.

Lastly a couple minor data fixes.

[^1]: There is exactly one scenario, Crimson Scales scenario 04, that uses the `randomItem` reward field to grant multiple items. But it didn't work before this change and doesn't work after it. And it's broken in a lot of ways that probably aren't worth fixing:

    - The items in its reward range aren't tagged as `random`, so they never pass the filter for drawing random items.
    - Even with that set, the drawn items only show in the rewards summary but get neither unlocked nor assigned.
    - The CS FAQ specify these item draws are meant to be from every copy of the items currently in the unavailable item supply (starting with 2 each there), which would require drastically different logic than every other random design/blueprint draw.

    There are other CS scenarios that seem intended to have this same reward, but all of them just use its reminder text instead of using this broken reward type.
    There's another one-off reward type for a single CS scenario, `randomItems` used for scenario 37, which is also broken both before and after this change. But treasures drawing from the same item group (which CS has many of) work fine. So whatever issue with that one is unique to the scenario rewards code.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution