### PR TITLE
Small Entities menu UX improvements.

### DIFF
--- a/src/app/ui/figures/entities-menu/entities-menu-dialog.html
+++ b/src/app/ui/figures/entities-menu/entities-menu-dialog.html
@@ -204,7 +204,9 @@
               class="name"
               [ngClass]="{ 'change-entity': !!monsterEntity }"
               tabclick
-              (click)="monsterHelper.changeMonsterEntity()"
+              ghs-pointer-input
+              (singleClick)="monsterEntity ? monsterHelper.changeMonsterEntity() : toggleMonster(monster)"
+              (doubleClick)="monsterEntity ? monsterHelper.changeMonsterEntity() : toggleExceptMonster(monster)"
               [ghs-tooltip]="'entities.title.monster' + (!!entity ? 'Entity' : '')"
               [ghs-label-args]="[...gameManager.entityManager.titleInfo(entity, monster), !!monsterEntity ? monsterEntity.type : '']"
               [originX]="'center'"
@@ -263,6 +265,9 @@
 
             <div
               class="name"
+              ghs-pointer-input
+              (singleClick)="!figure && toggleMonster(objective)"
+              (doubleClick)="!figure && toggleExceptMonster(objective)"
               [ghs-tooltip]="'entities.title.objective' + (!!entity ? 'Entity' : '')"
               [ghs-label-args]="gameManager.entityManager.titleInfo(entity, objective)"
               [originX]="'center'"

--- a/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
+++ b/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
@@ -396,10 +396,35 @@ export class EntitiesMenuDialogComponent {
     }
   }
 
-  toggleAll(select: boolean) {
-    this.entities = [];
+  toggleMonster(figure: Monster | ObjectiveContainer) {
+    const monsters: Entity[] = figure.entities;
+    if (monsters.some((entitiy) => !this.entities.includes(entitiy))) {
+      figure.entities.forEach((entity) => {
+        if (!this.entities.includes(entity)) {
+          this.entities.push(entity);
+        }
+      });
+    } else {
+      figure.entities.forEach((entity) => {
+        const index = this.entities.indexOf(entity);
+        if (index != -1) {
+          this.entities.splice(index, 1);
+        }
+      });
+    }
+  }
+
+  toggleExceptMonster(figure: Monster | ObjectiveContainer) {
+    const monsters: Entity[] = figure.entities;
+    const active = this.entities.filter((entity) => monsters.includes(entity));
+    const select = this.allEntities.length - monsters.length != this.entities.length - active.length;
+    this.toggleAll(select, monsters);
+  }
+
+  toggleAll(select: boolean, except: Entity[] = []) {
+    this.entities = except.length != 0 ? (this.entities = this.entities.filter((entity) => except.includes(entity))) : [];
     if (select) {
-      this.allEntities.forEach((entity) => this.entities.push(entity));
+      this.allEntities.filter((entity) => !except.includes(entity)).forEach((entity) => this.entities.push(entity));
     }
   }
 

--- a/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
+++ b/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
@@ -150,7 +150,7 @@ export class EntitiesMenuDialogComponent {
   figure: Figure | undefined;
   entity: Entity | undefined;
   figures: Figure[] = [];
-  entities: Entity[];
+  entities: Entity[] = [];
   allEntities: Entity[] = [];
   filter: 'character' | 'monster' | 'allies' | 'enemies' | 'objectives' | undefined;
   filters: ('character' | 'monster' | 'allies' | 'enemies' | 'objectives' | undefined)[] = [
@@ -253,7 +253,10 @@ export class EntitiesMenuDialogComponent {
     }
 
     if (!this.figure && !this.entity) {
-      this.updateFigures();
+      this.updateFigures(true);
+    } else {
+      this.allEntities.forEach((entity) => this.entities.push(entity));
+      this.update();
     }
 
     this.dialogRef.closed.subscribe({
@@ -263,13 +266,9 @@ export class EntitiesMenuDialogComponent {
         }
       }
     });
-
-    this.entities = [];
-    this.allEntities.forEach((entity) => this.entities.push(entity));
-    this.update();
   }
 
-  updateFigures() {
+  updateFigures(selectAll: boolean = false) {
     if (gameManager.game.figures.find((figure) => figure instanceof Character) === undefined) {
       this.filters = this.filters.filter((v) => v !== 'character');
     } else if (!this.filters.includes('character')) {
@@ -323,6 +322,7 @@ export class EntitiesMenuDialogComponent {
             this.filter === 'objectives'))
     );
 
+    selectAll ||= this.entities.length === this.allEntities.length;
     this.allEntities = [];
 
     this.figures.forEach((figure) => {
@@ -333,9 +333,11 @@ export class EntitiesMenuDialogComponent {
       }
     });
 
-    if (!this.entities || this.entities.length) {
+    if (selectAll || (this.entities.length && !this.entities.some((entity) => this.allEntities.includes(entity)))) {
       this.entities = [];
       this.allEntities.forEach((entity) => this.entities.push(entity));
+    } else {
+      this.entities = this.entities.filter((entity) => this.allEntities.includes(entity));
     }
     this.update();
   }

--- a/src/app/ui/figures/entities-menu/helpers/marker.ts
+++ b/src/app/ui/figures/entities-menu/helpers/marker.ts
@@ -11,7 +11,7 @@ export class MarkerHelper {
     );
 
     this.component.characterMarker.forEach((marker) => {
-      if (this.component.entities.every((entity) => entity.markers.includes(marker))) {
+      if (this.component.entities.length > 0 && this.component.entities.every((entity) => entity.markers.includes(marker))) {
         this.component.characterMarkerToAdd.push(marker);
       }
     });


### PR DESCRIPTION
# Description

Modify the update logic for the entities menu slightly, so if some selected entities match both filters (and you have some of them deselected), it keeps the selections on filter change.

Also adds the option to toggle a single group of monsters by clicking its portrait, or double clicking it to toggle everything _but_ that monster. There's a minor issue with this in that it doesn't set the cursor to pointer correctly. My attempt to fix that changed the font size in the figure/monster menu. I imagine there's an easy fix for that, but I'm not familiar enough with Angular to spot it.

Also fixes a bug where deselecting everything would turn the character marker on.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution