### PR TITLE
Fix some uncommon sources of damage bypassing ward.

### DIFF
--- a/src/app/game/businesslogic/ActionsManager.ts
+++ b/src/app/game/businesslogic/ActionsManager.ts
@@ -549,15 +549,8 @@ export class ActionsManager {
         break;
       case ActionType.damage:
       case ActionType.sufferDamage:
-        entity.health -= EntityValueFunction(action.value, figure.level);
-        if (entity.health <= 0) {
-          entity.health = 0;
-        }
-        if (figure instanceof Monster && entity instanceof MonsterEntity && entity.health <= 0) {
-          entity.dead = true;
-        } else if (figure instanceof ObjectiveContainer && entity instanceof ObjectiveEntity && entity.health <= 0) {
-          entity.dead = true;
-        }
+        // TODO: make this wait for highlighted conditions
+        gameManager.entityManager.changeHealth(entity, figure, -EntityValueFunction(action.value, figure.level), true);
         break;
       case ActionType.switchType:
         if (figure instanceof Monster && entity instanceof MonsterEntity) {

--- a/src/app/game/businesslogic/ActionsManager.ts
+++ b/src/app/game/businesslogic/ActionsManager.ts
@@ -549,7 +549,6 @@ export class ActionsManager {
         break;
       case ActionType.damage:
       case ActionType.sufferDamage:
-        // TODO: make this wait for highlighted conditions
         gameManager.entityManager.changeHealth(entity, figure, -EntityValueFunction(action.value, figure.level), true);
         break;
       case ActionType.switchType:

--- a/src/app/game/businesslogic/LootManager.ts
+++ b/src/app/game/businesslogic/LootManager.ts
@@ -169,22 +169,14 @@ export class LootManager {
         break;
       case TreasureRewardType.damage:
         if (typeof reward.value === 'number') {
-          character.health -= reward.value;
+          gameManager.entityManager.changeHealth(character, character, -reward.value, true);
         } else if (reward.value === 'terrain') {
-          character.health -= gameManager.levelManager.terrain();
-        }
-        if (character.health <= 0) {
-          character.exhausted = true;
-          character.off = true;
-          character.active = false;
+          gameManager.entityManager.changeHealth(character, character, -gameManager.levelManager.terrain(), true);
         }
         break;
       case TreasureRewardType.heal:
         if (typeof reward.value === 'number') {
-          character.health += reward.value;
-          if (character.health > character.maxHealth) {
-            character.health = character.maxHealth;
-          }
+          gameManager.entityManager.changeHealth(character, character, reward.value);
         }
         break;
       case TreasureRewardType.loot:

--- a/src/app/game/businesslogic/RoundManager.ts
+++ b/src/app/game/businesslogic/RoundManager.ts
@@ -453,9 +453,8 @@ export class RoundManager {
 
           if (figure.name === 'lightning' && figure.tags.includes('blood-pact')) {
             if (figure.edition !== 'gh2e' || figure.health > 1) {
-              figure.health -= 1;
+              gameManager.entityManager.changeHealth(figure, figure, -1, true);
             }
-            gameManager.entityManager.checkHealth(figure, figure);
           }
         }
       } else {
@@ -473,9 +472,8 @@ export class RoundManager {
 
         if (figure.name === 'lightning' && figure.tags.includes('blood-pact')) {
           if (figure.edition !== 'gh2e' || figure.health > 1) {
-            figure.health -= 1;
+            gameManager.entityManager.changeHealth(figure, figure, -1, true);
           }
-          gameManager.entityManager.checkHealth(figure, figure);
         }
       }
     }

--- a/src/app/ui/figures/actions/interactive/interactive-actions.html
+++ b/src/app/ui/figures/actions/interactive/interactive-actions.html
@@ -5,7 +5,11 @@
     (singleClick)="applyInteractiveActions($event)"
     [ngClass]="{ fh: settingsManager.settings.theme === 'fh' }"
   >
-    <span [ghs-label]="interactiveActions().length ? 'monster.applyInteractiveActions' : 'monster.skipInteractiveActions'"></span>
+    <span
+      [ghs-label]="
+        'monster.' + (!ignoreWarning && checkWarning() ? 'warn' : interactiveActions().length ? 'apply' : 'skip') + 'InteractiveActions'
+      "
+    ></span>
     <span class="entity-numbers">
       @for (entity of interactiveActionEntities | trackUUID; track entity._trackUUID; let i = $index) {
         <span class="entity">

--- a/src/app/ui/figures/actions/interactive/interactive-actions.spec.ts
+++ b/src/app/ui/figures/actions/interactive/interactive-actions.spec.ts
@@ -13,10 +13,10 @@ import { InteractiveActionsComponent } from 'src/app/ui/figures/actions/interact
 
 // InteractiveActionsComponent's applyInteractiveActions() is deeply coupled to ActionsManager's
 // apply/state-mutation pipeline and out of scope here. This spec focuses on wildToConsume()/
-// wildToCreate() (pure filters over gameManager.game.elementBoard), update()'s interactiveAbilities/
-// figure-active gating, and onInteractiveActionsChange(). Following the AppComponent.spec.ts
-// pattern: create via TestBed, never call fixture.detectChanges() (ngOnInit never runs — we call
-// update() directly instead), set the required `figure` input via setInput().
+// wildToCreate() (pure filters over gameManager.game.elementBoard), and update()'s interactiveAbilities/
+// figure-active gating, Following the AppComponent.spec.ts/ pattern: create via TestBed,
+// never call fixture.detectChanges() (ngOnInit never runs — we call update() directly instead),
+// set the required `figure` input via setInput().
 
 function buildMonster(active: boolean = true): Monster {
   const stat = new MonsterStat(MonsterType.normal, 1, 10, 2, 3, 0);
@@ -113,16 +113,6 @@ describe('InteractiveActionsComponent', () => {
       const component = createComponent(monster);
       component.chooseElementValues = [Element.fire];
       expect(component.wildToCreate()).toEqual([]);
-    });
-  });
-
-  describe('onInteractiveActionsChange', () => {
-    it('stores the given change', () => {
-      const monster = buildMonster();
-      const component = createComponent(monster);
-      const change = [{ action: new Action(ActionType.attack, 1), index: '0' }] as InteractiveAction[];
-      component.onInteractiveActionsChange(change);
-      expect(component.interactiveActions()).toEqual(change);
     });
   });
 });

--- a/src/app/ui/figures/actions/interactive/interactive-actions.ts
+++ b/src/app/ui/figures/actions/interactive/interactive-actions.ts
@@ -5,7 +5,9 @@ import { GameManager, gameManager } from 'src/app/game/businesslogic/GameManager
 import { GhsManager } from 'src/app/game/businesslogic/GhsManager';
 import { SettingsManager, settingsManager } from 'src/app/game/businesslogic/SettingsManager';
 import { Action, ActionType, ActionValueType } from 'src/app/game/model/data/Action';
+import { Condition, ConditionName } from 'src/app/game/model/data/Condition';
 import { Element, ElementState } from 'src/app/game/model/data/Element';
+import { EntityValueFunction } from 'src/app/game/model/Entity';
 import { Monster } from 'src/app/game/model/Monster';
 import { MonsterEntity } from 'src/app/game/model/MonsterEntity';
 import { ObjectiveContainer } from 'src/app/game/model/ObjectiveContainer';
@@ -43,6 +45,7 @@ export class InteractiveActionsComponent implements OnInit {
   interactiveActionEntities: (MonsterEntity | ObjectiveEntity)[] = [];
   chooseElementAction: InteractiveAction | undefined;
   chooseElementValues: string[] = [];
+  ignoreWarning: boolean = false;
 
   constructor() {
     this.ghsManager.uiChangeEffect(() => this.update());
@@ -72,10 +75,42 @@ export class InteractiveActionsComponent implements OnInit {
       );
 
       this.interactiveActions.set(gameManager.actionsManager.getAllInteractiveActions(this.figure, this.actions, this.preIndex()));
+      this.ignoreWarning = false;
     } else {
       this.interactiveActionEntities = [];
       this.interactiveActions.set([]);
     }
+  }
+
+  checkWarning(): boolean {
+    // Ward or brittle could change whether monsters survive damage.
+    // Warn if that's the case.
+    const wardEnabled =
+      settingsManager.settings.applyConditions &&
+      settingsManager.settings.activeApplyConditions &&
+      settingsManager.settings.activeApplyConditionsAuto.includes(ConditionName.ward) &&
+      !settingsManager.settings.activeApplyConditionsExcludes.includes(ConditionName.ward);
+    const brittleEnabled =
+      settingsManager.settings.applyConditions &&
+      settingsManager.settings.activeApplyConditions &&
+      settingsManager.settings.activeApplyConditionsAuto.includes(ConditionName.brittle) &&
+      !settingsManager.settings.activeApplyConditionsExcludes.includes(ConditionName.brittle);
+    return (
+      !(wardEnabled && brittleEnabled) &&
+      this.interactiveActions()
+        .filter((action) => action.action.type === ActionType.sufferDamage)
+        .some((action) => {
+          const damage = EntityValueFunction(action.action.value);
+          const result = (ward: boolean, brittle: boolean) => Math.floor((damage * (brittle ? 2 : 1)) / (ward ? 2 : 1));
+          return this.interactiveActionEntities.some((entity) => {
+            const ward = gameManager.entityManager.hasCondition(entity, new Condition(ConditionName.ward));
+            const brittle = gameManager.entityManager.hasCondition(entity, new Condition(ConditionName.brittle));
+            const shouldDie = entity.health - result(ward, brittle) <= 0;
+            const wouldDie = entity.health - result(ward && wardEnabled, brittle && brittleEnabled) <= 0;
+            return shouldDie != wouldDie;
+          });
+        })
+    );
   }
 
   applyInteractiveActions(event: PointerEvent, selectElement: boolean = false) {
@@ -117,9 +152,12 @@ export class InteractiveActionsComponent implements OnInit {
       }
     }
 
-    if (this.interactiveActionEntities.length || this.interactiveActionEntities.length) {
-      let after = true;
+    if (!this.ignoreWarning && this.checkWarning()) {
+      this.ignoreWarning = true;
+      return;
+    }
 
+    if (this.interactiveActionEntities.length) {
       const interactiveActionsLabel = (
         settingsManager.settings.combineInteractiveAbilities
           ? this.interactiveActions()
@@ -203,37 +241,8 @@ export class InteractiveActionsComponent implements OnInit {
         });
       });
 
-      if (this.interactiveActionEntities.some((entity) => entity.dead)) {
-        after = false;
-        this.ghsManager.triggerUiChange();
-        setTimeout(
-          () => {
-            this.interactiveActionEntities.forEach((entity) => {
-              if (entity.dead) {
-                if (this.figure instanceof Monster && entity instanceof MonsterEntity) {
-                  gameManager.monsterManager.removeMonsterEntity(this.figure, entity);
-                } else if (this.figure instanceof ObjectiveContainer && entity instanceof ObjectiveEntity) {
-                  gameManager.objectiveManager.removeObjectiveEntity(this.figure, entity);
-                }
-                if (this.figure.entities.every((entity) => entity.dead || entity.health <= 0 || !entity.active)) {
-                  this.figure.off = true;
-                  if (this.figure.active) {
-                    gameManager.roundManager.toggleFigure(this.figure);
-                  }
-                }
-              }
-            });
-            this.update();
-            gameManager.stateManager.after();
-          },
-          settingsManager.settings.animations ? 1500 * settingsManager.settings.animationSpeed : 0
-        );
-      }
-
-      if (after) {
-        this.update();
-        gameManager.stateManager.after();
-      }
+      this.update();
+      gameManager.stateManager.after();
       event.preventDefault();
       event.stopPropagation();
     }
@@ -276,9 +285,5 @@ export class InteractiveActionsComponent implements OnInit {
     this.applyInteractiveActions(event, true);
     event.preventDefault();
     event.stopPropagation();
-  }
-
-  onInteractiveActionsChange(change: InteractiveAction[]) {
-    this.interactiveActions.set(change);
   }
 }

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -4019,8 +4019,7 @@
       "updateManualPlayerCount": "Set manual player count to {0}",
       "updatePartyAchievements": "Party achievement to {0}",
       "updateStandee": "Change {1} standee number {2} to {3} for {0}",
-      "upgradeBuilding": "Upgrade building '%data.buildings.{1}%' ({0}) to level {2}",
-      "warnInteractiveActions": "Ignore warning for standees {1} of {2}"
+      "upgradeBuilding": "Upgrade building '%data.buildings.{1}%' ({0}) to level {2}"
     },
     "loadMore": "Show more",
     "missing": "Missing states: {0}",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1494,7 +1494,8 @@
     "toggleDormant": {
       "off": "Switch back to active entities",
       "on": "Switch to dormant entities"
-    }
+    },
+    "warnInteractiveActions": "Ward or brittle impact outcome. Continue?"
   },
   "number": {
     "0": "zero",
@@ -4018,7 +4019,8 @@
       "updateManualPlayerCount": "Set manual player count to {0}",
       "updatePartyAchievements": "Party achievement to {0}",
       "updateStandee": "Change {1} standee number {2} to {3} for {0}",
-      "upgradeBuilding": "Upgrade building '%data.buildings.{1}%' ({0}) to level {2}"
+      "upgradeBuilding": "Upgrade building '%data.buildings.{1}%' ({0}) to level {2}",
+      "warnInteractiveActions": "Ignore warning for standees {1} of {2}"
     },
     "loadMore": "Show more",
     "missing": "Missing states: {0}",


### PR DESCRIPTION
# Description

Change basically every source of damage/healing that wasn't checking relevant conditions do so.
If I found everything, the only exceptions left are things that set max health and things that are intended to ignore conditions (some Shackles stuff).

I noticed some other similar effects (all heals, I think) would directly modify health and then manually create the corresponding heal condition to pass to `applyCondition` to get this behavior. I don't know if there's a reason to do that instead of just calling `changeHealth`., but this way seemed to work 

For interactive actions, I added a warning in case ward or brittle automation is turned off and some monster would die or not as a result. Otherwise, for example, a warded ooze could summon a zero health copy while waiting for ward confirmation. The better approach would be to pause and wait for condition highlights to clear, but I don't know enough about Angular to wire up the events for that.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution
