### PR TITLE
[FH] add ability cards for banner spear

### DIFF
--- a/data/fh/character/deck/banner-spear.json
+++ b/data/fh/character/deck/banner-spear.json
@@ -22,7 +22,6 @@
         },
         {
           "type": "forceBox",
-          "value": "",
           "small": true,
           "subActions": [
             {
@@ -50,8 +49,7 @@
           "subActions": [
             {
               "type": "custom",
-              "value": "%data.custom.fh.banner-spear.abilities.61.2%",
-              "small": true
+              "value": "%data.custom.fh.banner-spear.abilities.61.2%"
             }
           ]
         }
@@ -79,7 +77,8 @@
             },
             {
               "type": "condition",
-              "value": "disarm"
+              "value": "disarm",
+              "small": true
             }
           ]
         }
@@ -175,13 +174,14 @@
         },
         {
           "type": "forceBox",
-          "value": 0,
+          "small": true,
           "subActions": [
             {
               "type": "element",
               "value": "air"
             }
-          ]
+          ],
+          "noDivider": true
         }
       ],
       "bottomActions": [
@@ -212,22 +212,72 @@
       "initiative": 15,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "attack",
+          "value": 2,
           "enhancementTypes": [
-            "any"
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "element",
+              "value": "air",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "concatenation",
+                  "value": ",",
+                  "subActions": [
+                    {
+                      "type": "attack",
+                      "value": 1,
+                      "valueType": "add",
+                      "small": true
+                    },
+                    {
+                      "type": "custom",
+                      "value": "%game.custom.advantage%",
+                      "small": true
+                    },
+                    {
+                      "type": "card",
+                      "value": "experience:1",
+                      "small": true
+                    }
+                  ]
+                }
+              ]
+            }
           ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.fh.banner-spear.abilities.65.1%",
+          "small": true
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "shield",
+              "value": 2,
+              "enhancementTypes": [
+                "circle"
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.65.2%",
+              "small": true
+            }
           ]
         }
-      ]
+      ],
+      "round": true,
+      "bottomRound": true
     },
     {
       "name": "Tip of the Spear",
@@ -236,22 +286,34 @@
       "initiative": 67,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "attack",
+          "value": 3,
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,3,active)|(0,4,ally)|(1,1,target)|(1,2,target)|(2,0,enhance)",
+              "enhancementTypes": [
+                "hex"
+              ]
+            },
+            {
+              "type": "pierce",
+              "value": 3,
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 4,
           "enhancementTypes": [
-            "any"
+            "circle"
           ]
         }
-      ]
+      ],
+      "xp": 1
     },
     {
       "name": "Combined Effort",
@@ -260,22 +322,52 @@
       "initiative": 32,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "attack",
+          "value": 3,
           "enhancementTypes": [
-            "any"
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,active)|(1,0,target)|(1,1,ally)"
+            },
+            {
+              "type": "condition",
+              "value": "wound",
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 2,
           "enhancementTypes": [
-            "any"
+            "circle"
+          ]
+        },
+        {
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.67.1%",
+              "small": true
+            },
+            {
+              "type": "move",
+              "value": 2,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
           ]
         }
-      ]
+      ],
+      "xp": 1
     },
     {
       "name": "Set for the Charge",
@@ -285,21 +377,17 @@
       "actions": [
         {
           "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "value": "%data.custom.fh.banner-spear.abilities.68.1%",
+          "small": true
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "type": "move",
+          "value": 4
         }
-      ]
+      ],
+      "round": true
     },
     {
       "name": "Pincer Movement",
@@ -308,22 +396,38 @@
       "initiative": 69,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "attack",
+          "value": 5,
           "enhancementTypes": [
-            "any"
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,target)|(0,2,active)|(1,0,ally)"
+            },
+            {
+              "type": "condition",
+              "value": "muddle",
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 1,
           "enhancementTypes": [
-            "any"
+            "circle"
           ]
+        },
+        {
+          "type": "loot",
+          "value": 1
         }
-      ]
+      ],
+      "xp": 1
     },
     {
       "name": "Regroup",
@@ -332,19 +436,42 @@
       "initiative": 25,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "heal",
+          "value": 2,
           "enhancementTypes": [
-            "any"
+            "diamond_plus"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 2,
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "regenerate",
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.70.1%",
+              "small": true
+            },
+            {
+              "type": "move",
+              "value": 3,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
           ]
         }
       ]
@@ -356,22 +483,30 @@
       "initiative": 10,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "attack",
+          "value": 3,
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,ally)|(1,1,active)|(2,0,target)|(2,1,target)|(2,2,target)"
+            },
+            {
+              "type": "condition",
+              "value": "immobilize",
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
           "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "value": "%data.custom.fh.banner-spear.abilities.71.1%",
+          "small": true
         }
-      ]
+      ],
+      "xp": 1,
+      "bottomRound": true
     },
     {
       "name": "Incendiary Throw",
@@ -380,22 +515,67 @@
       "initiative": 22,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 1,
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.72.1%",
+              "small": true
+            }
           ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "fire"
+            }
+          ],
+          "noDivider": true
         }
       ],
+      "bottomLost": true,
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "torch-bearer",
+            "thumbnail": true,
+            "health": 5,
+            "attack": 1,
+            "movement": 2,
+            "enhancements": [
+              "heal",
+              "attack"
+            ],
+            "action": {
+              "type": "condition",
+              "value": "wound"
+            }
+          },
+          "small": true
         }
-      ]
+      ],
+      "bottomXp": 2,
+      "bottomPersistent": true
     },
     {
       "name": "Driving Inspiration",
@@ -404,22 +584,77 @@
       "initiative": 18,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "attack",
+          "value": 2,
           "enhancementTypes": [
-            "any"
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "custom",
+              "value": "%game.custom.advantage%",
+              "small": true
+            }
           ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "light"
+            }
+          ],
+          "noDivider": true
         }
       ],
+      "bottomLost": true,
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "banner-of-hope",
+            "thumbnail": true,
+            "health": 4,
+            "enhancements": [
+              "heal"
+            ],
+            "action": {
+              "type": "grid",
+              "value": 1,
+              "subActions": [
+                {
+                  "type": "custom",
+                  "value": "%data.custom.fh.banner-spear.abilities.73.1%",
+                  "small": true
+                },
+                {
+                  "type": "heal",
+                  "value": 1,
+                  "small": true,
+                  "subActions": [
+                    {
+                      "type": "specialTarget",
+                      "value": "self",
+                      "small": true
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "small": true
         }
-      ]
+      ],
+      "bottomXp": 2,
+      "bottomPersistent": true
     },
     {
       "name": "Meat Grinder",
@@ -428,22 +663,50 @@
       "initiative": 62,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "attack",
+          "value": 4,
           "enhancementTypes": [
-            "any"
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,target)|(1,0,ally)|(1,1,target)|(1,2,active)"
+            },
+            {
+              "type": "condition",
+              "value": "wound",
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 3
+        },
+        {
+          "type": "heal",
+          "value": 1,
           "enhancementTypes": [
-            "any"
+            "circle"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 1,
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "regenerate",
+              "small": true
+            }
           ]
         }
-      ]
+      ],
+      "xp": 1
     },
     {
       "name": "Pinning Charge",
@@ -452,19 +715,74 @@
       "initiative": 17,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 2,
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 3,
+                  "small": true
+                },
+                {
+                  "type": "element",
+                  "value": "air",
+                  "valueType": "minus",
+                  "small": true,
+                  "subActions": [
+                    {
+                      "type": "concatenation",
+                      "value": ",",
+                      "subActions": [
+                        {
+                          "type": "range",
+                          "value": 1,
+                          "valueType": "add",
+                          "small": true
+                        },
+                        {
+                          "type": "condition",
+                          "value": "immobilize",
+                          "small": true
+                        },
+                        {
+                          "type": "card",
+                          "value": "experience:1",
+                          "small": true
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.75.1%",
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
           "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "value": "%data.custom.fh.banner-spear.abilities.75.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 2,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
           ]
         }
       ]
@@ -476,46 +794,119 @@
       "initiative": 24,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "attack",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,0,target)|(0,1,target)|(0,2,ally)|(1,0,target)|(1,2,active)"
+            },
+            {
+              "type": "condition",
+              "value": "poison",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "heal",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "target",
+              "value": "%data.custom.fh.banner-spear.abilities.76.1%",
+              "small": true
+            }
           ]
         }
       ],
+      "bottomLost": true,
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "banner-of-courage",
+            "thumbnail": true,
+            "health": 7,
+            "enhancements": [
+              "heal"
+            ],
+            "action": {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.76.2%"
+            }
+          },
+          "small": true
         }
-      ]
+      ],
+      "xp": 1,
+      "bottomXp": 2,
+      "bottomPersistent": true
     },
     {
       "name": "Head of the Hammer",
       "cardId": 77,
       "level": 3,
       "initiative": 87,
+      "lost": true,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "attack",
+          "value": 7,
           "enhancementTypes": [
-            "any"
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,active)|(0,2,ally)|(1,0,target)"
+            },
+            {
+              "type": "condition",
+              "value": "stun",
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 4,
           "enhancementTypes": [
-            "any"
+            "circle"
           ]
+        },
+        {
+          "type": "condition",
+          "value": "muddle",
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "all",
+              "small": true
+            },
+            {
+              "type": "range",
+              "value": 1,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "air"
+            }
+          ],
+          "noDivider": true
         }
-      ]
+      ],
+      "xp": 3
     },
     {
       "name": "Boldening Blow",
@@ -524,22 +915,56 @@
       "initiative": 72,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "attack",
+          "value": 4,
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,ally)|(1,0,target)|(1,1,active)|(1,2,ally)|(2,0,target)|(2,1,target)|(2,2,target)"
+            },
+            {
+              "type": "target",
+              "value": "%data.custom.fh.banner-spear.abilities.78.1%",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "condition",
+          "value": "bless",
+          "subActions": [
+            {
+              "type": "target",
+              "value": "%data.custom.fh.banner-spear.abilities.78.2%",
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 2,
           "enhancementTypes": [
-            "any"
+            "circle"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.fh.banner-spear.abilities.78.3%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 3,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
           ]
         }
-      ]
+      ],
+      "xp": 1
     },
     {
       "name": "Air Support",
@@ -548,22 +973,60 @@
       "initiative": 20,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "attack",
+          "value": 4,
           "enhancementTypes": [
-            "any"
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "pierce",
+              "value": 2,
+              "small": true
+            }
           ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "element",
+              "value": "air"
+            }
+          ],
+          "noDivider": true
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "trained-falcon",
+            "thumbnail": true,
+            "health": 1,
+            "attack": 2,
+            "movement": 3,
+            "enhancements": [
+              "heal",
+              "move",
+              "attack"
+            ],
+            "action": {
+              "type": "fly"
+            }
+          },
+          "small": true
         }
-      ]
+      ],
+      "bottomXp": 1,
+      "bottomPersistent": true
     },
     {
       "name": "Explosive Epicenter",
@@ -572,22 +1035,49 @@
       "initiative": 78,
       "actions": [
         {
+          "type": "attack",
+          "value": 3,
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,0,target)|(0,1,ally)|(0,2,target)|(1,0,target)|(1,1,active)|(1,2,target)|(2,0,target)|(2,2,target)"
+            },
+            {
+              "type": "push",
+              "value": 1,
+              "small": true
+            }
+          ]
+        },
+        {
           "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "value": "%data.custom.fh.banner-spear.abilities.80.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 1
+            }
           ]
         }
       ],
+      "bottomLost": true,
       "bottomActions": [
         {
           "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "value": "%data.custom.fh.banner-spear.abilities.80.2%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 1
+            }
           ]
         }
-      ]
+      ],
+      "xp": 1,
+      "bottomXp": 2,
+      "bottomPersistent": true
     },
     {
       "name": "Hold the Line",
@@ -596,22 +1086,48 @@
       "initiative": 5,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "shield",
+          "value": 2,
           "enhancementTypes": [
-            "any"
+            "diamond_plus"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.fh.banner-spear.abilities.81.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "shield",
+              "value": 2
+            }
           ]
         }
       ],
+      "bottomLost": true,
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 3,
           "enhancementTypes": [
-            "any"
+            "circle"
+          ]
+        },
+        {
+          "type": "shield",
+          "value": 2
+        },
+        {
+          "type": "retaliate",
+          "value": 3,
+          "enhancementTypes": [
+            "circle"
           ]
         }
-      ]
+      ],
+      "round": true,
+      "bottomXp": 2,
+      "bottomRound": true
     },
     {
       "name": "Barricade",
@@ -620,22 +1136,57 @@
       "initiative": 16,
       "actions": [
         {
+          "type": "attack",
+          "value": 3,
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,0,target)|(0,1,ally)|(1,0,target)|(1,1,active)|(2,0,target)|(2,1,ally)|(3,0,target)"
+            },
+            {
+              "type": "condition",
+              "value": "wound",
+              "small": true
+            }
+          ]
+        },
+        {
           "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "value": "%data.custom.fh.banner-spear.abilities.82.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "shield",
+              "value": 1
+            }
           ]
         }
       ],
+      "bottomLost": true,
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "banner-of-valor",
+            "thumbnail": true,
+            "health": 5,
+            "enhancements": [
+              "heal"
+            ],
+            "action": {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.82.2%",
+              "small": true
+            }
+          },
+          "small": true
         }
-      ]
+      ],
+      "xp": 1,
+      "round": true,
+      "bottomXp": 2,
+      "bottomPersistent": true
     },
     {
       "name": "Bolstering Shout",
@@ -644,19 +1195,69 @@
       "initiative": 75,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "heal",
+          "value": 3,
+          "subActions": [
+            {
+              "type": "range",
+              "value": 3,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "condition",
+              "value": "regenerate",
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "air",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "target",
+                  "value": 1,
+                  "valueType": "add",
+                  "small": true
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1",
+                  "small": true
+                }
+              ]
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 3,
           "enhancementTypes": [
-            "any"
+            "circle"
+          ]
+        },
+        {
+          "type": "pull",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "target",
+              "value": 2,
+              "small": true,
+              "enhancementTypes": [
+                "square"
+              ]
+            },
+            {
+              "type": "range",
+              "value": 3,
+              "small": true
+            }
           ]
         }
       ]
@@ -668,22 +1269,66 @@
       "initiative": 27,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "attack",
+          "value": 7,
           "enhancementTypes": [
-            "any"
+            "diamond"
+          ],
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,0,ally)|(0,1,target)|(0,2,active)|(1,1,ally)"
+            },
+            {
+              "type": "condition",
+              "value": "stun",
+              "small": true
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 3,
           "enhancementTypes": [
-            "any"
+            "circle"
+          ]
+        },
+        {
+          "type": "attack",
+          "value": 1,
+          "enhancementTypes": [
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "target",
+              "value": 3,
+              "small": true
+            },
+            {
+              "type": "element",
+              "value": "air",
+              "valueType": "minus",
+              "small": true,
+              "subActions": [
+                {
+                  "type": "target",
+                  "value": "%data.custom.fh.banner-spear.abilities.84.1%",
+                  "small": true
+                },
+                {
+                  "type": "card",
+                  "value": "experience:1",
+                  "small": true
+                }
+              ]
+            }
           ]
         }
-      ]
+      ],
+      "xp": 1
     },
     {
       "name": "Lead from Afar",
@@ -692,22 +1337,58 @@
       "initiative": 80,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 2,
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 4,
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.85.1%",
+              "small": true
+            }
           ]
         }
       ],
+      "bottomLost": true,
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "longbowman",
+            "thumbnail": true,
+            "health": 4,
+            "attack": 2,
+            "movement": 2,
+            "range": 4,
+            "enhancements": [
+              "heal",
+              "move",
+              "range"
+            ],
+            "action": {
+              "type": "condition",
+              "value": "muddle"
+            }
+          },
+          "small": true
         }
-      ]
+      ],
+      "bottomXp": 2,
+      "bottomPersistent": true
     },
     {
       "name": "Sweeping Aid",
@@ -716,46 +1397,130 @@
       "initiative": 73,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "grid",
+          "value": 1,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 4,
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "pierce",
+                  "value": 2,
+                  "small": true
+                },
+                {
+                  "type": "condition",
+                  "value": "immobilize",
+                  "small": true
+                }
+              ],
+              "multiAttack": true
+            },
+            {
+              "type": "area",
+              "value": "(0,1,active)|(1,1,ally)|(2,0,target)|(2,1,target)|(2,2,target)"
+            }
           ]
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "heal",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "range",
+              "value": 2,
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "move",
+          "value": 3,
           "enhancementTypes": [
-            "any"
+            "circle"
+          ]
+        },
+        {
+          "type": "heal",
+          "value": 2,
+          "subActions": [
+            {
+              "type": "range",
+              "value": 2,
+              "small": true
+            }
           ]
         }
-      ]
+      ],
+      "xp": 1
     },
     {
       "name": "Taunting Howl",
       "cardId": 87,
       "level": 8,
       "initiative": 11,
+      "lost": true,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "pull",
+          "value": 2,
           "enhancementTypes": [
-            "any"
+            "square"
+          ],
+          "subActions": [
+            {
+              "type": "specialTarget",
+              "value": "all",
+              "small": true
+            },
+            {
+              "type": "range",
+              "value": 4,
+              "small": true
+            },
+            {
+              "type": "condition",
+              "value": "muddle",
+              "small": true
+            }
           ]
+        },
+        {
+          "type": "shield",
+          "value": 3
         }
       ],
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
+          "type": "move",
+          "value": 3,
           "enhancementTypes": [
-            "any"
+            "circle"
+          ]
+        },
+        {
+          "type": "custom",
+          "value": "%data.custom.fh.banner-spear.abilities.87.1%",
+          "small": true,
+          "subActions": [
+            {
+              "type": "move",
+              "value": 3,
+              "enhancementTypes": [
+                "square"
+              ]
+            }
           ]
         }
-      ]
+      ],
+      "xp": 2,
+      "round": true
     },
     {
       "name": "Take no Prisoners",
@@ -764,22 +1529,45 @@
       "initiative": 85,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "attack",
+          "value": 3,
+          "subActions": [
+            {
+              "type": "area",
+              "value": "(0,1,target)|(0,2,ally)|(0,3,ally)|(1,0,target)|(1,1,target)|(1,2,active)|(1,3,target)|(2,0,target)|(2,1,target)|(2,2,target)|(2,3,target)|(3,2,target)"
+            },
+            {
+              "type": "condition",
+              "value": "poison",
+              "small": true
+            }
           ]
         }
       ],
+      "bottomLost": true,
       "bottomActions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "type": "summon",
+          "value": "summonData",
+          "valueObject": {
+            "name": "banner-of-doom",
+            "thumbnail": true,
+            "health": 9,
+            "enhancements": [
+              "heal"
+            ],
+            "action": {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.88.1%",
+              "small": true
+            }
+          },
+          "small": true
         }
-      ]
+      ],
+      "xp": 1,
+      "bottomXp": 2,
+      "bottomPersistent": true
     },
     {
       "name": "Hail of Spears",
@@ -788,20 +1576,53 @@
       "initiative": 44,
       "actions": [
         {
-          "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
+          "type": "grid",
+          "value": 1,
+          "multiTarget": true,
+          "subActions": [
+            {
+              "type": "attack",
+              "value": 5,
+              "enhancementTypes": [
+                "diamond"
+              ],
+              "subActions": [
+                {
+                  "type": "range",
+                  "value": 4,
+                  "small": true
+                }
+              ]
+            },
+            {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.89.1%",
+              "small": true
+            }
+          ]
+        },
+        {
+          "type": "forceBox",
+          "small": true,
+          "subActions": [
+            {
+              "type": "custom",
+              "value": "%data.custom.fh.banner-spear.abilities.89.2%"
+            }
           ]
         }
       ],
+      "bottomLost": true,
+      "bottomLoss": true,
       "bottomActions": [
         {
+          "type": "move",
+          "value": 4
+        },
+        {
           "type": "custom",
-          "value": "%character.abilities.wip%",
-          "enhancementTypes": [
-            "any"
-          ]
+          "value": "%data.custom.fh.banner-spear.abilities.89.3%",
+          "small": true
         }
       ]
     }

--- a/data/fh/label/en.json
+++ b/data/fh/label/en.json
@@ -1353,6 +1353,69 @@
           },
           "63": {
             "1": "All your ranged attacks have %game.action.range.valueSign:-1%."
+          },
+          "65": {
+            "1": "All attacks targeting you this round gain disadvantage.",
+            "2": "This %game.action.shield% only applies to ranged attacks."
+          },
+          "67": {
+            "1": "Grant two allies within %game.action.range:2%:"
+          },
+          "68": {
+            "1": "Whenever an enemy moves or teleports from a hex not adjacent to you to a hex adjacent to you this round, that enemy suffers %game.damage:2%."
+          },
+          "70": {
+            "1": "Grant two allies within %game.action.range:3%:"
+          },
+          "71": {
+            "1": "Add %game.action.attack.valueSign:1% to the next attack ability performed by you or an adjacent ally this round."
+          },
+          "72": {
+            "1": "If the target suffers %game.damage% from this attack, the target and all enemies adjacent to the target gain %game.condition.wound%."
+          },
+          "73": {
+            "1": "At the start of their turns, grant allies within %game.action.range:3%:"
+          },
+          "75": {
+            "1": "Add %game.action.attack.valueSign:1% for each ally adjacent to the target.",
+            "2": "Grant three allies within %game.action.range:4%:"
+          },
+          "76": {
+            "1": "the ally in the blue hey of the attack ability and self",
+            "2": "All adjacent allies gain %game.action.shield:1%."
+          },
+          "78": {
+            "1": "1 enemy in the red hexes",
+            "2": "all allies in the blue hexes of the attack ability",
+            "3": "Grant two allies within %game.action.range:3%:"
+          },
+          "80": {
+            "1": "Grant the ally in the blue hex of the attack ability and self:",
+            "2": "Once per turn, on your turn, while an enemy is within %game.action.range:3%, grant one adjacent ally and self:"
+          },
+          "81": {
+            "1": "Grant all adjacent allies:"
+          },
+          "82": {
+            "1": "Grant all allies in the blue hexes of the attack ability and self:",
+            "2": "Negate the first source of %game.damage% to an adjacent ally each round."
+          },
+          "84": {
+            "1": "3 enemies within two hexes instead"
+          },
+          "85": {
+            "1": "Add %game.action.attack.valueSign:2% for each ally adjacent to the target."
+          },
+          "87": {
+            "1": "Grant two allies within %game.action.range:3%:"
+          },
+          "88": {
+            "1": "All enemies within %game.action.range:4% suffer %game.damage:1% at the start of their turns."
+          },
+          "89": {
+            "1": "Add %game.action.target.valueSign:1% for each adjacent Banner summon.",
+            "2": "%game.action.teleport% each adjacent Banner summon to a hex adjacent to one of the targets.",
+            "3": "%game.card.recover% up to two of your lost cards with Banner summon abilities. Immediately play the recovered cards and perform their Banner summon abilities."
           }
         }
       },


### PR DESCRIPTION
# Description

I add the ability cards for banner spear.

There are 2 remaining issues:

- I used the property `"multiTarget": false` at the cards _Combined Effort_ and _Pincer Movement_, because there are area attacks but it only target 1 enemy. But it's still the multi target penalty on the enhancement price.
- the image of the summons are zoomed to much and mirrored

Mayme you help at this two things

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Data fix (fixes incorrect data)

<!-- Submitting a new feature? Please make sure you have started a discussion first: https://github.com/Lurkars/gloomhavensecretariat/discussions/new/choose — PRs for significant features without a prior discussion may be closed. -->

# Checklist:

- [x] I have performed a self-review of my code
- [x] I tried to follow the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I have read and followed the [Commit & Pull Request Guidelines](../CONTRIBUTING.md#commit--pull-request-guidelines)

## AI Usage

- [x] I did **not** use any AI tools for this contribution

<!-- If you used AI tools, please describe: which tool(s), what they were used for, and confirm you reviewed the output. -->
