### PR TITLE
Fix curse/bless hotkeys checking wrong cards

### DIFF
--- a/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
+++ b/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
@@ -469,9 +469,8 @@ export class EntitiesMenuDialogComponent {
           event.stopPropagation();
         } else if (!event.ctrlKey && event.key.toLowerCase() === 'b') {
           if (
-            (!event.shiftKey &&
-              (!!this.figure ? gameManager.attackModifierManager.countUpcomingCurses(this.isMonster) : 0) + this.curse < 10) ||
-            (event.shiftKey && (this.curseMin < 0 || this.curseMin + this.curse > 0))
+            (!event.shiftKey && (!!this.figure ? gameManager.attackModifierManager.countUpcomingBlesses() : 0) + this.bless < 10) ||
+            (event.shiftKey && (this.blessMin < 0 || this.blessMin + this.bless > 0))
           ) {
             this.bless += event.shiftKey ? -1 : 1;
           }
@@ -479,8 +478,8 @@ export class EntitiesMenuDialogComponent {
           event.stopPropagation();
         } else if (!event.ctrlKey && event.key.toLowerCase() === 'c') {
           if (
-            (!event.shiftKey && gameManager.attackModifierManager.countUpcomingBlesses() + this.bless < 10) ||
-            (event.shiftKey && (this.blessMin < 0 || this.blessMin + this.bless > 0))
+            (!event.shiftKey && gameManager.attackModifierManager.countUpcomingCurses(this.isMonster) + this.curse < 10) ||
+            (event.shiftKey && (this.curseMin < 0 || this.curseMin + this.curse > 0))
           ) {
             this.curse += event.shiftKey ? -1 : 1;
           }


### PR DESCRIPTION
# Description

Conditions were swapped for these hotkeys, with curse checking bless and vice versa.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x]I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution
