### PR TITLE
Remove dead monster types from entities menu.

### DIFF
--- a/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
+++ b/src/app/ui/figures/entities-menu/entities-menu-dialog.ts
@@ -309,17 +309,18 @@ export class EntitiesMenuDialogComponent {
 
     this.figures = gameManager.game.figures.filter(
       (figure) =>
-        (figure instanceof Character && !figure.absent && (!this.filter || this.filter === 'character' || this.filter === 'allies')) ||
-        (figure instanceof Monster &&
-          (!this.filter ||
-            this.filter === 'monster' ||
-            (this.filter === 'enemies' && !figure.isAlly) ||
-            (this.filter === 'allies' && figure.isAlly))) ||
-        (figure instanceof ObjectiveContainer &&
-          (!this.filter ||
-            (this.filter === 'allies' && figure.escort) ||
-            (this.filter === 'enemies' && !figure.escort) ||
-            this.filter === 'objectives'))
+        gameManager.gameplayFigure(figure) &&
+        ((figure instanceof Character && !figure.absent && (!this.filter || this.filter === 'character' || this.filter === 'allies')) ||
+          (figure instanceof Monster &&
+            (!this.filter ||
+              this.filter === 'monster' ||
+              (this.filter === 'enemies' && !figure.isAlly) ||
+              (this.filter === 'allies' && figure.isAlly))) ||
+          (figure instanceof ObjectiveContainer &&
+            (!this.filter ||
+              (this.filter === 'allies' && figure.escort) ||
+              (this.filter === 'enemies' && !figure.escort) ||
+              this.filter === 'objectives')))
     );
 
     selectAll ||= this.entities.length === this.allEntities.length;


### PR DESCRIPTION
# Description

Add a `gameplayFigure` filter to the entities menu to prune dead monster types.

The "Remove Unused" setting will remove the figures entirely, but then their ability deck state gets lost.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution
