### PR TITLE
Miscellaneous Gh2e rules fixes

### DIFF
--- a/src/app/game/businesslogic/AttackModifierManager.ts
+++ b/src/app/game/businesslogic/AttackModifierManager.ts
@@ -310,7 +310,7 @@ export class AttackModifierManager {
 
   drawAdvantage(attackModifierDeck: AttackModifierDeck, state: 'advantage' | 'disadvantage') {
     let additionalDraw = false;
-    const fhRules = gameManager.fhRules() || settingsManager.settings.alwaysFhAdvantage;
+    const fhRules = gameManager.fhRules(true) || settingsManager.settings.alwaysFhAdvantage;
     attackModifierDeck.current = attackModifierDeck.current + 1;
     attackModifierDeck.lastVisible = attackModifierDeck.current;
     attackModifierDeck.state = state;
@@ -982,7 +982,7 @@ export class AttackModifierManager {
     let baseCard: AttackModifier = firstCard;
     let chooseOffset: number = 0;
     const effects: AttackModifierEffect[] = [];
-    const fh = gameManager.fhRules() || settingsManager.settings.alwaysFhAdvantage;
+    const fh = gameManager.fhRules(true) || settingsManager.settings.alwaysFhAdvantage;
 
     if (attackModifierDeck.state) {
       switch (attackModifierDeck.state) {

--- a/src/app/game/businesslogic/MonsterManager.ts
+++ b/src/app/game/businesslogic/MonsterManager.ts
@@ -566,7 +566,7 @@ export class MonsterManager {
     if (summon) {
       monsterEntity.summon = SummonState.new;
     }
-    if (!summon || gameManager.fhRules()) {
+    if (!summon || gameManager.fhRules(true)) {
       if (this.game.state === GameState.next) {
         if (monster.ability === -1) {
           if (!this.applySameDeck(monster)) {

--- a/src/app/game/businesslogic/ScenarioManager.ts
+++ b/src/app/game/businesslogic/ScenarioManager.ts
@@ -12,6 +12,7 @@ import { MonsterStandeeData, RoomData } from 'src/app/game/model/data/RoomData';
 import { ScenarioData, ScenarioRewards } from 'src/app/game/model/data/ScenarioData';
 import { EntityValueFunction } from 'src/app/game/model/Entity';
 import { Game, GameState } from 'src/app/game/model/Game';
+import { Monster } from 'src/app/game/model/Monster';
 import { MonsterEntity } from 'src/app/game/model/MonsterEntity';
 import { GameScenarioModel, Scenario, ScenarioMissingRequirements } from 'src/app/game/model/Scenario';
 import { ghsShuffleArray } from 'src/app/ui/helper/Static';

--- a/src/app/game/businesslogic/ScenarioManager.ts
+++ b/src/app/game/businesslogic/ScenarioManager.ts
@@ -12,7 +12,6 @@ import { MonsterStandeeData, RoomData } from 'src/app/game/model/data/RoomData';
 import { ScenarioData, ScenarioRewards } from 'src/app/game/model/data/ScenarioData';
 import { EntityValueFunction } from 'src/app/game/model/Entity';
 import { Game, GameState } from 'src/app/game/model/Game';
-import { Monster } from 'src/app/game/model/Monster';
 import { MonsterEntity } from 'src/app/game/model/MonsterEntity';
 import { GameScenarioModel, Scenario, ScenarioMissingRequirements } from 'src/app/game/model/Scenario';
 import { ghsShuffleArray } from 'src/app/ui/helper/Static';
@@ -242,9 +241,10 @@ export class ScenarioManager {
             }
 
             if (rewards.prosperity) {
+              const prosperityMax = gameManager.fhRules() ? 132 : gameManager.gh2eRules() ? 89 : 64;
               this.game.party.prosperity += rewards.prosperity;
-              if (this.game.party.prosperity > (gameManager.fhRules() ? 132 : 64)) {
-                this.game.party.prosperity = gameManager.fhRules() ? 132 : 64;
+              if (this.game.party.prosperity > prosperityMax) {
+                this.game.party.prosperity = prosperityMax;
               } else if (this.game.party.prosperity < 0) {
                 this.game.party.prosperity = 0;
               }

--- a/src/app/ui/figures/attackmodifier/attackmodifierdeck.html
+++ b/src/app/ui/figures/attackmodifier/attackmodifierdeck.html
@@ -149,7 +149,7 @@
             ignored:
               !drawing &&
               deck.state === 'disadvantage' &&
-              (index < current || (!gameManager.fhRules() && !settingsManager.settings.alwaysFhAdvantage)) &&
+              (index < current || (!gameManager.fhRules(true) && !settingsManager.settings.alwaysFhAdvantage)) &&
               attackModifier.rolling
           }"
           [style.left]="

--- a/src/app/ui/footer/scenario/summary/scenario-summary.html
+++ b/src/app/ui/footer/scenario/summary/scenario-summary.html
@@ -598,9 +598,9 @@
                 <span><span [ghs-label]="'scenario.summary.casualWarning.hintFh'"></span></span>
               </div>
             }
-            @if (forceCampaign || gameManager.fhRules()) {
+            @if (forceCampaign || gameManager.fhRules(true)) {
               <div class="item">
-                <a (click)="characterProgress = gameManager.fhRules() ? !characterProgress : true; updateState()"
+                <a (click)="characterProgress = gameManager.fhRules(true) ? !characterProgress : true; updateState()"
                   ><span
                     [ghs-label]="'scenario.summary.casualWarning.' + (!characterProgress && !forceCampaign ? 'ignore' : 'reapply')"
                   ></span
@@ -1470,7 +1470,7 @@
           <label><span [ghs-label]="'scenario.rewards.bonus'"></span>:</label>
           <div class="list">
             @if (
-              gameManager.fhRules() &&
+              gameManager.fhRules(true) &&
               EntityValueFunction('4-C') &&
               (!rewards || !rewards.ignoredBonus || !rewards.ignoredBonus.includes('inspiration'))
             ) {

--- a/src/app/ui/footer/scenario/summary/scenario-summary.html
+++ b/src/app/ui/footer/scenario/summary/scenario-summary.html
@@ -595,7 +595,7 @@
           <div class="list">
             @if (!characterProgress && gameManager.fhRules(true)) {
               <div class="item">
-                <span><span [ghs-label]="'scenario.summary.casualWarning.hint' + (gameManager.fhRules() ? 'FH' : 'GH2E')"></span></span>
+                <span><span [ghs-label]="'scenario.summary.casualWarning.hint' + (gameManager.fhRules() ? 'Fh' : 'Gh2e')"></span></span>
               </div>
             }
             @if (forceCampaign || gameManager.fhRules(true)) {

--- a/src/app/ui/footer/scenario/summary/scenario-summary.html
+++ b/src/app/ui/footer/scenario/summary/scenario-summary.html
@@ -593,9 +593,9 @@
         <div class="reward warning">
           <label><span [ghs-label]="'scenario.summary.casualWarning' + (gameManager.fhRules() ? '.fh' : '')"></span></label>
           <div class="list">
-            @if (!characterProgress && gameManager.fhRules()) {
+            @if (!characterProgress && gameManager.fhRules(true)) {
               <div class="item">
-                <span><span [ghs-label]="'scenario.summary.casualWarning.hintFh'"></span></span>
+                <span><span [ghs-label]="'scenario.summary.casualWarning.hint' + (gameManager.fhRules() ? 'FH' : 'GH2E')"></span></span>
               </div>
             }
             @if (forceCampaign || gameManager.fhRules(true)) {

--- a/src/app/ui/footer/scenario/summary/scenario-summary.ts
+++ b/src/app/ui/footer/scenario/summary/scenario-summary.ts
@@ -244,7 +244,8 @@ export class ScenarioSummaryComponent {
             ) !== undefined))) ||
       false;
 
-    this.characterProgress = !this.rewardsOnly && !this.conclusionOnly && (gameManager.game.party.campaignMode || !gameManager.fhRules());
+    this.characterProgress =
+      !this.rewardsOnly && !this.conclusionOnly && (gameManager.game.party.campaignMode || !gameManager.fhRules(true));
     this.gainRewards = gameManager.game.party.campaignMode;
 
     this.updateState(this.rewardsOnly);
@@ -642,7 +643,7 @@ export class ScenarioSummaryComponent {
       this.success &&
       !this.conclusionOnly &&
       !this.scenario.solo &&
-      ((gameManager.fhRules() &&
+      ((gameManager.fhRules(true) &&
         gameManager.characterManager.characterCount() < 4 &&
         (!this.rewards || !this.rewards.ignoredBonus || !this.rewards.ignoredBonus.includes('inspiration'))) ||
         this.numberChallenges > 0)

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -2304,7 +2304,7 @@
         "campaignRewards": "Enable Campaign Rewards",
         "fh": "Frosthaven Casual Mode",
         "hintFh": "In Frosthaven casual mode , all campaign effects are ignored. No event is resolved, time does not pass, and the party does not gain any experience, loot, treasures, checkmarks, personal quest progress, rewards, unlockables, etc",
-        "hintGH2E": "In casual mode, all campaign effects are ignored. No event is resolved, and the party does not gain any experience, loot, treasures, checkmarks, personal quest progress, rewards, unlockables, etc",
+        "hintGh2e": "In casual mode, all campaign effects are ignored. No event is resolved, and the party does not gain any experience, loot, treasures, checkmarks, personal quest progress, rewards, unlockables, etc",
         "ignore": "Gain rewards anyways!",
         "reapply": "Switch back to casual mode"
       },

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -2304,6 +2304,7 @@
         "campaignRewards": "Enable Campaign Rewards",
         "fh": "Frosthaven Casual Mode",
         "hintFh": "In Frosthaven casual mode , all campaign effects are ignored. No event is resolved, time does not pass, and the party does not gain any experience, loot, treasures, checkmarks, personal quest progress, rewards, unlockables, etc",
+        "hintGH2E": "In casual mode, all campaign effects are ignored. No event is resolved, and the party does not gain any experience, loot, treasures, checkmarks, personal quest progress, rewards, unlockables, etc",
         "ignore": "Gain rewards anyways!",
         "reapply": "Switch back to casual mode"
       },


### PR DESCRIPTION
# Description

Fixes a handful of GH2E rules errors (mainly where it was using GH1 behavior when it should use FH).

1. Prosperity cap
2. Advantage rule.
3. Summons drawing ability cards if there wasn't one for the round (for purposes of focus).
4. Scenario rewards when in casual mode.

Scenario reward behavior is still wrong when repeating a scenario, but it's wrong in the same way for both GH2E and Frosthaven.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution
