### PR TITLE
Make Safeguard work more consistently

### DIFF
--- a/data/fc/sections/011.json
+++ b/data/fc/sections/011.json
@@ -11,10 +11,10 @@
       "figures": [
         {
           "identifier": {
-            "type": "character",
+            "type": "all",
             "name": ".*"
           },
-          "type": "amAdd",
+          "type": "gainCondition",
           "value": "curse:1"
         }
       ]

--- a/data/fc/sections/087.json
+++ b/data/fc/sections/087.json
@@ -11,7 +11,7 @@
       "figures": [
         {
           "identifier": {
-            "type": "character",
+            "type": "all",
             "name": ".*"
           },
           "type": "damage",
@@ -26,15 +26,15 @@
       "figures": [
         {
           "identifier": {
-            "type": "character",
+            "type": "all",
             "name": ".*"
           },
-          "type": "amAdd",
+          "type": "gainCondition",
           "value": "curse:1"
         },
         {
           "identifier": {
-            "type": "character",
+            "type": "all",
             "name": ".*"
           },
           "type": "gainCondition",
@@ -42,7 +42,7 @@
         },
         {
           "identifier": {
-            "type": "character",
+            "type": "all",
             "name": ".*"
           },
           "type": "gainCondition",
@@ -50,7 +50,7 @@
         },
         {
           "identifier": {
-            "type": "character",
+            "type": "all",
             "name": ".*"
           },
           "type": "gainCondition",
@@ -58,7 +58,7 @@
         },
         {
           "identifier": {
-            "type": "character",
+            "type": "all",
             "name": ".*"
           },
           "type": "gainCondition",

--- a/data/fh/scenarios/004A.json
+++ b/data/fh/scenarios/004A.json
@@ -62,7 +62,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/004B.json
+++ b/data/fh/scenarios/004B.json
@@ -59,7 +59,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/007.json
+++ b/data/fh/scenarios/007.json
@@ -55,7 +55,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/008.json
+++ b/data/fh/scenarios/008.json
@@ -71,7 +71,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/022.json
+++ b/data/fh/scenarios/022.json
@@ -54,7 +54,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/037.json
+++ b/data/fh/scenarios/037.json
@@ -66,7 +66,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/042.json
+++ b/data/fh/scenarios/042.json
@@ -60,7 +60,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/045.json
+++ b/data/fh/scenarios/045.json
@@ -56,7 +56,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/046.json
+++ b/data/fh/scenarios/046.json
@@ -55,7 +55,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/049.json
+++ b/data/fh/scenarios/049.json
@@ -69,7 +69,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/050.json
+++ b/data/fh/scenarios/050.json
@@ -74,7 +74,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/051.json
+++ b/data/fh/scenarios/051.json
@@ -58,7 +58,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/053.json
+++ b/data/fh/scenarios/053.json
@@ -60,7 +60,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/054.json
+++ b/data/fh/scenarios/054.json
@@ -91,7 +91,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/060.json
+++ b/data/fh/scenarios/060.json
@@ -84,7 +84,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/061.json
+++ b/data/fh/scenarios/061.json
@@ -75,7 +75,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         },
         {

--- a/data/fh/scenarios/068.json
+++ b/data/fh/scenarios/068.json
@@ -51,7 +51,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         },
         {

--- a/data/fh/scenarios/070.json
+++ b/data/fh/scenarios/070.json
@@ -54,7 +54,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/082.json
+++ b/data/fh/scenarios/082.json
@@ -66,7 +66,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/084.json
+++ b/data/fh/scenarios/084.json
@@ -48,7 +48,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/100.json
+++ b/data/fh/scenarios/100.json
@@ -43,7 +43,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/102.json
+++ b/data/fh/scenarios/102.json
@@ -43,7 +43,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/117.json
+++ b/data/fh/scenarios/117.json
@@ -53,7 +53,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/135.json
+++ b/data/fh/scenarios/135.json
@@ -52,7 +52,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/scenarios/137.json
+++ b/data/fh/scenarios/137.json
@@ -54,7 +54,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/fh/sections/101-1.json
+++ b/data/fh/sections/101-1.json
@@ -35,7 +35,7 @@
             "type": "character",
             "name": ".*"
           },
-          "type": "amAdd",
+          "type": "gainCondition",
           "value": "curse:1",
           "scenarioEffect": true
         }

--- a/data/fh/sections/157-1.json
+++ b/data/fh/sections/157-1.json
@@ -39,7 +39,7 @@
             "type": "character",
             "name": ".*"
           },
-          "type": "amAdd",
+          "type": "gainCondition",
           "value": "curse:1",
           "scenarioEffect": true
         }

--- a/data/fh/sections/176-3.json
+++ b/data/fh/sections/176-3.json
@@ -39,7 +39,7 @@
             "type": "character",
             "name": ".*"
           },
-          "type": "amAdd",
+          "type": "gainCondition",
           "value": "curse:1"
         }
       ]

--- a/data/gh/scenarios/14.json
+++ b/data/gh/scenarios/14.json
@@ -31,7 +31,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/gh/scenarios/23.json
+++ b/data/gh/scenarios/23.json
@@ -38,7 +38,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/gh/scenarios/25.json
+++ b/data/gh/scenarios/25.json
@@ -39,7 +39,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/gh/scenarios/29.json
+++ b/data/gh/scenarios/29.json
@@ -54,7 +54,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/gh/scenarios/40.json
+++ b/data/gh/scenarios/40.json
@@ -48,7 +48,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/gh/scenarios/45.json
+++ b/data/gh/scenarios/45.json
@@ -55,7 +55,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/gh/scenarios/55.json
+++ b/data/gh/scenarios/55.json
@@ -31,7 +31,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:3",
+          "value": "minus1extra:3",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/013.json
+++ b/data/gh2e/scenarios/013.json
@@ -21,7 +21,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/017.json
+++ b/data/gh2e/scenarios/017.json
@@ -28,7 +28,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/019.json
+++ b/data/gh2e/scenarios/019.json
@@ -36,7 +36,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         },
         {

--- a/data/gh2e/scenarios/030.json
+++ b/data/gh2e/scenarios/030.json
@@ -21,7 +21,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/036.json
+++ b/data/gh2e/scenarios/036.json
@@ -22,7 +22,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/037.json
+++ b/data/gh2e/scenarios/037.json
@@ -26,7 +26,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/046.json
+++ b/data/gh2e/scenarios/046.json
@@ -34,7 +34,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/047.json
+++ b/data/gh2e/scenarios/047.json
@@ -44,7 +44,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/048.json
+++ b/data/gh2e/scenarios/048.json
@@ -39,7 +39,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         },
         {

--- a/data/gh2e/scenarios/049.json
+++ b/data/gh2e/scenarios/049.json
@@ -51,7 +51,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/050.json
+++ b/data/gh2e/scenarios/050.json
@@ -62,7 +62,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/051.json
+++ b/data/gh2e/scenarios/051.json
@@ -33,7 +33,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/052.json
+++ b/data/gh2e/scenarios/052.json
@@ -27,7 +27,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/059.json
+++ b/data/gh2e/scenarios/059.json
@@ -26,7 +26,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/061.json
+++ b/data/gh2e/scenarios/061.json
@@ -23,7 +23,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/data/gh2e/scenarios/076.json
+++ b/data/gh2e/scenarios/076.json
@@ -29,7 +29,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:1",
+          "value": "minus1extra:1",
           "scenarioEffect": true
         }
       ]

--- a/data/sits/scenarios/03.json
+++ b/data/sits/scenarios/03.json
@@ -45,8 +45,8 @@
             "type": "character",
             "name": ".*"
           },
-          "type": "gainCondition",
-          "value": "curse",
+          "type": "amAdd",
+          "value": "curse:1",
           "scenarioEffect": true
         }
       ]

--- a/data/toa/scenarios/75.json
+++ b/data/toa/scenarios/75.json
@@ -24,7 +24,7 @@
             "name": ".*"
           },
           "type": "amAdd",
-          "value": "minus1:2",
+          "value": "minus1extra:2",
           "scenarioEffect": true
         }
       ]

--- a/src/app/game/businesslogic/ActionsManager.ts
+++ b/src/app/game/businesslogic/ActionsManager.ts
@@ -1,8 +1,6 @@
 import { gameManager } from 'src/app/game/businesslogic/GameManager';
 import { settingsManager } from 'src/app/game/businesslogic/SettingsManager';
-import { Character } from 'src/app/game/model/Character';
 import { Action, ActionHint, ActionSpecialTarget, ActionType, ActionValueType } from 'src/app/game/model/data/Action';
-import { AttackModifier, AttackModifierType } from 'src/app/game/model/data/AttackModifier';
 import { Condition, ConditionName, ConditionType, EntityCondition } from 'src/app/game/model/data/Condition';
 import { Element, ElementModel, ElementState } from 'src/app/game/model/data/Element';
 import { AdditionalIdentifier } from 'src/app/game/model/data/Identifier';
@@ -547,26 +545,7 @@ export class ActionsManager {
         gameManager.entityManager.applyCondition(entity, figure, healCondition, true);
         break;
       case ActionType.condition:
-        if (action.value === 'bless' || action.value === 'curse') {
-          const am =
-            figure instanceof Monster
-              ? settingsManager.settings.allyAttackModifierDeck &&
-                (gameManager.fhRules(true) || settingsManager.settings.alwaysAllyAttackModifierDeck) &&
-                (figure.isAlly || figure.isAllied)
-                ? gameManager.game.allyAttackModifierDeck
-                : gameManager.game.monsterAttackModifierDeck
-              : figure instanceof Character
-                ? figure.attackModifierDeck
-                : undefined;
-          if (am) {
-            gameManager.attackModifierManager.addModifier(
-              am,
-              new AttackModifier(action.value === 'bless' ? AttackModifierType.bless : AttackModifierType.curse)
-            );
-          }
-        } else {
-          gameManager.entityManager.addCondition(entity, figure, new Condition('' + action.value));
-        }
+        gameManager.entityManager.addCondition(entity, figure, new Condition('' + action.value));
         break;
       case ActionType.damage:
       case ActionType.sufferDamage:

--- a/src/app/game/businesslogic/AttackModifierManager.ts
+++ b/src/app/game/businesslogic/AttackModifierManager.ts
@@ -62,6 +62,18 @@ export class AttackModifierManager {
     return new AttackModifierDeck();
   }
 
+  getModifier(type: AttackModifierType, count: number = 1): AttackModifier[] {
+    return Array(count).fill(new AttackModifier(type));
+  }
+
+  getBless(count: number = 1): AttackModifier[] {
+    return this.getModifier(AttackModifierType.bless, Math.min(count, 10 - this.countUpcomingBlesses()));
+  }
+
+  getCurse(isMonster: boolean, count: number = 1): AttackModifier[] {
+    return this.getModifier(AttackModifierType.curse, Math.min(count, 10 - this.countUpcomingCurses(isMonster)));
+  }
+
   countUpcomingBlesses(): number {
     let count = 0;
     if (
@@ -118,7 +130,7 @@ export class AttackModifierManager {
     return count;
   }
 
-  getAdditional(character: Character, type: AttackModifierType, all: boolean = false): AttackModifier[] {
+  getAdditional(character: Character, type: AttackModifierType, count: number = 1): AttackModifier[] {
     const additional: AttackModifier[] = [];
     if (character.additionalModifier.find((perk) => perk.attackModifier && perk.attackModifier.type === type)) {
       character.additionalModifier.forEach((card, index) => {
@@ -126,8 +138,8 @@ export class AttackModifierManager {
           const am = Object.assign(new AttackModifier(card.attackModifier.type), card.attackModifier);
           am.id = 'additional-' + character.name + index;
           am.character = true;
-          const existing: number = all ? 0 : this.countUpcomingAdditional(character, type);
-          for (let i = 0; i < card.count - existing; i++) {
+          const existing: number = this.countUpcomingAdditional(character, type, am.id);
+          for (let i = 0; i < card.count - existing && additional.length < count; i++) {
             additional.push(am);
           }
         }
@@ -156,7 +168,8 @@ export class AttackModifierManager {
     return additional;
   }
 
-  countUpcomingAdditional(character: Character, type: AttackModifierType) {
+  countUpcomingAdditional(character: Character, type: AttackModifierType, idPrefix?: string) {
+    idPrefix ??= 'additional-' + character.name;
     let count = 0;
     if (
       settingsManager.settings.alwaysAllyAttackModifierDeck ||
@@ -168,7 +181,7 @@ export class AttackModifierManager {
           index > gameManager.game.allyAttackModifierDeck.current &&
           attackModifier.type === type &&
           attackModifier.id &&
-          attackModifier.id.startsWith('additional-' + character.name)
+          attackModifier.id.startsWith(idPrefix)
         );
       }).length;
     }
@@ -178,7 +191,7 @@ export class AttackModifierManager {
         index > gameManager.game.monsterAttackModifierDeck.current &&
         attackModifier.type === type &&
         attackModifier.id &&
-        attackModifier.id.startsWith('additional-' + character.name)
+        attackModifier.id.startsWith(idPrefix)
       );
     }).length;
 
@@ -191,12 +204,16 @@ export class AttackModifierManager {
             index > figure.attackModifierDeck.current &&
             attackModifier.type === type &&
             attackModifier.id &&
-            attackModifier.id.startsWith('additional-' + character.name)
+            attackModifier.id.startsWith(idPrefix)
           );
         }).length;
       });
 
     return count;
+  }
+
+  getExtraMinus1(count: number = 1): AttackModifier[] {
+    return this.getModifier(AttackModifierType.minus1extra, Math.min(count, 15 - this.countExtraMinus1()));
   }
 
   countExtraMinus1(): number {
@@ -227,6 +244,10 @@ export class AttackModifierManager {
     return count;
   }
 
+  addModifierBatch(attackModifierDeck: AttackModifierDeck, batch: AttackModifier[]) {
+    batch.forEach((card) => this.addModifier(attackModifierDeck, card));
+  }
+
   addModifier(attackModifierDeck: AttackModifierDeck, am: AttackModifier, index: number = -1, shuffle: boolean = true) {
     const attackModifier = Object.assign(new AttackModifier(am.type), am);
     if ((shuffle && index < 0) || index > attackModifierDeck.cards.length) {
@@ -240,8 +261,26 @@ export class AttackModifierManager {
     attackModifierDeck.cards = [...attackModifierDeck.cards.slice(0, index), attackModifier, ...attackModifierDeck.cards.slice(index)];
   }
 
-  addModifierByType(attackModifierDeck: AttackModifierDeck, type: AttackModifierType) {
-    this.addModifier(attackModifierDeck, new AttackModifier(type));
+  addModifierByType(attackModifierDeck: AttackModifierDeck, type: AttackModifierType, respectSupplyLimit: boolean = true) {
+    let modifiers: AttackModifier[] = [];
+    if (respectSupplyLimit) {
+      switch (type) {
+        case AttackModifierType.bless:
+          modifiers = this.getBless();
+          break;
+        case AttackModifierType.curse:
+          modifiers = this.getCurse(this.game.monsterAttackModifierDeck === attackModifierDeck);
+          break;
+        case AttackModifierType.minus1extra:
+          modifiers = this.getExtraMinus1();
+          break;
+        default:
+          modifiers.push(new AttackModifier(type));
+      }
+    } else {
+      modifiers.push(new AttackModifier(type));
+    }
+    this.addModifierBatch(attackModifierDeck, modifiers);
   }
 
   removeModifierByType(attackModifierDeck: AttackModifierDeck, type: AttackModifierType) {
@@ -563,9 +602,7 @@ export class AttackModifierManager {
         for (const itemIdentifier of character.progress.equippedItems) {
           const itemData = gameManager.itemManager.getItem(itemIdentifier.name, itemIdentifier.edition, true);
           if (itemData && itemData.minusOne) {
-            for (let i = 0; i < itemData.minusOne; i++) {
-              this.addModifier(attackModifierDeck, new AttackModifier(AttackModifierType.minus1));
-            }
+            this.addModifierBatch(attackModifierDeck, this.getExtraMinus1(itemData.minusOne));
           }
         }
       }

--- a/src/app/game/businesslogic/EntityManager.ts
+++ b/src/app/game/businesslogic/EntityManager.ts
@@ -637,6 +637,23 @@ export class EntityManager {
   }
 
   addStandardCondition(entity: Entity, figure: Figure, condition: Condition, permanent: boolean = false) {
+    if (condition.types.includes(ConditionType.upgrade)) {
+      const upgradeCondition = condition;
+      const baseCondition = this.activeConditions(entity).find(
+        (other) => other.name + '_x' === condition.name && other.types.includes(ConditionType.upgradable)
+      );
+      if (upgradeCondition && baseCondition) {
+        this.removeCondition(entity, figure, baseCondition);
+      }
+    } else if (condition.types.includes(ConditionType.upgradable)) {
+      const upgradeCondition = this.activeConditions(entity).find(
+        (other) => other.name === condition.name + '_x' && other.types.includes(ConditionType.upgrade)
+      );
+      if (upgradeCondition) {
+        return;
+      }
+    }
+
     let entityCondition: EntityCondition | undefined = entity.entityConditions.find(
       (entityCondition) => entityCondition.name === condition.name && !entityCondition.types.includes(ConditionType.multiple)
     );

--- a/src/app/game/businesslogic/EntityManager.ts
+++ b/src/app/game/businesslogic/EntityManager.ts
@@ -588,6 +588,19 @@ export class EntityManager {
   }
 
   addCondition(entity: Entity, figure: Figure, condition: Condition, permanent: boolean = false) {
+    if (
+      settingsManager.settings.applyConditions &&
+      !settingsManager.settings.applyConditionsExcludes.includes(ConditionName.safeguard) &&
+      this.hasCondition(entity, new Condition(ConditionName.safeguard)) &&
+      condition.types.includes(ConditionType.negative)
+    ) {
+      this.removeCondition(entity, figure, new Condition(ConditionName.safeguard));
+      if (condition.value <= 1 || condition.types.includes(ConditionType.upgrade)) {
+        return;
+      } else if (condition.types.includes(ConditionType.stackable)) {
+        condition = new Condition(condition.name, condition.value - 1);
+      }
+    }
     let entityCondition: EntityCondition | undefined = entity.entityConditions.find(
       (entityCondition) => entityCondition.name === condition.name && !entityCondition.types.includes(ConditionType.multiple)
     );
@@ -598,6 +611,11 @@ export class EntityManager {
       entityCondition.expired = false;
       entityCondition.lastState = entityCondition.state;
       entityCondition.state = EntityConditionState.normal;
+      if (entityCondition.types.includes(ConditionType.stackable)) {
+        entityCondition.value += condition.value;
+      } else if (entityCondition.types.includes(ConditionType.upgrade)) {
+        entityCondition.value = Math.max(entityCondition.value, condition.value);
+      }
     }
 
     if (entityCondition.name === ConditionName.plague && entityCondition.value > 3) {
@@ -636,16 +654,6 @@ export class EntityManager {
       !this.isImmune(entity, entity, ConditionName.wound)
     ) {
       this.addCondition(entity, figure, new Condition(ConditionName.wound));
-    }
-
-    if (
-      settingsManager.settings.applyConditions &&
-      !settingsManager.settings.applyConditionsExcludes.includes(ConditionName.safeguard) &&
-      this.hasCondition(entity, new Condition(ConditionName.safeguard)) &&
-      entityCondition.types.includes(ConditionType.negative)
-    ) {
-      this.removeCondition(entity, figure, entityCondition);
-      this.removeCondition(entity, figure, new Condition(ConditionName.safeguard));
     }
   }
 

--- a/src/app/game/businesslogic/EntityManager.ts
+++ b/src/app/game/businesslogic/EntityManager.ts
@@ -2,6 +2,7 @@ import { gameManager } from 'src/app/game/businesslogic/GameManager';
 import { settingsManager } from 'src/app/game/businesslogic/SettingsManager';
 import { Character } from 'src/app/game/model/Character';
 import { ActionType } from 'src/app/game/model/data/Action';
+import { AttackModifier, AttackModifierType } from 'src/app/game/model/data/AttackModifier';
 import { Condition, ConditionName, ConditionType, EntityCondition, EntityConditionState } from 'src/app/game/model/data/Condition';
 import { MonsterData } from 'src/app/game/model/data/MonsterData';
 import { Entity, EntityValueFunction } from 'src/app/game/model/Entity';
@@ -587,7 +588,14 @@ export class EntityManager {
     return immune;
   }
 
-  addCondition(entity: Entity, figure: Figure, condition: Condition, permanent: boolean = false, ignoreImmunity: boolean = false) {
+  addCondition(
+    entity: Entity,
+    figure: Figure,
+    condition: Condition,
+    permanent: boolean = false,
+    ignoreImmunity: boolean = false,
+    deckSource?: Character
+  ) {
     if (!ignoreImmunity && this.isImmune(entity, figure, condition.name)) {
       return;
     }
@@ -605,6 +613,26 @@ export class EntityManager {
         condition = new Condition(condition.name, condition.value - 1);
       }
     }
+    if (condition.types.includes(ConditionType.amDeck)) {
+      this.addDeckCondition(figure, condition, deckSource);
+    } else {
+      this.addStandardCondition(entity, figure, condition, permanent);
+    }
+
+    // apply Challenge #1487
+    if (
+      gameManager.challengesManager.apply &&
+      gameManager.challengesManager.isActive(1487, 'fh') &&
+      condition.types.includes(ConditionType.negative) &&
+      condition.name !== ConditionName.wound &&
+      entity instanceof Character &&
+      !this.isImmune(entity, entity, ConditionName.wound)
+    ) {
+      this.addCondition(entity, figure, new Condition(ConditionName.wound));
+    }
+  }
+
+  addStandardCondition(entity: Entity, figure: Figure, condition: Condition, permanent: boolean = false) {
     let entityCondition: EntityCondition | undefined = entity.entityConditions.find(
       (entityCondition) => entityCondition.name === condition.name && !entityCondition.types.includes(ConditionType.multiple)
     );
@@ -647,18 +675,31 @@ export class EntityManager {
 
     entityCondition.permanent = permanent;
     entityCondition.highlight = false;
+  }
 
-    // apply Challenge #1487
-    if (
-      gameManager.challengesManager.apply &&
-      gameManager.challengesManager.isActive(1487, 'fh') &&
-      entityCondition.types.includes(ConditionType.negative) &&
-      entityCondition.name !== ConditionName.wound &&
-      entity instanceof Character &&
-      !this.isImmune(entity, entity, ConditionName.wound)
-    ) {
-      this.addCondition(entity, figure, new Condition(ConditionName.wound));
+  addDeckCondition(figure: Figure, condition: Condition, deckSource?: Character) {
+    let modifiers: AttackModifier[] = [];
+    switch (condition.name) {
+      case ConditionName.bless:
+        modifiers = gameManager.attackModifierManager.getBless(condition.value);
+        break;
+      case ConditionName.curse:
+        const isMonster =
+          (figure instanceof Monster &&
+            ((!figure.isAlly && !figure.isAllied) ||
+              (!settingsManager.settings.alwaysAllyAttackModifierDeck && !gameManager.fhRules(true)))) ||
+          (figure instanceof ObjectiveContainer && figure.amDeck === 'M');
+        modifiers = gameManager.attackModifierManager.getCurse(isMonster, condition.value);
+        break;
+      case ConditionName.empower:
+      case ConditionName.enfeeble:
+        if (!deckSource) {
+          console.error('No deck source found for:', condition.name, figure);
+          return;
+        }
+        modifiers = gameManager.attackModifierManager.getAdditional(deckSource, AttackModifierType[condition.name], condition.value);
     }
+    gameManager.attackModifierManager.addModifierBatch(gameManager.attackModifierManager.byFigure(figure), modifiers);
   }
 
   removeCondition(entity: Entity, figure: Figure, condition: Condition, permanent: boolean = false) {

--- a/src/app/game/businesslogic/EntityManager.ts
+++ b/src/app/game/businesslogic/EntityManager.ts
@@ -563,6 +563,10 @@ export class EntityManager {
           this.isImmune(entity, figure, ConditionName.immobilize, ignoreManual) ||
           this.isImmune(entity, figure, ConditionName.muddle, ignoreManual)
         );
+      } else if (conditionName === ConditionName.empower) {
+        return this.isImmune(entity, figure, ConditionName.bless, ignoreManual);
+      } else if (conditionName === ConditionName.enfeeble) {
+        return this.isImmune(entity, figure, ConditionName.curse, ignoreManual);
       }
     }
 

--- a/src/app/game/businesslogic/EntityManager.ts
+++ b/src/app/game/businesslogic/EntityManager.ts
@@ -587,8 +587,12 @@ export class EntityManager {
     return immune;
   }
 
-  addCondition(entity: Entity, figure: Figure, condition: Condition, permanent: boolean = false) {
+  addCondition(entity: Entity, figure: Figure, condition: Condition, permanent: boolean = false, ignoreImmunity: boolean = false) {
+    if (!ignoreImmunity && this.isImmune(entity, figure, condition.name)) {
+      return;
+    }
     if (
+      !ignoreImmunity &&
       settingsManager.settings.applyConditions &&
       !settingsManager.settings.applyConditionsExcludes.includes(ConditionName.safeguard) &&
       this.hasCondition(entity, new Condition(ConditionName.safeguard)) &&

--- a/src/app/game/businesslogic/EventCardManager.ts
+++ b/src/app/game/businesslogic/EventCardManager.ts
@@ -467,7 +467,7 @@ export class EventCardManager {
                           .forEach((c) => {
                             gameManager.entityManager.addCondition(c, c, new Condition(condition));
                           });
-                      } else if (condition === ConditionName.curse) {
+                      } else if (condition === ConditionName.curse || condition == ConditionName.bless) {
                         const count = value.split(':')[1] ? +value.split(':')[1] : 1;
                         for (let i = 0; i < count; i++) {
                           characters
@@ -475,22 +475,7 @@ export class EventCardManager {
                               (c) => effect.type === EventCardEffectType.scenarioCondition || c.traits.some((t) => t === effect.values[0])
                             )
                             .forEach((c) => {
-                              if (gameManager.attackModifierManager.countUpcomingCurses(false) < 10) {
-                                gameManager.attackModifierManager.addModifierByType(c.attackModifierDeck, AttackModifierType.curse);
-                              }
-                            });
-                        }
-                      } else if (condition === ConditionName.bless) {
-                        const count = value.split(':')[1] ? +value.split(':')[1] : 1;
-                        for (let i = 0; i < count; i++) {
-                          characters
-                            .filter(
-                              (c) => effect.type === EventCardEffectType.scenarioCondition || c.traits.some((t) => t === effect.values[0])
-                            )
-                            .forEach((c) => {
-                              if (gameManager.attackModifierManager.countUpcomingBlesses() < 10) {
-                                gameManager.attackModifierManager.addModifierByType(c.attackModifierDeck, AttackModifierType.bless);
-                              }
+                              gameManager.attackModifierManager.addModifierByType(c.attackModifierDeck, AttackModifierType[condition]);
                             });
                         }
                       }
@@ -523,9 +508,7 @@ export class EventCardManager {
                 if (minus1) {
                   for (let i = 0; i < minus1; i++) {
                     characters.forEach((c) => {
-                      if (gameManager.attackModifierManager.countExtraMinus1() < 15) {
-                        gameManager.attackModifierManager.addModifierByType(c.attackModifierDeck, AttackModifierType.minus1extra);
-                      }
+                      gameManager.attackModifierManager.addModifierByType(c.attackModifierDeck, AttackModifierType.minus1extra);
                     });
                   }
                 }

--- a/src/app/game/businesslogic/ItemManager.ts
+++ b/src/app/game/businesslogic/ItemManager.ts
@@ -652,12 +652,12 @@ export class ItemManager {
     ).slice(0, count);
   }
 
-  applyEquippedItemEffects(character: Character) {
+  applyEquippedItemEffects(character: Character, immunitiesOnly: boolean = false) {
     character.immunities = [];
     character.progress.equippedItems.forEach((identifier) => {
       const item = gameManager.itemManager.getItem(identifier.name, identifier.edition, true);
       if (item) {
-        gameManager.itemManager.applyItemEffects(character, item, item.consumed === 'initial');
+        gameManager.itemManager.applyItemEffects(character, item, item.consumed === 'initial', immunitiesOnly);
         if (item.consumed === 'initial') {
           identifier.tags = [...(identifier.tags || []), ItemFlags.consumed];
         }
@@ -665,11 +665,13 @@ export class ItemManager {
     });
   }
 
-  applyItemEffects(character: Character, item: ItemData, equip: boolean = false) {
+  applyItemEffects(character: Character, item: ItemData, equip: boolean = false, immunitiesOnly: boolean = false) {
     if (item.effects) {
       item.effects.forEach((itemEffect) => {
         if ((!item.spent && !item.consumed) || equip || itemEffect.always) {
-          this.applyItemEffect(character, itemEffect);
+          if (itemEffect.type === ItemEffectType.immune || !immunitiesOnly) {
+            this.applyItemEffect(character, itemEffect);
+          }
         }
       });
     }

--- a/src/app/game/businesslogic/ItemManager.ts
+++ b/src/app/game/businesslogic/ItemManager.ts
@@ -1,7 +1,6 @@
 import { gameManager } from 'src/app/game/businesslogic/GameManager';
 import { settingsManager } from 'src/app/game/businesslogic/SettingsManager';
 import { Character } from 'src/app/game/model/Character';
-import { AttackModifier, AttackModifierType } from 'src/app/game/model/data/AttackModifier';
 import { Condition, ConditionName, ConditionType, EntityCondition } from 'src/app/game/model/data/Condition';
 import { Element, ElementState } from 'src/app/game/model/data/Element';
 import { AdditionalIdentifier, CountIdentifier, Identifier } from 'src/app/game/model/data/Identifier';
@@ -685,7 +684,7 @@ export class ItemManager {
     if (settingsManager.settings.characterItemsApply) {
       if (item.edition === 'fh' && item.id === 258 && character.health < character.maxHealth / 2) {
         character.health += 7;
-        gameManager.attackModifierManager.addModifier(character.attackModifierDeck, new AttackModifier(AttackModifierType.curse));
+        gameManager.entityManager.addCondition(character, character, new Condition(ConditionName.curse));
       }
     }
   }
@@ -706,22 +705,7 @@ export class ItemManager {
       case ItemEffectType.condition:
         const condition: ConditionName = ('' + effect.value).split(':')[0] as ConditionName;
         const value: number = ('' + effect.value).split(':').length > 1 ? +('' + effect.value).split(':')[1] : 1;
-
-        if (condition === ConditionName.bless) {
-          for (let i = 0; i < value; i++) {
-            if (gameManager.attackModifierManager.countUpcomingBlesses() < 10) {
-              gameManager.attackModifierManager.addModifier(character.attackModifierDeck, new AttackModifier(AttackModifierType.bless));
-            }
-          }
-        } else if (condition === ConditionName.curse) {
-          for (let i = 0; i < value; i++) {
-            if (gameManager.attackModifierManager.countUpcomingCurses(false) < 10) {
-              gameManager.attackModifierManager.addModifier(character.attackModifierDeck, new AttackModifier(AttackModifierType.curse));
-            }
-          }
-        } else {
-          gameManager.entityManager.addCondition(character, character, new Condition(condition, value));
-        }
+        gameManager.entityManager.addCondition(character, character, new Condition(condition, value));
         break;
       case ItemEffectType.immune:
         const immunity: ConditionName = ('' + effect.value) as ConditionName;

--- a/src/app/game/businesslogic/LootManager.ts
+++ b/src/app/game/businesslogic/LootManager.ts
@@ -204,9 +204,7 @@ export class LootManager {
       case TreasureRewardType.condition:
         if (typeof reward.value === 'string') {
           reward.value.split('+').forEach((condition) => {
-            if (!gameManager.entityManager.hasCondition(character, new Condition(condition as ConditionName))) {
-              gameManager.entityManager.addCondition(character, character, new Condition(condition as ConditionName));
-            }
+            gameManager.entityManager.addCondition(character, character, new Condition(condition as ConditionName));
           });
         }
         break;

--- a/src/app/game/businesslogic/ScenarioRulesManager.ts
+++ b/src/app/game/businesslogic/ScenarioRulesManager.ts
@@ -947,7 +947,7 @@ export class ScenarioRulesManager {
                   case 'permanentCondition':
                     const permanentCondition = new Condition(figureRule.value);
                     if (!gameManager.entityManager.hasCondition(entity, permanentCondition, true)) {
-                      gameManager.entityManager.addCondition(entity, figure, permanentCondition, true);
+                      gameManager.entityManager.addCondition(entity, figure, permanentCondition, true, true);
                     }
                     break;
                   case 'loseCondition':

--- a/src/app/game/businesslogic/ScenarioRulesManager.ts
+++ b/src/app/game/businesslogic/ScenarioRulesManager.ts
@@ -926,23 +926,7 @@ export class ScenarioRulesManager {
                     const conditionName = figureRule.value.split(':')[0];
                     const value = figureRule.value.split(':').length > 1 ? +figureRule.value.split(':')[1] : 1;
                     const gainCondition = new Condition(conditionName, value);
-                    if (gainCondition.name === ConditionName.curse) {
-                      for (let i = 0; i < value; i++) {
-                        gameManager.attackModifierManager.addModifierByType(
-                          gameManager.attackModifierManager.byFigure(figure),
-                          AttackModifierType.curse
-                        );
-                      }
-                    } else if (gainCondition.name === ConditionName.bless) {
-                      for (let i = 0; i < value; i++) {
-                        gameManager.attackModifierManager.addModifierByType(
-                          gameManager.attackModifierManager.byFigure(figure),
-                          AttackModifierType.bless
-                        );
-                      }
-                    } else if (!gameManager.entityManager.hasCondition(entity, gainCondition)) {
-                      gameManager.entityManager.addCondition(entity, figure, gainCondition);
-                    }
+                    gameManager.entityManager.addCondition(entity, figure, gainCondition);
                     break;
                   case 'permanentCondition':
                     const permanentCondition = new Condition(figureRule.value);

--- a/src/app/game/businesslogic/ScenarioRulesManager.ts
+++ b/src/app/game/businesslogic/ScenarioRulesManager.ts
@@ -2,7 +2,7 @@ import { moveItemInArray } from '@angular/cdk/drag-drop';
 import { gameManager } from 'src/app/game/businesslogic/GameManager';
 import { settingsManager } from 'src/app/game/businesslogic/SettingsManager';
 import { Character } from 'src/app/game/model/Character';
-import { AttackModifier, AttackModifierType } from 'src/app/game/model/data/AttackModifier';
+import { AttackModifierType } from 'src/app/game/model/data/AttackModifier';
 import { Condition, ConditionName, EntityCondition } from 'src/app/game/model/data/Condition';
 import { Element } from 'src/app/game/model/data/Element';
 import { FigureError, FigureErrorType } from 'src/app/game/model/data/FigureError';
@@ -1235,20 +1235,7 @@ export class ScenarioRulesManager {
               let value = +figureRule.value.split(':')[1];
               if (figureRule.type === 'amAdd') {
                 for (let i = 0; i < value; i++) {
-                  if (type === AttackModifierType.bless && gameManager.attackModifierManager.countUpcomingBlesses() >= 10) {
-                    return;
-                  } else if (
-                    type === AttackModifierType.curse &&
-                    gameManager.attackModifierManager.countUpcomingCurses(
-                      figure instanceof Monster && !figure.isAlly && !figure.isAllied
-                    ) >= 10
-                  ) {
-                    return;
-                  } else if (type === AttackModifierType.minus1 && gameManager.attackModifierManager.countExtraMinus1() >= 15) {
-                    return;
-                  } else {
-                    gameManager.attackModifierManager.addModifier(deck, new AttackModifier(type));
-                  }
+                  gameManager.attackModifierManager.addModifierByType(deck, type);
                 }
               } else {
                 let card = deck.cards.find((attackModifier, index) => {

--- a/src/app/game/businesslogic/SpecialActionsManager.spec.ts
+++ b/src/app/game/businesslogic/SpecialActionsManager.spec.ts
@@ -412,7 +412,7 @@ describe('SpecialActionsManager', () => {
 
       specialActionsManager.triggerSlotAfter(character, specialAction, false);
 
-      expect(addSpy).toHaveBeenCalledWith(character, character, new Condition(ConditionName.poison));
+      expect(addSpy).toHaveBeenCalledWith(character, character, new Condition(ConditionName.poison), false, true);
       expect(character.immunities).toEqual([]);
     });
 

--- a/src/app/game/businesslogic/SpecialActionsManager.ts
+++ b/src/app/game/businesslogic/SpecialActionsManager.ts
@@ -258,7 +258,7 @@ export class SpecialActionsManager {
           if (condition.types.includes(ConditionType.negative) && !condition.expired && condition.state !== EntityConditionState.removed) {
             condition.state = EntityConditionState.new;
             condition.state = EntityConditionState.new;
-            if (!character.immunities.includes(condition.name)) {
+            if (!character.immunities.includes(condition.name) && !condition.types.includes(ConditionType.amDeck)) {
               character.immunities.push(condition.name);
             }
           }
@@ -272,10 +272,14 @@ export class SpecialActionsManager {
       if (character.name === 'shackles' && specialAction.name === 'delayed_malady' && !character.tags.includes(specialAction.name)) {
         {
           character.immunities.forEach((immunity) => {
-            gameManager.entityManager.addCondition(character, character, new Condition(immunity));
+            const condition = new Condition(immunity);
+            if (!condition.types.includes(ConditionType.amDeck)) {
+              gameManager.entityManager.addCondition(character, character, new Condition(immunity), false, true);
+            }
           });
 
           character.immunities = [];
+          gameManager.itemManager.applyEquippedItemEffects(character, true);
         }
       }
 
@@ -310,6 +314,7 @@ export class SpecialActionsManager {
         });
 
         entity.immunities = [];
+        gameManager.itemManager.applyEquippedItemEffects(entity, true);
         entity.tags = entity.tags.filter((tag) => tag !== 'delayed_malady');
       }
 

--- a/src/app/game/model/data/Condition.ts
+++ b/src/app/game/model/data/Condition.ts
@@ -38,6 +38,7 @@ export enum ConditionType {
   monster = 'monster',
   objective = 'objective',
   upgrade = 'upgrade',
+  upgradable = 'upgradable',
   stack = 'stack',
   stackable = 'stackable',
   turn = 'turn',
@@ -151,6 +152,10 @@ export class Condition {
     if ([ConditionName.poison_x, ConditionName.wound_x].includes(this.name)) {
       this.types.push(ConditionType.upgrade);
       this.types.push(ConditionType.value);
+    }
+
+    if ([ConditionName.poison, ConditionName.wound].includes(this.name)) {
+      this.types.push(ConditionType.upgradable);
     }
 
     if ([ConditionName.chill, ConditionName.plague].includes(this.name)) {

--- a/src/app/game/model/data/Condition.ts
+++ b/src/app/game/model/data/Condition.ts
@@ -243,6 +243,7 @@ export class Condition {
         ConditionName.strengthen,
         ConditionName.bless,
         ConditionName.dodge,
+        ConditionName.empower,
         ConditionName.safeguard
       ].includes(this.name)
     ) {

--- a/src/app/ui/figures/attackmodifier/attackmodifierdeck-dialog.ts
+++ b/src/app/ui/figures/attackmodifier/attackmodifierdeck-dialog.ts
@@ -377,18 +377,16 @@ export class AttackModifierDeckDialogComponent implements OnInit {
 
   changeAttackModifier(type: AttackModifierType, value: number) {
     if (value > 0) {
-      if (type === AttackModifierType.bless && gameManager.attackModifierManager.countUpcomingBlesses() >= 10) {
-        return;
-      } else if (
-        type === AttackModifierType.curse &&
-        gameManager.attackModifierManager.countUpcomingCurses(!this.character && !this.ally) >= 10
-      ) {
-        return;
-      } else if (type === AttackModifierType.minus1 && gameManager.attackModifierManager.countExtraMinus1() >= 15) {
-        return;
+      let batch: AttackModifier[] = [];
+      if (type === AttackModifierType.bless) {
+        batch = gameManager.attackModifierManager.getBless(value);
+      } else if (type === AttackModifierType.curse) {
+        batch = gameManager.attackModifierManager.getCurse(!this.character && !this.ally, value);
+      } else if (type === AttackModifierType.minus1extra) {
+        batch = gameManager.attackModifierManager.getExtraMinus1(value);
       }
 
-      gameManager.attackModifierManager.addModifier(this.deck, new AttackModifier(type));
+      gameManager.attackModifierManager.addModifierBatch(this.deck, batch);
     } else if (value < 0) {
       const card = this.deck.cards.find((attackModifier, index) => {
         return attackModifier.type === type && index > this.deck.current;
@@ -497,11 +495,9 @@ export class AttackModifierDeckDialogComponent implements OnInit {
   changeEmpower(index: number, value: number) {
     if (this.empowerChars[index]) {
       this.before.emit(new AttackModiferDeckChange(this.deck, value < 0 ? 'removeEmpower' : 'addEmpower'));
-      const additional = gameManager.attackModifierManager.getAdditional(this.empowerChars[index], AttackModifierType.empower);
       if (value > 0) {
-        for (let i = 0; i < Math.min(value, additional.length); i++) {
-          gameManager.attackModifierManager.addModifier(this.deck, additional[i]);
-        }
+        const additional = gameManager.attackModifierManager.getAdditional(this.empowerChars[index], AttackModifierType.empower, value);
+        gameManager.attackModifierManager.addModifierBatch(this.deck, additional);
       } else {
         for (let i = 0; i < value * -1; i++) {
           const empower = this.deck.cards.find(
@@ -525,20 +521,18 @@ export class AttackModifierDeckDialogComponent implements OnInit {
   changeEnfeeble(index: number, value: number) {
     if (this.enfeebleChars[index]) {
       this.before.emit(new AttackModiferDeckChange(this.deck, value < 0 ? 'removeEnfeeble' : 'addEnfeeble'));
-      const additional = gameManager.attackModifierManager.getAdditional(this.enfeebleChars[index], AttackModifierType.enfeeble);
       if (value > 0) {
-        for (let i = 0; i < Math.min(value, additional.length); i++) {
-          gameManager.attackModifierManager.addModifier(this.deck, additional[i]);
-        }
+        const additional = gameManager.attackModifierManager.getAdditional(this.enfeebleChars[index], AttackModifierType.enfeeble, value);
+        gameManager.attackModifierManager.addModifierBatch(this.deck, additional);
       } else {
         for (let i = 0; i < value * -1; i++) {
           const enfeeble = this.deck.cards.find(
             (am, i) =>
-              this.empowerChars[index] &&
+              this.enfeebleChars[index] &&
               i > this.deck.current &&
               am.type === AttackModifierType.enfeeble &&
               am.id &&
-              am.id.startsWith('additional-' + this.empowerChars[index].name)
+              am.id.startsWith('additional-' + this.enfeebleChars[index].name)
           );
           if (enfeeble) {
             this.deck.cards.splice(this.deck.cards.indexOf(enfeeble), 1);

--- a/src/app/ui/figures/conditions/conditions.html
+++ b/src/app/ui/figures/conditions/conditions.html
@@ -33,7 +33,7 @@
             <span [ngClass]="{ stack: true }" class="value">{{ getValue(condition) | ghsValueSign }}</span>
           }
           @if (condition.types.includes(ConditionType.upgrade)) {
-            <span [ngClass]="{ stack: false }" class="value">{{ getValue(condition) }}</span>
+            <span class="value">{{ getValue(condition) }}</span>
           }
         </span>
         @if (isPermanent(condition.name)) {

--- a/src/app/ui/figures/conditions/conditions.html
+++ b/src/app/ui/figures/conditions/conditions.html
@@ -29,10 +29,11 @@
           }"
         >
           <img [src]="'./assets/images' + (settingsManager.settings.fhStyle ? '/fh' : '') + '/condition/' + condition.name + '.svg'" />
-          @if (condition.types.includes(ConditionType.stack) || condition.types.includes(ConditionType.upgrade)) {
-            <span [ngClass]="{ stack: condition.types.includes(ConditionType.stack) }" class="value">{{
-              getValue(condition) | ghsValueSign
-            }}</span>
+          @if (condition.types.includes(ConditionType.stack)) {
+            <span [ngClass]="{ stack: true }" class="value">{{ getValue(condition) | ghsValueSign }}</span>
+          }
+          @if (condition.types.includes(ConditionType.upgrade)) {
+            <span [ngClass]="{ stack: false }" class="value">{{ getValue(condition) }}</span>
           }
         </span>
         @if (isPermanent(condition.name)) {

--- a/src/app/ui/figures/conditions/conditions.ts
+++ b/src/app/ui/figures/conditions/conditions.ts
@@ -281,7 +281,7 @@ export class ConditionsComponent implements OnInit {
 
   dec(condition: Condition) {
     condition.value = this.getValue(condition) - 1;
-    if (condition.value < 1 && !condition.types.includes(ConditionType.stack) && !condition.types.includes(ConditionType.upgrade)) {
+    if (condition.value < 1 && !condition.types.includes(ConditionType.stack)) {
       condition.value = 1;
     }
     this.checkUpdate(condition);

--- a/src/app/ui/figures/entities-menu/entities-menu-dialog.html
+++ b/src/app/ui/figures/entities-menu/entities-menu-dialog.html
@@ -574,7 +574,8 @@
                 [ngClass]="{
                   disabled:
                     gameManager.attackModifierManager.countUpcomingBlesses() +
-                      bless * (entities.length - countBlocking(ConditionName.bless, bless)) >=
+                      bless * entities.length -
+                      countBlocking(ConditionName.bless, bless) >=
                       10 ||
                     entityImmunities.includes(ConditionName.bless) ||
                     (!!figure && !!entity && gameManager.entityManager.isImmune(entity, figure, ConditionName.bless))

--- a/src/app/ui/figures/entities-menu/entities-menu-dialog.html
+++ b/src/app/ui/figures/entities-menu/entities-menu-dialog.html
@@ -573,7 +573,9 @@
                 class="button"
                 [ngClass]="{
                   disabled:
-                    gameManager.attackModifierManager.countUpcomingBlesses() + bless * entities.length >= 10 ||
+                    gameManager.attackModifierManager.countUpcomingBlesses() +
+                      bless * (entities.length - countBlocking(ConditionName.bless, bless)) >=
+                      10 ||
                     entityImmunities.includes(ConditionName.bless) ||
                     (!!figure && !!entity && gameManager.entityManager.isImmune(entity, figure, ConditionName.bless))
                 }"
@@ -631,7 +633,10 @@
                 class="button"
                 [ngClass]="{
                   disabled:
-                    (!!figure ? gameManager.attackModifierManager.countUpcomingCurses(isMonster) : 0) + curse * entities.length >= 10 ||
+                    (!!figure ? gameManager.attackModifierManager.countUpcomingCurses(isMonster) : 0) +
+                      curse * entities.length -
+                      countBlocking(ConditionName.curse, curse) >=
+                      10 ||
                     entityImmunities.includes(ConditionName.curse) ||
                     (!!figure && !!entity && gameManager.entityManager.isImmune(entity, figure, ConditionName.curse))
                 }"
@@ -656,7 +661,7 @@
                     (!!figure && !!entity && gameManager.entityManager.isImmune(entity, figure, ConditionName.empower))
                 }"
                 tabclick
-                (singleClick)="!empowerChar ? amHelper.selectAdditionalAM(AttackModifierType.empower) : (empower -= 1)"
+                (singleClick)="empower -= 1"
                 [repeat]="true"
               >
                 <img class="ghs-svg" src="./assets/images/minus.svg" />
@@ -701,7 +706,7 @@
                 class="button"
                 [ngClass]="{
                   disabled:
-                    (empowerChar && empower >= empowerMax) ||
+                    (empowerChar && empower - countBlocking(ConditionName.empower, empower) >= empowerMax) ||
                     entityImmunities.includes(ConditionName.empower) ||
                     (!!figure && !!entity && gameManager.entityManager.isImmune(entity, figure, ConditionName.empower))
                 }"
@@ -726,7 +731,7 @@
                     (!!figure && !!entity && gameManager.entityManager.isImmune(entity, figure, ConditionName.enfeeble))
                 }"
                 tabclick
-                (singleClick)="!enfeebleChar ? amHelper.selectAdditionalAM(AttackModifierType.enfeeble) : (enfeeble -= 1)"
+                (singleClick)="enfeeble -= 1"
                 [repeat]="true"
               >
                 <img class="ghs-svg" src="./assets/images/minus.svg" />
@@ -771,7 +776,7 @@
                 class="button"
                 [ngClass]="{
                   disabled:
-                    (enfeebleChar && enfeeble >= enfeebleMax) ||
+                    (enfeebleChar && enfeeble - countBlocking(ConditionName.enfeeble, enfeeble) >= enfeebleMax) ||
                     entityImmunities.includes(ConditionName.enfeeble) ||
                     (!!figure && !!entity && gameManager.entityManager.isImmune(entity, figure, ConditionName.enfeeble))
                 }"

--- a/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
+++ b/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
@@ -365,7 +365,7 @@ export class EntitiesMenuDialogComponent {
     this.updateFigures();
   }
 
-  countBlocking(condition: ConditionName, count: number = 1) {
+  countBlocking(condition: ConditionName, count: number = 1): number {
     const safeeguardEnabled =
       new Condition(condition).types.includes(ConditionType.negative) &&
       settingsManager.settings.applyConditions &&

--- a/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
+++ b/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
@@ -9,7 +9,7 @@ import { Character } from 'src/app/game/model/Character';
 import { Action, ActionType, ActionValueType } from 'src/app/game/model/data/Action';
 import { AttackModifierType } from 'src/app/game/model/data/AttackModifier';
 import { CharacterSpecialAction } from 'src/app/game/model/data/CharacterStat';
-import { ConditionName, ConditionType, EntityCondition } from 'src/app/game/model/data/Condition';
+import { Condition, ConditionName, ConditionType, EntityCondition } from 'src/app/game/model/data/Condition';
 import { EventCardCondition, EventCardEffect } from 'src/app/game/model/data/EventCard';
 import { MonsterData } from 'src/app/game/model/data/MonsterData';
 import { MonsterType } from 'src/app/game/model/data/MonsterType';
@@ -363,6 +363,23 @@ export class EntitiesMenuDialogComponent {
   setFilter(filter: 'character' | 'monster' | 'allies' | 'enemies' | 'objectives' | undefined = undefined) {
     this.filter = filter;
     this.updateFigures();
+  }
+
+  countBlocking(condition: ConditionName, count: number = 1) {
+    const safeeguardEnabled =
+      new Condition(condition).types.includes(ConditionType.negative) &&
+      settingsManager.settings.applyConditions &&
+      !settingsManager.settings.applyConditionsExcludes.includes(ConditionName.safeguard);
+    const safeguard = new Condition(ConditionName.safeguard);
+    return this.entities.reduce((sum, entity) => {
+      if (gameManager.entityManager.isImmune(entity, this.figureForEntity(entity), condition)) {
+        return sum + count;
+      }
+      if (safeeguardEnabled && gameManager.entityManager.hasCondition(entity, safeguard)) {
+        return sum + 1;
+      }
+      return sum;
+    }, 0);
   }
 
   figureForEntity(entity: Entity): Figure {

--- a/src/app/ui/figures/entities-menu/helpers/attack-modifiers.ts
+++ b/src/app/ui/figures/entities-menu/helpers/attack-modifiers.ts
@@ -1,9 +1,9 @@
 import { gameManager } from 'src/app/game/businesslogic/GameManager';
 import { settingsManager } from 'src/app/game/businesslogic/SettingsManager';
 import { Character } from 'src/app/game/model/Character';
-import { AttackModifier, AttackModifierDeck, AttackModifierType } from 'src/app/game/model/data/AttackModifier';
+import { AttackModifierDeck, AttackModifierType } from 'src/app/game/model/data/AttackModifier';
+import { Condition, ConditionName } from 'src/app/game/model/data/Condition';
 import { Entity } from 'src/app/game/model/Entity';
-import { Monster } from 'src/app/game/model/Monster';
 import { ObjectiveContainer } from 'src/app/game/model/ObjectiveContainer';
 import { AdditionalAMSelectDialogComponent } from 'src/app/ui/figures/entities-menu/additional-am-select/additional-am-select';
 import type { EntitiesMenuDialogComponent } from 'src/app/ui/figures/entities-menu/entities-menu-dialog';
@@ -135,19 +135,8 @@ export class AttackModifierHelper {
   changeAttackModifier(entity: Entity, type: AttackModifierType, value: number) {
     const figure = this.component.figureForEntity(entity);
     const amDeck = gameManager.attackModifierManager.byFigure(figure);
-    const isMonster =
-      (figure instanceof Monster &&
-        ((!figure.isAlly && !figure.isAllied) || (!settingsManager.settings.alwaysAllyAttackModifierDeck && !gameManager.fhRules(true)))) ||
-      (figure instanceof ObjectiveContainer && figure.amDeck === 'M');
     if (value > 0) {
-      for (let i = 0; i < value; i++) {
-        if (
-          (type === AttackModifierType.bless && gameManager.attackModifierManager.countUpcomingBlesses() < 10) ||
-          (type === AttackModifierType.curse && gameManager.attackModifierManager.countUpcomingCurses(isMonster) < 10)
-        ) {
-          gameManager.attackModifierManager.addModifier(amDeck, new AttackModifier(type));
-        }
-      }
+      gameManager.entityManager.addCondition(entity, figure, new Condition(type, value));
     } else if (value < 0) {
       let card = amDeck.cards.find((attackModifier, index) => attackModifier.type === type && index > amDeck.current);
       while (card && value < 0) {
@@ -227,18 +216,14 @@ export class AttackModifierHelper {
           const figure = this.component.figureForEntity(entity);
           const amDeck = gameManager.attackModifierManager.byFigure(figure);
           if (this.component.empowerChar && this.component.empower > 0) {
-            const additional = gameManager.attackModifierManager.getAdditional(this.component.empowerChar, AttackModifierType.empower);
-            for (let i = 0; i < Math.min(this.component.empower, additional.length); i++) {
-              const count =
-                this.component.empowerChar.additionalModifier
-                  .filter((perk) => perk.attackModifier && perk.attackModifier.type === AttackModifierType.empower)
-                  .map((perk) => perk.count)
-                  .reduce((a, b) => a + b) -
-                gameManager.attackModifierManager.countUpcomingAdditional(this.component.empowerChar, AttackModifierType.empower);
-              if (count > 0) {
-                gameManager.attackModifierManager.addModifier(amDeck, additional[i]);
-              }
-            }
+            gameManager.entityManager.addCondition(
+              entity,
+              figure,
+              new Condition(ConditionName.empower, this.component.empower),
+              false,
+              false,
+              this.component.empowerChar
+            );
           } else {
             for (let i = 0; i < this.component.empower * -1; i++) {
               const empower = amDeck.cards.find((am, index) => index > amDeck.current && am.type === AttackModifierType.empower);
@@ -266,18 +251,14 @@ export class AttackModifierHelper {
           const figure = this.component.figureForEntity(entity);
           const amDeck = gameManager.attackModifierManager.byFigure(figure);
           if (this.component.enfeebleChar && this.component.enfeeble > 0) {
-            const additional = gameManager.attackModifierManager.getAdditional(this.component.enfeebleChar, AttackModifierType.enfeeble);
-            for (let i = 0; i < Math.min(this.component.enfeeble, additional.length); i++) {
-              const count =
-                this.component.enfeebleChar.additionalModifier
-                  .filter((perk) => perk.attackModifier && perk.attackModifier.type === AttackModifierType.enfeeble)
-                  .map((perk) => perk.count)
-                  .reduce((a, b) => a + b) -
-                gameManager.attackModifierManager.countUpcomingAdditional(this.component.enfeebleChar, AttackModifierType.enfeeble);
-              if (count > 0) {
-                gameManager.attackModifierManager.addModifier(amDeck, additional[i]);
-              }
-            }
+            gameManager.entityManager.addCondition(
+              entity,
+              figure,
+              new Condition(ConditionName.enfeeble, this.component.enfeeble),
+              false,
+              false,
+              this.component.enfeebleChar
+            );
           } else {
             for (let i = 0; i < this.component.enfeeble * -1; i++) {
               const enfeeble = amDeck.cards.find((am, index) => index > amDeck.current && am.type === AttackModifierType.enfeeble);

--- a/src/app/ui/figures/entities-menu/helpers/attack-modifiers.ts
+++ b/src/app/ui/figures/entities-menu/helpers/attack-modifiers.ts
@@ -68,7 +68,8 @@ export class AttackModifierHelper {
 
     if (this.component.figure) {
       const amDeck = gameManager.attackModifierManager.byFigure(this.component.figure);
-      this.component.empowerMin = this.countUpcomingAttackModifier(amDeck, AttackModifierType.empower);
+      const empowerPrefix = 'additional-' + (this.component.empowerChar?.name ?? '');
+      this.component.empowerMin = this.countUpcomingAttackModifier(amDeck, AttackModifierType.empower, empowerPrefix);
       this.component.empowerMax = this.component.empowerChar
         ? this.component.empowerChar.additionalModifier
             .filter((perk) => perk.attackModifier && perk.attackModifier.type === AttackModifierType.empower)
@@ -76,7 +77,8 @@ export class AttackModifierHelper {
             .reduce((a, b) => a + b) -
           gameManager.attackModifierManager.countUpcomingAdditional(this.component.empowerChar, AttackModifierType.empower)
         : -1;
-      this.component.enfeebleMin = this.countUpcomingAttackModifier(amDeck, AttackModifierType.enfeeble);
+      const enfeeblePrefix = 'additional-' + (this.component.enfeebleChar?.name ?? '');
+      this.component.enfeebleMin = this.countUpcomingAttackModifier(amDeck, AttackModifierType.enfeeble, enfeeblePrefix);
       this.component.enfeebleMax = this.component.enfeebleChar
         ? this.component.enfeebleChar.additionalModifier
             .filter((perk) => perk.attackModifier && perk.attackModifier.type === AttackModifierType.enfeeble)
@@ -225,8 +227,11 @@ export class AttackModifierHelper {
               this.component.empowerChar
             );
           } else {
+            const idPrefix = 'additional-' + (this.component.empowerChar?.name ?? '');
             for (let i = 0; i < this.component.empower * -1; i++) {
-              const empower = amDeck.cards.find((am, index) => index > amDeck.current && am.type === AttackModifierType.empower);
+              const empower = amDeck.cards.find(
+                (am, index) => index > amDeck.current && am.type === AttackModifierType.empower && am.id.startsWith(idPrefix)
+              );
               if (empower) {
                 amDeck.cards.splice(amDeck.cards.indexOf(empower), 1);
               }
@@ -260,8 +265,11 @@ export class AttackModifierHelper {
               this.component.enfeebleChar
             );
           } else {
+            const idPrefix = 'additional-' + (this.component.enfeebleChar?.name ?? '');
             for (let i = 0; i < this.component.enfeeble * -1; i++) {
-              const enfeeble = amDeck.cards.find((am, index) => index > amDeck.current && am.type === AttackModifierType.enfeeble);
+              const enfeeble = amDeck.cards.find(
+                (am, index) => index > amDeck.current && am.type === AttackModifierType.enfeeble && am.id.startsWith(idPrefix)
+              );
               if (enfeeble) {
                 amDeck.cards.splice(amDeck.cards.indexOf(enfeeble), 1);
               }

--- a/src/app/ui/figures/entities-menu/helpers/attack-modifiers.ts
+++ b/src/app/ui/figures/entities-menu/helpers/attack-modifiers.ts
@@ -230,7 +230,7 @@ export class AttackModifierHelper {
             const idPrefix = 'additional-' + (this.component.empowerChar?.name ?? '');
             for (let i = 0; i < this.component.empower * -1; i++) {
               const empower = amDeck.cards.find(
-                (am, index) => index > amDeck.current && am.type === AttackModifierType.empower && am.id.startsWith(idPrefix)
+                (am, index) => index > amDeck.current && am.type === AttackModifierType.empower && am.id && am.id.startsWith(idPrefix)
               );
               if (empower) {
                 amDeck.cards.splice(amDeck.cards.indexOf(empower), 1);
@@ -268,7 +268,7 @@ export class AttackModifierHelper {
             const idPrefix = 'additional-' + (this.component.enfeebleChar?.name ?? '');
             for (let i = 0; i < this.component.enfeeble * -1; i++) {
               const enfeeble = amDeck.cards.find(
-                (am, index) => index > amDeck.current && am.type === AttackModifierType.enfeeble && am.id.startsWith(idPrefix)
+                (am, index) => index > amDeck.current && am.type === AttackModifierType.enfeeble && am.id && am.id.startsWith(idPrefix)
               );
               if (enfeeble) {
                 amDeck.cards.splice(amDeck.cards.indexOf(enfeeble), 1);

--- a/src/app/ui/figures/entities-menu/helpers/conditions.ts
+++ b/src/app/ui/figures/entities-menu/helpers/conditions.ts
@@ -17,21 +17,21 @@ export class ConditionHelper {
         if (
           !existing &&
           self.every((otherEntity) =>
-            otherEntity.entityConditions.find((other) => other.name === entityCondition.name && other.state === entityCondition.state)
+            otherEntity.entityConditions.find(
+              (other) =>
+                other.name === entityCondition.name &&
+                other.state === entityCondition.state &&
+                (!entityCondition.types.includes(ConditionType.upgrade) || other.value === entityCondition.value)
+            )
           )
         ) {
           const condition = new EntityCondition(entityCondition.name, entityCondition.value);
           condition.state = entityCondition.state;
           condition.lastState = entityCondition.lastState;
-          if (condition.types.includes(ConditionType.stack) || condition.types.includes(ConditionType.upgrade)) {
+          if (condition.types.includes(ConditionType.stack)) {
             condition.value = 0;
           }
           this.component.entityConditions.push(condition);
-        } else if (
-          existing &&
-          (entityCondition.types.includes(ConditionType.stack) || entityCondition.types.includes(ConditionType.upgrade))
-        ) {
-          existing.value = 0;
         }
       });
 
@@ -69,31 +69,69 @@ export class ConditionHelper {
       });
 
     this.component.entityConditions
-      .filter((condition) =>
-        this.component.entities.some((entity) => {
-          const entityCondition = entity.entityConditions.find(
-            (entityCondition) => entityCondition.name === condition.name && !entityCondition.expired
-          );
-          return condition.types.includes(ConditionType.stack) || (condition.types.includes(ConditionType.upgrade) && entityCondition);
-        })
+      .filter(
+        (condition) =>
+          condition.types.includes(ConditionType.stack) &&
+          condition.state !== EntityConditionState.new &&
+          condition.value != 0 &&
+          this.component.entities.some((entity) =>
+            entity.entityConditions.find((entityCondition) => entityCondition.name === condition.name && !entityCondition.expired)
+          )
       )
       .forEach((condition) => {
-        this.component.before('setConditionValue', condition.name, Math.max(0, condition.value));
+        this.component.before('setConditionValue', condition.name, condition.value);
         this.component.entities.forEach((entity) => {
           const figure = this.component.figureForEntity(entity);
           const entityCondition = entity.entityConditions.find(
             (entityCondition) => entityCondition.name === condition.name && !entityCondition.expired
           );
-          if ((condition.types.includes(ConditionType.stack) || condition.types.includes(ConditionType.upgrade)) && entityCondition) {
-            entityCondition.value += condition.value;
-
-            if (entityCondition.name === ConditionName.plague && entityCondition.value > 3) {
-              entityCondition.value = 3;
+          if (condition.types.includes(ConditionType.stack) && entityCondition) {
+            if (condition.value < 0) {
+              entityCondition.value += condition.value;
+            } else if (condition.value > 0) {
+              gameManager.entityManager.addCondition(entity, figure, condition);
             }
-
             if (entityCondition.value <= 0) {
               gameManager.entityManager.removeCondition(entity, figure, entityCondition);
             }
+          }
+        });
+        gameManager.stateManager.after();
+      });
+
+    this.component.entityConditions
+      .filter(
+        (condition) =>
+          condition.types.includes(ConditionType.upgrade) &&
+          condition.value > 0 &&
+          ![EntityConditionState.new, EntityConditionState.removed].includes(condition.state)
+      )
+      .filter((condition) => {
+        const sample = this.component.entities[0]?.entityConditions.find(
+          (entityCondition) => entityCondition.name === condition.name && !entityCondition.expired
+        );
+        return (
+          sample &&
+          sample.value !== condition.value &&
+          this.component.entities.every((entity) =>
+            entity.entityConditions.some(
+              (entityCondition) =>
+                entityCondition.name === condition.name && !entityCondition.expired && entityCondition.value === sample.value
+            )
+          )
+        );
+      })
+      .forEach((condition) => {
+        this.component.before('setConditionValue', condition.name, condition.value);
+        this.component.entities.forEach((entity) => {
+          const figure = this.component.figureForEntity(entity);
+          const entityCondition = entity.entityConditions.find(
+            (entityCondition) => entityCondition.name === condition.name && !entityCondition.expired
+          );
+          if (entityCondition && condition.value < entityCondition.value) {
+            entityCondition.value = condition.value;
+          } else {
+            gameManager.entityManager.addCondition(entity, figure, condition);
           }
         });
         gameManager.stateManager.after();

--- a/src/app/ui/figures/entities-menu/helpers/conditions.ts
+++ b/src/app/ui/figures/entities-menu/helpers/conditions.ts
@@ -8,6 +8,8 @@ export class ConditionHelper {
 
   update() {
     this.component.entityConditions = [];
+    this.component.entityImmunities = [];
+    this.component.initialImmunities = [];
 
     this.component.entities.forEach((entity, index, self) => {
       entity.entityConditions.forEach((entityCondition) => {

--- a/src/app/ui/figures/entities-menu/helpers/conditions.ts
+++ b/src/app/ui/figures/entities-menu/helpers/conditions.ts
@@ -144,12 +144,19 @@ export class ConditionHelper {
 
             if (entityCondition.state === EntityConditionState.removed) {
               gameManager.entityManager.removeCondition(entity, figure, entityCondition, entityCondition.permanent);
-            } else if (!gameManager.entityManager.isImmune(entity, figure, entityCondition.name)) {
+            } else {
+              const shacklesImmunity =
+                entity instanceof Character &&
+                entity.name === 'shackles' &&
+                !entity.absent &&
+                entity.tags.includes('delayed_malady') &&
+                entityCondition.types.includes(ConditionType.negative) &&
+                !entityCondition.types.includes(ConditionType.amDeck);
               if (
                 entityCondition.state === EntityConditionState.new ||
                 !gameManager.entityManager.hasCondition(entity, entityCondition, entityCondition.permanent)
               ) {
-                gameManager.entityManager.addCondition(entity, figure, entityCondition, entityCondition.permanent);
+                gameManager.entityManager.addCondition(entity, figure, entityCondition, entityCondition.permanent, shacklesImmunity);
               }
 
               if (entityCondition.state === EntityConditionState.roundExpire || entityCondition.state === EntityConditionState.expire) {
@@ -161,14 +168,7 @@ export class ConditionHelper {
                 });
               }
 
-              if (
-                entity instanceof Character &&
-                entity.name === 'shackles' &&
-                !entity.absent &&
-                entity.tags.includes('delayed_malady') &&
-                entityCondition.types.includes(ConditionType.negative) &&
-                !entity.immunities.includes(entityCondition.name)
-              ) {
+              if (shacklesImmunity && !entity.immunities.includes(entityCondition.name)) {
                 entity.immunities.push(entityCondition.name);
                 this.component.entityImmunities.push(entityCondition.name);
               }

--- a/src/app/ui/figures/entities-menu/helpers/special-actions.ts
+++ b/src/app/ui/figures/entities-menu/helpers/special-actions.ts
@@ -116,6 +116,7 @@ export class SpecialActionsHelper {
             entity.entityConditions.forEach((condition) => {
               if (
                 condition.types.includes(ConditionType.negative) &&
+                !condition.types.includes(ConditionType.amDeck) &&
                 !condition.expired &&
                 condition.state !== EntityConditionState.removed &&
                 !this.component.entityConditions.find(

--- a/src/app/ui/figures/entities-menu/helpers/special-actions.ts
+++ b/src/app/ui/figures/entities-menu/helpers/special-actions.ts
@@ -1,7 +1,7 @@
 import { gameManager } from 'src/app/game/businesslogic/GameManager';
 import { Character } from 'src/app/game/model/Character';
 import { CharacterSpecialAction } from 'src/app/game/model/data/CharacterStat';
-import { Condition, ConditionName, ConditionType, EntityConditionState } from 'src/app/game/model/data/Condition';
+import { ConditionName, ConditionType, EntityConditionState } from 'src/app/game/model/data/Condition';
 import { Summon } from 'src/app/game/model/Summon';
 import type { EntitiesMenuDialogComponent } from 'src/app/ui/figures/entities-menu/entities-menu-dialog';
 
@@ -106,9 +106,6 @@ export class SpecialActionsHelper {
           if (entity.name === 'lightning' && specialTagsToAdd.includes('careless-charge')) {
             entity.immunities = gameManager.conditionsForTypes('character', 'negative').map((condition) => condition.name);
             entity.immunities.push(ConditionName.curse);
-            if (gameManager.entityManager.hasCondition(this.component.entity, new Condition(ConditionName.enfeeble))) {
-              entity.immunities.push(ConditionName.enfeeble);
-            }
             this.component.entityImmunities = character.immunities;
           }
 

--- a/src/app/ui/header/menu/settings/settings.ts
+++ b/src/app/ui/header/menu/settings/settings.ts
@@ -86,7 +86,7 @@ export class SettingsMenuComponent {
           this.applyConditionsExcludes.push(condition);
         }
 
-        if (condition.types.includes(ConditionType.autoApply)) {
+        if (condition.types.includes(ConditionType.autoApply) && condition.name !== ConditionName.safeguard) {
           this.activeApplyConditionsAuto.push(condition);
         }
 


### PR DESCRIPTION
# Description

The intent of this is mainly to fix safeguard, but a handful of vaguely related things got touched in the process, as I discovered lots of little oddities that were related to or could be handled better thanks to the safeguard code changes.

A subtheme of the changes was to make checks that were done at basically all places code is called (like component limits for curses or immunity for conditions) checked by default inside the methods usually used to make the changes. That makes the calling code a lot simpler and less error prone.

Fixes #1046

The changes fall into some main themes:
1. Attack modifier handling changes in preparation for use with conditions like curse.
    Inspired by how `AttackModifierManager.getAdditional` works, returning an array of modifier cards but respecting component limits, I added similar methods for other common modifier types. Then I added a method to batch add modifiers, intended to accept the outputs of those new methods. With those changes in place, I updated things to use them.
    - Made `addModifierbyType` to respect component limits by default, with an option to override.
    - Made some things that make bulk deck changes use these methods.
    - Made various things that were wrongly using regular minus1 cards instead of minus1extra use the right one, and now respect component limits.
2. Fixed some safeguard bugs.
    - Check for safeguard at beginning of `addCondition` so we can fail fast.
    - Make it work better with stackable and upgrade conditions (remove one from stackable, but block a whole upgrade application).
3. Immunity changes.
    - `addCondition` now checks immunity by default (with an option to override, which also overrides safeguard).
    - Removed now redundant immunity checks from a lot of places.
    - Minor bugfixes with some immunity stuff like Delayed Malady
4. Add deck conditions (curse/bless/empower/enfeeble) support to `EntityManager.addCondition`.
    This is the real meat of the code change. With the other changes in place I could use the new attack modifier code to help add these conditions and count on the safeguard and immunity fixes to make them work correctly.
    - Moved most of the previous `addCondition` logic to an `addStandardCondition` method and added a new `addDeckCondition` method. Now `addCondition` mostly just calls one of those, and does safeguard, immunity, and challenge stuff.
    - For empower/enfeeble it needs to know where to get cards from, so there's a new optional `deckSource` parameter. I don't love this, but fixing it will require even more sweeping changes so this was the simplest for now.
    - Almost everything that adds curse/bless was changed to call `addCondition`. I left event cards and first round scenario rules, since some of those are worded differently and in any case could be ambiguous timing with safeguard from other events. The handful of scenarios that used the condition instead of `amAdd` at start, (or vice versa for later rooms) I switched to be more consistent. It might be worth special casing start of scenario rules to bypass immunity/safeguard instead so that data entry doesn't have to remember these need to be `amAdd` and not `gainCondition`.
5. Entities menu improvements.
    I had to fiddle around with the entities menu a bunch in testing, and as a result found myself finding and fixing some quirks around using it with conditions.
    -With safeguard and immunity working with curse and bless, I added some logic to keep buttons to add those conditions enabled if some would adds would get prevented.
    - Stack and upgrade conditions were made to work better with the safeguard change. So added stacks always call `addCondition` rather than modifying the value directly, so some could be blocked by safeguard. And upgrade conditions.
    - Upgrade conditions overwrite the base versions, and the highest value prevails (so for example wound or  wound 2 doesn't land if you have wound 3, but it properly gets eaten by safeguard even if it wouldn't stick).
    - Entities menu only shows an upgrade condition as initially on if all selected units have the same value (the code for this is kind of ugly and I'm sure it'll almost never get used, but fixing it helped a lot in testing).
    - Some minor bugs around empower/enfeeble were fixed.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
   Not exactly breaking, but if people add a bunch of curse/bless at once it may no longer distribute them fairly. This is correct if the interaction matches a single game ability (say a forest imp attacking two targets with curse, curse) because targets should be resolved sequentially. But it's incorrect if players batch game actions together (say handling all the attacks for multiple imps, then bulk adding curses at the end). Not sure which scenario is more important to get right.
- [x] Data fix (fixes incorrect data)

# Checklist:

- [x] I have performed a self-review of my code
- [x] (-ish) I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution