### PR TITLE
Fix random side scenarios being hidden in scenario chart.

### DIFF
--- a/src/app/ui/figures/party/scenario-chart/scenario-chart.ts
+++ b/src/app/ui/figures/party/scenario-chart/scenario-chart.ts
@@ -115,7 +115,7 @@ export class ScenarioChartDialogComponent implements OnInit, AfterViewInit {
       ...gameManager.scenarioManager.scenarioData(this.edition, !this.campaignMode),
       ...extendedEditions.flatMap((ext) => gameManager.scenarioManager.scenarioData(ext, !this.campaignMode))
     ].filter((scenarioData) => {
-      if (scenarioData.random || scenarioData.group === 'random' || scenarioData.group === 'randomDungeon') {
+      if (scenarioData.group === 'randomDungeon') {
         return false;
       }
       if (this.campaignMode && scenarioData.solo) {


### PR DESCRIPTION
# Description

Scenario chart filtering was incorrectly catching random side scenarios (and scenarios in the `random` group, which as far as I can tell does not actually exist in data anywhere).

Fixes https://old.reddit.com/r/Gloomhaven/comments/1vmjt4m/gh_secretariat_scenario_flow_chart_not_showing/

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution
