### PR TITLE
Fix hidden rewards in scenario history.

### DIFF
--- a/src/app/ui/footer/scenario/summary/scenario-summary.ts
+++ b/src/app/ui/footer/scenario/summary/scenario-summary.ts
@@ -361,7 +361,7 @@ export class ScenarioSummaryComponent {
       }
 
       // the scenario rewards can only be gained once in FH/GH2E
-      if (gameManager.fhRules(true) && this.rewards && gameManager.scenarioManager.isSuccess(this.scenario)) {
+      if (!this.rewardsOnly && gameManager.fhRules(true) && this.rewards && gameManager.scenarioManager.isSuccess(this.scenario)) {
         this.rewards = undefined;
       }
 


### PR DESCRIPTION
# Description

Commit b3da595956692912dd6d11e3bf7923ba02cfaa86 fixed repeated scenarios granting rewards but broke being able to see those rewards in the scenario history. This fixes that.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution
